### PR TITLE
Fix branding & simplify job names.

### DIFF
--- a/Resources/Locale/en-US/_AU14/job/governmentforces.ftl
+++ b/Resources/Locale/en-US/_AU14/job/governmentforces.ftl
@@ -1,18 +1,18 @@
 au14-department-govforces-description = Government Forces
 au14-department-govforces = Government Forces
 
-au14-job-supervisors-govforplatco = Company Command
+au14-job-supervisors-govforplatco = High Command
 au14-job-supervisors-govfor = Platoon Commander
 
-AU14JobGOVFORPlatCo = Platoon Commander
-au14-job-name-govforplatco = Platoon Commander
-au14-job-description-govforplatco = Command the platoon. Manage strategy, unit coordination and liaise with command from the CIC.
-au14-job-prefix-govforplatco = PLTCO
+AU14JobGOVFORPlatCo = Commander
+au14-job-name-govforplatco = Commander
+au14-job-description-govforplatco = Command the unit. Manage strategy, unit coordination and liaise with command from the CIC.
+au14-job-prefix-govforplatco = CMNDR
 
-AU14JobGOVFORPlatOp = Platoon Operations Officer
-au14-job-name-govforplatop = Platoon Operations Officer
-au14-job-description-govforplatop = Assist the Platoon Commander with logistics, coordination, and operational oversight.
-au14-job-prefix-govforplatop = PLTOP
+AU14JobGOVFORPlatOp = Operations Officer
+au14-job-name-govforplatop = Operations Officer
+au14-job-description-govforplatop = Assist the Commander with logistics, coordination, and operational oversight.
+au14-job-prefix-govforplatop = OPOF
 
 AU14JobGOVFORDSPilot = Dropship Pilot
 au14-job-name-govfordspilot = Dropship Pilot
@@ -24,33 +24,33 @@ au14-job-name-govfordcc = Dropship Crew Chief
 au14-job-description-govfordcc = Maintain the bird. Coordinate cargo, passengers, and assist the pilot.
 au14-job-prefix-govfordcc = DCC
 
-AU14JobGOVFORSectionSergeant = Platoon Sergeant
-au14-job-name-govforSSG = Platoon Sergeant
+AU14JobGOVFORSectionSergeant = Senior Sergeant
+au14-job-name-govforSSG = Senior Sergeant
 au14-job-description-govforSSG = Senior enlisted. Keep the platoon running and lead them on the ground.
-au14-job-prefix-govforSSG = PLTSGT
+au14-job-prefix-govforSSG = SNRSRGT
 
-AU14JobGOVFORSquadSergeant = Squad Sergeant
-au14-job-name-govforsquadsergeant = Squad Sergeant
+AU14JobGOVFORSquadSergeant = Sergeant
+au14-job-name-govforsquadsergeant = Sergeant
 au14-job-description-govforsquadsergeant = Lead a fireteam. Follow orders from the top and get your people home.
-au14-job-prefix-govforsquadsergeant = SQSGT
+au14-job-prefix-govforsquadsergeant = SGT
 
-AU14JobGOVFORSquadRifleman = Squad Rifleman
-au14-job-name-govforsquadrifleman = Squad Rifleman
+AU14JobGOVFORSquadRifleman = Rifleman
+au14-job-name-govforsquadrifleman = Rifleman
 au14-job-description-govforsquadrifleman = The backbone of the unit. Follow orders, pull security, and shoot straight.
 au14-job-prefix-govforsquadrifleman = RFN
 
-AU14JobGOVFORSquadAutomaticRifleman = Squad Automatic Rifleman
-au14-job-name-govforsquadautomaticrifleman = Squad Automatic Rifleman
+AU14JobGOVFORSquadAutomaticRifleman = Automatic Rifleman
+au14-job-name-govforsquadautomaticrifleman = Automatic Rifleman
 au14-job-description-govforsquadautomaticrifleman = Lay down suppressive fire. Keep the enemy's head down and your squad moving.
 au14-job-prefix-govforsquadautomaticrifleman = ARFN
 
-AU14JobGOVFORPlatoonCorpsman = Platoon Hospital Corpsman
-au14-job-name-govforplatooncorpsman = Platoon Hospital Corpsman
+AU14JobGOVFORPlatoonCorpsman = Hospital Corpsman
+au14-job-name-govforplatooncorpsman = Hospital Corpsman
 au14-job-description-govforplatooncorpsman = Provide field medical aid. Patch them up, keep them breathing, and get them back in the fight.
 au14-job-prefix-govforplatooncorpsman = HM
 
