### PR TITLE
Neutral vendors

### DIFF
--- a/Resources/Prototypes/_AU14/Entities/Vendors/cmbciuvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/cmbciuvendors.yml
@@ -6,7 +6,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/uscmgearrack.rsi
   - type: CMAutomatedVendor
@@ -172,7 +172,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/assortedequipment.rsi
   - type: CMAutomatedVendor
@@ -260,7 +260,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforMedical" ]
+    - [ [ "AU14AccessGovforMedical" ], [ "AU14AccessOpforMedical" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/medical_gear.rsi
   - type: CMAutomatedVendor
@@ -395,7 +395,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforCommand" ]
+    - [ [ "AU14AccessGovforCommand" ], [ "AU14AccessOpforCommand" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/uscmcommandclothes.rsi
   - type: CMAutomatedVendor
@@ -443,7 +443,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/smart_gun_operator_gear.rsi
   - type: CMAutomatedVendor
@@ -465,7 +465,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforFTL" ]
+    - [ [ "AU14AccessGovforFTL" ], [ "AU14AccessOpforFTL" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
   - type: CMAutomatedVendor
@@ -493,7 +493,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/guns.rsi
   - type: CMAutomatedVendor
@@ -557,7 +557,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/genericweaponrack.rsi
   - type: CMAutomatedVendor

--- a/Resources/Prototypes/_AU14/Entities/Vendors/lacnvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/lacnvendors.yml
@@ -6,7 +6,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
   - type: CMAutomatedVendor
@@ -177,7 +177,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/gear.rsi
   - type: CMAutomatedVendor
@@ -269,7 +269,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforMedical" ]
+    - [ [ "AU14AccessGovforMedical" ], [ "AU14AccessOpforMedical" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/medical_equipment.rsi
   - type: CMAutomatedVendor
@@ -402,7 +402,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforPilot" ]
+    - [ [ "AU14AccessGovforPilot" ], [ "AU14AccessOpforPilot" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
   - type: CMAutomatedVendor
@@ -631,7 +631,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforCommand" ]
+    - [ [ "AU14AccessGovforCommand" ], [ "AU14AccessOpforCommand" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
   - type: CMAutomatedVendor
@@ -684,7 +684,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforGunner" ]
+    - [ [ "AU14AccessGovforGunner" ], [ "AU14AccessOpforGunner" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/requisitions_ammo.rsi
   - type: CMAutomatedVendor
@@ -708,7 +708,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforFTL" ]
+    - [ [ "AU14AccessGovforFTL" ], [ "AU14AccessOpforFTL" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
   - type: CMAutomatedVendor
@@ -751,7 +751,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/guns.rsi
   - type: CMAutomatedVendor
@@ -799,7 +799,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/genericweaponrack.rsi
   - type: CMAutomatedVendor

--- a/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
@@ -6,7 +6,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/uscmgearrack.rsi
   - type: CMAutomatedVendor
@@ -261,7 +261,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/assortedequipment.rsi
   - type: CMAutomatedVendor
@@ -356,7 +356,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforMedical" ]
+    - [ [ "AU14AccessGovforMedical" ], [ "AU14AccessOpforMedical" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/medical_gear.rsi
   - type: CMAutomatedVendor
@@ -495,7 +495,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforPilot" ]
+    - [ [ "AU14AccessGovforPilot" ], [ "AU14AccessOpforPilot" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
   - type: CMAutomatedVendor
@@ -734,7 +734,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforCommand" ]
+    - [ [ "AU14AccessGovforCommand" ], [ "AU14AccessOpforCommand" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/uscmcommandclothes.rsi
   - type: CMAutomatedVendor
@@ -795,7 +795,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforGunner" ]
+    - [ [ "AU14AccessGovforGunner" ], [ "AU14AccessOpforGunner" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/smart_gun_operator_gear.rsi
   - type: CMAutomatedVendor
@@ -835,7 +835,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforFTL" ]
+    - [ [ "AU14AccessGovforFTL" ], [ "AU14AccessOpforFTL" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
   - type: CMAutomatedVendor
@@ -874,7 +874,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/guns.rsi
   - type: CMAutomatedVendor
@@ -932,7 +932,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforFTL" ]
+    - [ [ "AU14AccessGovforFTL" ], [ "AU14AccessOpforFTL" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
   - type: CMAutomatedVendor
@@ -960,7 +960,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/genericweaponrack.rsi
   - type: CMAutomatedVendor
@@ -1003,7 +1003,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforPilot" ]
+    - [ [ "AU14AccessGovforPilot" ], [ "AU14AccessOpforPilot" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/guns.rsi
   - type: CMAutomatedVendor

--- a/Resources/Prototypes/_AU14/Entities/Vendors/uppvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/uppvendors.yml
@@ -6,7 +6,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/uscmgearrack.rsi
   - type: CMAutomatedVendor
@@ -183,7 +183,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/assortedequipment.rsi
   - type: CMAutomatedVendor
@@ -271,7 +271,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforMedical" ]
+    - [ [ "AU14AccessGovforMedical" ], [ "AU14AccessOpforMedical" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/medical_gear.rsi
   - type: CMAutomatedVendor
@@ -406,7 +406,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforPilot" ]
+    - [ [ "AU14AccessGovforPilot" ], [ "AU14AccessOpforPilot" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
   - type: CMAutomatedVendor
@@ -607,7 +607,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforCommand" ]
+    - [ [ "AU14AccessGovforCommand" ], [ "AU14AccessOpforCommand" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/uscmcommandclothes.rsi
   - type: CMAutomatedVendor
@@ -651,7 +651,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforGunner" ]
+    - [ [ "AU14AccessGovforGunner" ], [ "AU14AccessOpforGunner" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/smart_gun_operator_gear.rsi
   - type: CMAutomatedVendor
@@ -673,7 +673,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforFTL" ]
+    - [ [ "AU14AccessGovforFTL" ], [ "AU14AccessOpforFTL" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
   - type: CMAutomatedVendor
@@ -701,7 +701,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/guns.rsi
   - type: CMAutomatedVendor
@@ -755,7 +755,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/genericweaponrack.rsi
   - type: CMAutomatedVendor
@@ -799,7 +799,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforPilot" ]
+    - [ [ "AU14AccessGovforPilot" ], [ "AU14AccessOpforPilot" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/genericweaponrack.rsi
   - type: CMAutomatedVendor

--- a/Resources/Prototypes/_AU14/Entities/Vendors/wypmcvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/wypmcvendors.yml
@@ -6,7 +6,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/uscmgearrack.rsi
   - type: CMAutomatedVendor
@@ -176,7 +176,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/assortedequipment.rsi
   - type: CMAutomatedVendor
@@ -264,7 +264,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforMedical" ]
+    - [ [ "AU14AccessGovforMedical" ], [ "AU14AccessOpforMedical" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/medical_gear.rsi
   - type: CMAutomatedVendor
@@ -403,7 +403,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "CMAccessPilot" ]
+    - [ [ "AU14AccessGovforPilot" ], [ "AU14AccessOpforPilot" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
   - type: CMAutomatedVendor
@@ -600,7 +600,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforCommand" ]
+    - [ [ "AU14AccessGovforCommand" ], [ "AU14AccessOpforCommand" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/uscmcommandclothes.rsi
   - type: CMAutomatedVendor
@@ -646,7 +646,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforGunner" ]
+    - [ [ "AU14AccessGovforGunner" ], [ "AU14AccessOpforGunner" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/smart_gun_operator_gear.rsi
   - type: CMAutomatedVendor
@@ -690,7 +690,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforFTL" ]
+    - [ [ "AU14AccessGovforFTL" ], [ "AU14AccessOpforFTL" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
   - type: CMAutomatedVendor
@@ -728,7 +728,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/guns.rsi
   - type: CMAutomatedVendor
@@ -782,7 +782,7 @@
   components:
   - type: AccessReader
     access:
-    - [ "AU14AccessGovforSquad" ]
+    - [ [ "AU14AccessGovforSquad" ], [ "AU14AccessOpforSquad" ] ]
   - type: Sprite
     sprite: _AU14/Structures/Vendors/genericweaponrack.rsi
   - type: CMAutomatedVendor


### PR DESCRIPTION
## About the PR
Vendors are accessible by both Govfor and Opfor.

## Why / Balance
Server isn't ready for separately access locked vendors, or changing their access on spawn.

