### PR TITLE
No more emergency autoinjectors.

### DIFF
--- a/Resources/Prototypes/_AU14/Entities/Vendors/lacnvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/lacnvendors.yml
@@ -265,8 +265,6 @@
         amount: 12
       - id: CMPacketPillsTricordrazine
         amount: 12
-      - id: CMEmergencyAutoInjector
-        amount: 2
       - id: AU14NaloxoneAutoInjector
         amount: 2
 

--- a/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
@@ -319,8 +319,6 @@
         amount: 12
       - id: CMPacketPillsTricordrazine
         amount: 12
-      - id: CMEmergencyAutoInjector
-        amount: 2
       - id: AU14NaloxoneAutoInjector
         amount: 2
     - name: Miscellaneous


### PR DESCRIPTION
Removes the emergency autoinjector from the LACN/USCM vendors.

Causes a huge disparity/balance issue between them and the CLF.