-AU14JobGOVFORRadioTelephoneOperator = Radio Telephone Operator
-au14-job-name-radiotelephoneoperator = Radio Telephone Operator
+AU14JobGOVFORRadioTelephoneOperator = Radio Operator
+au14-job-name-radiotelephoneoperator = Radio Operator
 au14-job-description-radiotelephoneoperator = Operate long-range comms. You're the link between command and the boots. Don’t drop it.
 au14-job-prefix-radiotelephoneoperator = RTO
 

--- a/Resources/Locale/en-US/_AU14/job/opfor.ftl
+++ b/Resources/Locale/en-US/_AU14/job/opfor.ftl
@@ -1,18 +1,18 @@
 au14-department-opfor-description = Opposition Forces
 au14-department-opfor = Opposition Forces
 
-au14-job-supervisors-opforplatco = Company Command
-au14-job-supervisors-opfor = Platoon Commander
+au14-job-supervisors-opforplatco = High Command
+au14-job-supervisors-opfor = Commander
 
-AU14JobOpforPlatCo = Platoon Commander
-au14-job-name-opforplatco = Platoon Commander
-au14-job-description-opforplatco = Command the platoon. Manage strategy, unit coordination and liaise with command from the CIC.
-au14-job-prefix-opforplatco = PLTCO
+AU14JobOpforPlatCo = Commander
+au14-job-name-opforplatco = Commander
+au14-job-description-opforplatco = Command the unit. Manage strategy, unit coordination and liaise with command from the CIC.
+au14-job-prefix-opforplatco = CMNDR
 
-AU14JobOpforPlatOp = Platoon Operations Officer
-au14-job-name-opforplatop = Platoon Operations Officer
-au14-job-description-opforplatop = Assist the Platoon Commander with logistics, coordination, and operational oversight.
-au14-job-prefix-opforplatop = PLTOP
+AU14JobOpforPlatOp = Operations Officer
+au14-job-name-opforplatop = Operations Officer
+au14-job-description-opforplatop = Assist the Commander with logistics, coordination, and operational oversight.
+au14-job-prefix-opforplatop = OPOF
 
 AU14JobOpforDSPilot = Dropship Pilot
 au14-job-name-opfordspilot = Dropship Pilot
@@ -24,32 +24,32 @@ au14-job-name-opfordcc = Dropship Crew Chief
 au14-job-description-opfordcc = Maintain the bird. Coordinate cargo, passengers, and assist the pilot.
 au14-job-prefix-opfordcc = DCC
 
-AU14JobOpforSectionSergeant = Platoon Sergeant
-au14-job-name-opforSSG = Platoon Sergeant
+AU14JobOpforSectionSergeant = Senior Sergeant
+au14-job-name-opforSSG = Senior Sergeant
 au14-job-description-opforSSG = Senior enlisted. Keep the platoon running and lead them on the ground.
-au14-job-prefix-opforSSG = PLTSGT
+au14-job-prefix-opforSSG = SNRSRGT
 
-AU14JobOpforSquadSergeant = Squad Sergeant
-au14-job-name-opforsquadsergeant = Squad Sergeant
+AU14JobOpforSquadSergeant = Sergeant
+au14-job-name-opforsquadsergeant = Sergeant
 au14-job-description-opforsquadsergeant = Lead a fireteam. Follow orders from the top and get your people home.
-au14-job-prefix-opforsquadsergeant = SQSGT
+au14-job-prefix-opforsquadsergeant = SGT
 
-AU14JobOpforSquadRifleman = Squad Rifleman
-au14-job-name-opforsquadrifleman = Squad Rifleman
+AU14JobOpforSquadRifleman = Rifleman
+au14-job-name-opforsquadrifleman = Rifleman
 au14-job-description-opforsquadrifleman = The backbone of the unit. Follow orders, pull security, and shoot straight.
 au14-job-prefix-opforsquadrifleman = RFN
 
-AU14JobOpforSquadAutomaticRifleman = Squad Automatic Rifleman
-au14-job-name-opforsquadautomaticrifleman = Squad Automatic Rifleman
+AU14JobOpforSquadAutomaticRifleman = Automatic Rifleman
+au14-job-name-opforsquadautomaticrifleman = Automatic Rifleman
 au14-job-description-opforsquadautomaticrifleman = Lay down suppressive fire. Keep the enemy's head down and your squad moving.
 au14-job-prefix-opforsquadautomaticrifleman = ARFN
 
