### PR TITLE
Update Vendors + Slight Balance Updates

### DIFF
--- a/Resources/Prototypes/_AU14/Entities/Vendors/ccafvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/ccafvendors.yml
@@ -183,15 +183,15 @@
   - type: CMAutomatedVendor
     sections:
     - name: Essential Equipment
+      takeAll: CMUAREssentialEquipment
       entries:
       - id: RMCWeaponLMGM60
-        amount: 1
       - id: CMBeltMarine
-        amount: 1
       - id: AU14IMPBackpackMarine
-        amount: 1
+    - name: Munitions
+      entries:
       - id: RMCMagazineLMGM60
-        amount: 5
+        amount: 40
 
 - type: entity
   parent: ColMarTechBase

--- a/Resources/Prototypes/_AU14/Entities/Vendors/hazopsvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/hazopsvendors.yml
@@ -222,15 +222,15 @@
   - type: CMAutomatedVendor
     sections:
     - name: Essential Equipment
+      takeAll: CMUAREssentialEquipment
       entries:
       - id: RMCWeaponLMGM60
-        amount: 1
       - id: CMBeltMarine
-        amount: 1
       - id: AU14IMPBackpackMarine
-        amount: 1
+    - name: Munitions
+      entries:
       - id: RMCMagazineLMGM60
-        amount: 5
+        amount: 40
 
 - type: entity
   parent: ColMarTechBase

--- a/Resources/Prototypes/_AU14/Entities/Vendors/lacnvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/lacnvendors.yml
@@ -640,15 +640,16 @@
   - type: CMAutomatedVendor
     sections:
     - name: Essential Equipment
+      takeAll: CMUAREssentialEquipment
       entries:
-      - id: AU14LACNAmmoBackpack
-        amount: 1
-      - id: CMBeltMarine
-        amount: 1
       - id: AU14WeaponRifleKramerLSW
-        amount: 1
+      - id: AU14LACNAmmoBackpack
+      - id: CMBeltMarine
+      - id: RMCPouchMagazineLarge
+    - name: Munitions
+      entries:
       - id: AU14WeaponRifleKramerMagazineLSWStandard
-        amount: 7
+        amount: 40
 
 - type: entity
   parent: ColMarTechBase
@@ -674,10 +675,6 @@
     - name: Armor and Rigs
       entries:
       - id: AU14LACNArmorSL
-        amount: 1
-    - name: Backpack
-      entries:
-      - id: RMCBackpackRTO
         amount: 1
     - name: Miscellaneous
       entries:
@@ -777,8 +774,6 @@
         amount: 6
       - id: CMMagazineSniperM96SFlak
         amount: 2
-      - id: CMMagazineSniperM96SIncendiary
-        amount: 1
       - id: RMCScoutShoes
         amount: 1
     - name: MOU53 break action shotgun

--- a/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
@@ -750,31 +750,27 @@
   - type: CMAutomatedVendor
     sections:
     - name: Essential Equipment
+      takeAll: CMUAREssentialEquipment
       entries:
       - id: RMCSmartGun
-        amount: 1
       - id: RMCScabbardMacheteSGFilled
-        amount: 1
       - id: RMCGlassesSmartGunSight
-        amount: 1
-    - name: Smartgun Harnesses
+      - id: RMCPowerCellSmartgun
+      - id: RMCPouchDrumPMC
+    - name: Smartgun Harness
+      choices: { SmartgunHarness: 1 }
       entries:
       - id: AU14ArmorSmartGunDesertCombatHarness
-        amount: 1
       - id: AU14ArmorSmartGunJungleCombatHarness
-        amount: 1
     - name: Smartgun Belts
+      choices: { SmartgunBelts: 1 }
       entries:
       - id: RMCBeltSmartGunOperatorPistolFilled
-        amount: 1
       - id: CMBeltSmartGunOperatorFilled
-        amount: 1
     - name: Smartgun Munitions
       entries:
       - id: RMCMagazineSmartGun
-        amount: 5
-      - id: RMCPowerCellSmartgun
-        amount: 2
+        amount: 40
 
 - type: entity
   parent: ColMarTechBase

--- a/Resources/Prototypes/_AU14/Entities/Vendors/prodigyvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/prodigyvendors.yml
@@ -622,31 +622,27 @@
   - type: CMAutomatedVendor
     sections:
     - name: Essential Equipment
+      takeAll: CMUAREssentialEquipment
       entries:
       - id: RMCSmartGun
-        amount: 1
       - id: RMCScabbardMacheteSGFilled
-        amount: 1
       - id: RMCGlassesSmartGunSight
-        amount: 1
-    - name: Smartgun Harnesses
+      - id: RMCPowerCellSmartgun
+      - id: RMCPouchDrumPMC
+    - name: Smartgun Harness
+      choices: { SmartgunHarness: 1 }
       entries:
       - id: AU14ArmorSmartGunDesertCombatHarness
-        amount: 1
       - id: AU14ArmorSmartGunJungleCombatHarness
