### PR TITLE
Add gamemode/player count destructible triggers

### DIFF
--- a/Content.Server/Destructible/Thresholds/Triggers/GameModeTrigger.cs
+++ b/Content.Server/Destructible/Thresholds/Triggers/GameModeTrigger.cs
@@ -1,0 +1,35 @@
+using Content.Server.GameTicking;
+using Content.Shared.Damage;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Server.Destructible.Thresholds.Triggers;
+
+/// <summary>
+///     Triggers when the current game preset matches one of the specified modes.
+/// </summary>
+[Serializable]
+[DataDefinition]
+public sealed partial class GameModeTrigger : IThresholdTrigger
+{
+    /// <summary>
+    ///     List of game preset IDs that will trigger this threshold.
+    /// </summary>
+    [DataField("modes")] public List<string> Modes { get; set; } = new();
+
+    /// <summary>
+    ///     If true, the trigger will activate when the current preset does NOT match any of <see cref="Modes"/>.
+    /// </summary>
+    [DataField("invert")]
+    public bool Invert { get; set; }
+
+    public bool Reached(DamageableComponent damageable, DestructibleSystem system)
+    {
+        var ticker = system.EntityManager.System<GameTicker>();
+        var preset = ticker.CurrentPreset ?? ticker.Preset;
+        if (preset == null)
+            return false;
+
+        var match = Modes.Contains(preset.ID);
+        return Invert ? !match : match;
+    }
+}

--- a/Content.Server/Destructible/Thresholds/Triggers/PlayerCountTrigger.cs
+++ b/Content.Server/Destructible/Thresholds/Triggers/PlayerCountTrigger.cs
@@ -1,0 +1,36 @@
+using Content.Shared.Damage;
+using Robust.Shared.Player;
+using Robust.Shared.IoC;
+
+namespace Content.Server.Destructible.Thresholds.Triggers;
+
+/// <summary>
+///     Triggers when the server player count is within the specified range.
+/// </summary>
+[Serializable]
+[DataDefinition]
+public sealed partial class PlayerCountTrigger : IThresholdTrigger
+{
+    /// <summary>
+    ///     Minimum players required to trigger. Ignored if null.
+    /// </summary>
+    [DataField("minPlayers")] public int? MinPlayers;
+
+    /// <summary>
+    ///     Maximum players allowed to trigger. Ignored if null.
+    /// </summary>
+    [DataField("maxPlayers")] public int? MaxPlayers;
+
+    public bool Reached(DamageableComponent damageable, DestructibleSystem system)
+    {
+        var playerManager = IoCManager.Resolve<IPlayerManager>();
+        var count = playerManager.PlayerCount;
+
+        if (MinPlayers.HasValue && count < MinPlayers.Value)
+            return false;
+        if (MaxPlayers.HasValue && count > MaxPlayers.Value)
+            return false;
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- add `GameModeTrigger` to destroy entities depending on the active gamemode
- add `PlayerCountTrigger` to destroy entities based on server population

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c55fa5f908325a32cc11002fb1db8