### PR TITLE
Lethality increase

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m1984_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m1984_pistol.yml
@@ -9,7 +9,7 @@
     - Sidearm
     - CMWeaponPistolM1984
   - type: RMCSelectiveFire
-    scatterWielded: 10
+    scatterWielded: 8
     scatterUnwielded: 10
     baseFireRate: 10
     burstScatterMult: 5
@@ -114,7 +114,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 40
+        Piercing: 44
   - type: CMArmorPiercing
     amount: 10
 
@@ -139,7 +139,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 25
+        Piercing: 28
   - type: CMArmorPiercing
     amount: 40
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m77_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m77_pistol.yml
@@ -27,7 +27,7 @@
     baseFireModes:
     - SemiAuto
     - Burst
-    scatterWielded: 8
+    scatterWielded: 6
     scatterUnwielded: 8
     baseFireRate: 4
     burstScatterMult: 4

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_rifle.yml
@@ -28,7 +28,7 @@
     baseFireModes:
     - SemiAuto
     recoilUnwielded: 2
-    scatterWielded: 6
+    scatterWielded: 2
     baseFireRate: 2.86
   - type: RMCWeaponAccuracy
     accuracyMultiplier: 1.25
@@ -55,7 +55,7 @@
           - CMMagazineRifleM4SPRAP
           - CMMagazineRifleM4SPRExt
   - type: GunDamageModifier
-    multiplier: 1.4
+    multiplier: 1.6
   - type: AttachableHolder
     slots:
       rmc-aslot-barrel:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_mk1_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_mk1_rifle.yml
@@ -45,10 +45,10 @@
         shotsToMaxScatter: 6
       FullAuto:
         fireDelay: 0
-        maxScatterModifier: 26
+        maxScatterModifier: 16
         useBurstScatterMult: true
         unwieldedScatterMultiplier: 2
-        shotsToMaxScatter: 4
+        shotsToMaxScatter: 5
   - type: RMCWeaponAccuracy
     accuracyMultiplier: 1.15
     accuracyMultiplierUnwielded: 0.65
@@ -65,7 +65,7 @@
           - CMMagazineRifleM54CMK1AP
         startingItem: CMMagazineRifleM54CMK1
   - type: GunDamageModifier
-    multiplier: 1.1
+    multiplier: 1.3
   - type: AttachableHolder
     slots:
       rmc-aslot-barrel:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_rifle.yml
@@ -31,8 +31,8 @@
     - Burst
     - FullAuto
     recoilUnwielded: 4
-    scatterWielded: 6
-    scatterUnwielded: 20
+    scatterWielded: 3
+    scatterUnwielded: 15
     baseFireRate: 4
     burstScatterMult: 1
   - type: RMCWeaponAccuracy
@@ -51,7 +51,7 @@
           - CMMagazineRifleM54CAP
           - CMMagazineRifleM54CExt
   - type: GunDamageModifier
-    multiplier: 1.1
+    multiplier: 1.3
   - type: AttachableHolder
     slots:
       rmc-aslot-barrel:


### PR DESCRIPTION
increased lethality on several base USCMC weapons

increased dmg multipliers and decreased scatter on m41a mk1, mk2, m4spr

increased base dmg for 9mm rounds (base 40 -> 44, ap 25 -> 28) slightly decreased scatter when wielded for m4a3 and mod88