-        amount: 1
     - name: Smartgun Belts
+      choices: { SmartgunBelts: 1 }
       entries:
       - id: RMCBeltSmartGunOperatorPistolFilled
-        amount: 1
       - id: CMBeltSmartGunOperatorFilled
-        amount: 1
     - name: Smartgun Munitions
       entries:
       - id: RMCMagazineSmartGun
-        amount: 5
-      - id: RMCPowerCellSmartgun
-        amount: 2
+        amount: 40
 
 - type: entity
   parent: ColMarTechBase

--- a/Resources/Prototypes/_AU14/Entities/Vendors/uppvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/uppvendors.yml
@@ -615,13 +615,13 @@
   - type: CMAutomatedVendor
     sections:
     - name: Essential Equipment
+      takeAll: CMUAREssentialEquipment
       entries:
       - id: RMCWeaponLMGQYJ72
-        amount: 1
     - name: Gun Munitions
       entries:
       - id: RMCMagazineLMGQYJ72
-        amount: 10
+        amount: 40
 
 - type: entity
   parent: ColMarTechBase

--- a/Resources/Prototypes/_AU14/Entities/Vendors/vaipovendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/vaipovendors.yml
@@ -628,20 +628,18 @@
   - type: CMAutomatedVendor
     sections:
     - name: Essential Equipment
+      takeAll: CMUAREssentialEquipment
       entries:
       - id: RMCWeaponRifleM54CE2
-        amount: 2
-      - id: RMCAttachmentBipod
-    - name: Belts
-      entries:
       - id: CMBeltMarine
-        amount: 2
+      - id: RMCAttachmentS5RedDotSight
+      - id: RMCAttachmentExtendedCompensator
     - name: SAW Munitions
       entries:
       - id: CMMagazineRifleM54CE2AP
         amount: 2
       - id: CMMagazineRifleM54CE2
-        amount: 8
+        amount: 28
 
 - type: entity
   parent: ColMarTechBase
@@ -748,11 +746,12 @@
   - type: CMAutomatedVendor
     sections:
     - name: Portable Transceivers
+      choices: { CMUPlatoonRTOBags: 1 }
       entries:
       - id: AU14BackpackRTOPackJungle
-        amount: 1
       - id: AU14BackpackRTOPackDesert
-        amount: 1
+      - id: AU14BackpackRTOPackGray
+      - id: AU14BackpackRTOPackBlack
     - name: Equipment
       entries:
       - id: RMCLaserDesignator

--- a/Resources/Prototypes/_AU14/Entities/Vendors/wypmcvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/wypmcvendors.yml
@@ -596,35 +596,24 @@
   - type: CMAutomatedVendor
     sections:
     - name: Essential Equipment
+      takeAll: CMUAREssentialEquipment
       entries:
       - id: RMCSmartGunWhiteOut
-        amount: 1
       - id: RMCScabbardMacheteSGFilled
-        amount: 1
       - id: RMCGlassesSmartGunSight
-        amount: 1
-    - name: Smartgunner Clothing
+      - id: RMCPowerCellSmartgun
+      - id: RMCBeltSmartGunOperatorPistolPMC
+      - id: RMCPouchDrumPMC
+    - name: Clothing
+      takeAll: CMUAREssentialEquipmentClothing
       entries:
       - id: RMCJumpsuitVeteranPMCGunner
-        amount: 1
       - id: CMArmorM4PMCSmartGunHarness
-        amount: 1
       - id: ArmorHelmetPMCGunner
-        amount: 1
-    - name: Smartgun Equipment
-      entries:
-      - id: RMCBeltSmartGunOperatorPistolPMC
-        amount: 1
-      - id: RMCPouchDrumPMC
-        amount: 2
     - name: Smartgun Munitions
       entries:
       - id: RMCMagazineSmartGun
-        amount: 10
-      - id: RMCMagazineSmartGunirradiated
-        amount: 1
-      - id: RMCPowerCellSmartgun
-        amount: 2
+        amount: 25
 
 - type: entity
   parent: ColMarTechBase
@@ -735,21 +724,10 @@
     - name: NSG 23 Assault Rifle
       entries:
       - id: RMCWeaponRifleSSG45NoLock
-        amount: 1
+        amount: 2
       - id: RMCMagazineRifleSSG45
-        amount: 12
+        amount: 24
       - id: RMCMagazineRifleSSG45Extended
         amount: 2
       - id: RMCMagazineRifleSSG45AP
         amount: 2
-      - id: RMCMagazineRifleSSG45Incend
-        amount: 1
-    - name: XM43E1 Anti-Material Rifle
-      entries:
-      - id: RMCXM43E1AntiMaterielRifle
-        amount: 1
-      - id: RMCMagazineSniperXM43E1AntiMateriel
-        amount: 6
-      - id: RMCScoutShoes
-        amount: 1
-


### PR DESCRIPTION
Changes all RTO and AR vendors to use takeAll and/or choices to account for higher player population.
Incendiary/irradiated ammo has been removed. WY PMCs lost their AM rifle.