### PR TITLE
remove upstream station prototype from maps

### DIFF
--- a/Resources/Prototypes/_RMC14/Maps/almayer.yml
+++ b/Resources/Prototypes/_RMC14/Maps/almayer.yml
@@ -11,7 +11,7 @@
   fallback: true
   stations:
     Almayer:
-      stationProto: StandardNanotrasenStation
+      stationProto: StandardAU14
       components:
       - type: StationNameSetup
         mapNameTemplate: 'UNS Almayer'

--- a/Resources/Prototypes/_RMC14/Maps/warship_prototypes.yml
+++ b/Resources/Prototypes/_RMC14/Maps/warship_prototypes.yml
@@ -3,16 +3,8 @@
   parent:
   - BaseStation
   - BaseStationNews
-  - BaseStationCargo
   - BaseStationJobsSpawning
   - BaseStationRecords
-  - BaseStationShuttles
-  - BaseStationCentcomm
-  - BaseStationEvacuation
-  - BaseStationAlertLevels
-  - BaseStationSiliconLawCrewsimov
-  - BaseStationAllEventsEligible
-  - BaseStationNanotrasen
   categories: [ HideSpawnMenu ]
   components:
   - type: Transform


### PR DESCRIPTION
Changes the station prototype to not spawn centcomm and trade station etc.