-AU14JobOpforPlatoonCorpsman = Platoon Hospital Corpsman
-au14-job-name-opforplatooncorpsman = Platoon Hospital Corpsman
+AU14JobOpforPlatoonCorpsman = Hospital Corpsman
+au14-job-name-opforplatooncorpsman = Hospital Corpsman
 au14-job-description-opforplatooncorpsman = Provide field medical aid. Patch them up, keep them breathing, and get them back in the fight.
 au14-job-prefix-opforplatooncorpsman = HM
 
-AU14JobOpforRadioTelephoneOperator = Radio Telephone Operator
-au14-job-name-poforradiotelephoneoperator = Radio Telephone Operator
+AU14JobOpforRadioTelephoneOperator = Radio Operator
+au14-job-name-poforradiotelephoneoperator = Radio Operator
 au14-job-description-opforradiotelephoneoperator = Operate long-range comms. You're the link between command and the boots. Don’t drop it.
 au14-job-prefix-opforradiotelephoneoperator = RTO

--- a/Resources/Locale/en-US/_RMC14/roundend/no-eorg-popup.ftl
+++ b/Resources/Locale/en-US/_RMC14/roundend/no-eorg-popup.ftl
@@ -1,6 +1,6 @@
-no-eorg-popup-title = RMC14
+no-eorg-popup-title = CMU
 no-eorg-popup-label = Welcome to the End of Round!
-no-eorg-popup-message = [bold]End-of-round grief (EORG)[/bold] is not allowed at RMC14. Please stay in character until the lobby screen appears to maintain an immersive environment for everyone. Thank you for respecting the community rules!
+no-eorg-popup-message = [bold]End-of-round grief (EORG)[/bold] is not allowed at CMU. Please stay in character until the lobby screen appears to maintain an immersive environment for everyone. Thank you for respecting the community rules!
 no-eorg-popup-rule = [bold][color=#a4885c]End of round grief of your own faction is not permitted and results in an instant unappealable 3 hour game ban.[/color][/bold]
 no-eorg-popup-rule-text = This includes any friendly fire at round end regardless of who started the griefing, as the round may not be entirely over even if the main condition has been reached. This also includes suicides without a valid roleplay reason.
 no-eorg-popup-close-button = Sounds good!

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Opfor/platooncorpsman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Opfor/platooncorpsman.yml
@@ -48,7 +48,7 @@
   id: AU14GearopforPlatoonCorpsman
   equipment:
     id: AU14JobIDCardopforPlatoonCorpsman
-    ears: AU14HeadsetSectionMarine
+    ears: AU14HeadsetSectionOpfor
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Opfor/platoonradiotelephoneoperator.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Opfor/platoonradiotelephoneoperator.yml
@@ -53,7 +53,7 @@
   id: AU14GearopforRadioTelephoneOperator
   equipment:
     id: AU14JobIDCardopforRadioTelephoneOperator
-    ears: AU14HeadsetSectionMarine
+    ears: AU14HeadsetSectionOpfor
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Opfor/platoonsquadrifleman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Opfor/platoonsquadrifleman.yml
@@ -48,7 +48,7 @@
   id: AU14GearopforSquadRifleman
   equipment:
     id: AU14IDCardopforSquadRifleman
-    ears: AU14HeadsetSectionMarine
+    ears: AU14HeadsetSectionOpfor
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/general.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/general.yml
@@ -3,7 +3,7 @@
   parent: ColMarTechBaseAnchorable
   id: CMVendorCassettes
   name: Rec-Vend
-  description: Contains recreational items, like Cassette Players and Cards.
+  description: Contains recreational items, like Cards.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/cassette_player.rsi
@@ -13,26 +13,6 @@
   - type: CMAutomatedVendor
     hackable: true
     sections:
-    - name: Cassette Players
-      entries:
-      - id: AU14CassettePlayerGray
-        amount: 10
-      - id: AU14CassettePlayerBlue
-        amount: 10
-      - id: AU14CassettePlayerGreen
-        amount: 10
-      - id: AU14CassettePlayerPink
-        amount: 10
-      - id: AU14CassettePlayerOrange
-        amount: 10
-      - id: AU14CassettePlayerRainbow
-        amount: 10
-      - id: AU14CassettePlayerNeon
-        amount: 10
-    - name: Cassettes
-      entries:
-      - id: RMCCassetteTapeCustom
-        amount: 70
     - name: Cards
       entries: []
     - name: Other


### PR DESCRIPTION
Fixes some old RMC branding in the EORG popup and updates some of the OPFOR/GOVFOR jobs to not include squad/platoon/company level mentions.