### PR TITLE
Remove Prodigy & VAIPO vendors, fix dropship gravity

### DIFF
--- a/Resources/Maps/_CMU14/Shuttles/alamo.yml
+++ b/Resources/Maps/_CMU14/Shuttles/alamo.yml
@@ -79,6 +79,8 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+      inherent: True
+      enabled: True
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_CMU14/Shuttles/osprey.yml
+++ b/Resources/Maps/_CMU14/Shuttles/osprey.yml
@@ -79,6 +79,8 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+      inherent: True
+      enabled: True
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Prototypes/_AU14/Entities/Vendors/prodigyvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/prodigyvendors.yml
@@ -671,32 +671,6 @@
 
 - type: entity
   parent: ColMarTechBase
-  id: AU14prodigyRTOVendor
-  name: radio telephone operator rack
-  description: An automated rack hooked up to a small storage of radio equipment.
-  components:
-  - type: AccessReader
-    access: [ [ "AU14AccessGovforFTL" ], [ "AU14AccessOpforFTL" ] ]
-  - type: Sprite
-    sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
-  - type: CMAutomatedVendor
-    sections:
-    - name: RTO Backpack
-      choices: { RTOBackpack: 1 }
-      entries:
-      - id: AU14BackpackRTOPackGray
-      - id: AU14BackpackRTOPackBlack
-    - name: Equipment
-      entries:
-      - id: RMCLaserDesignator
-        amount: 1
-      - id: RMCWhistle
-        amount: 1
-      - id: RMCPackFlareCAS
-        amount: 2
-
-- type: entity
-  parent: ColMarTechBase
   id: AU14prodigySpecialWeaponsVendor
   name: Prodigy special weapons rack
   description: An automated rack hooked up to a small storage of special weapons.
@@ -730,38 +704,3 @@
         amount: 12
       - id: RMCBoxShotgunFlechette
         amount: 12
-
-- type: entity
-  parent: ColMarTechBase
-  id: AU14prodigyAircrewWeaponsVendor
-  name: aircrew weapons rack
-  description: An automated rack hooked up to a small storage of weapons.
-  components:
-  - type: AccessReader
-    access: [ [ "AU14AccessGovforPilot" ], [ "AU14AccessOpforPilot" ] ]
-  - type: Sprite
-    sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/guns.rsi
-  - type: CMAutomatedVendor
-    sections:
-    - name: Submachine Guns
-      entries:
-      - id: WeaponSMGM63
-        amount: 2
-    - name: Submachine Gun Ammunition
-      entries:
-      - id: CMMagazineSMGM63
-        amount: 20
-    - name: Handguns
-      entries:
-      - id: RMCWeaponPistolM77Empty
-        amount: 2
-    - name: Handgun Ammunition
-      entries:
-      - id: CMMagazinePistolM77AP
-        amount: 20
-    - name: Attachments
-      entries:
-      - id: RMCAttachmentS6ReflexSight
-        amount: 2
-      - id: RMCAttachmentFlashlightGrip
-        amount: 2

--- a/Resources/Prototypes/_AU14/Entities/Vendors/vaipovendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/vaipovendors.yml
@@ -671,34 +671,6 @@
 
 - type: entity
   parent: ColMarTechBase
-  id: AU14VAIPORTOVendor
-  name: radio telephone operator rack
-  description: An automated rack hooked up to a small storage of radio equipment.
-  components:
-  - type: AccessReader
-    access: [ [ "AU14AccessGovforFTL" ], [ "AU14AccessOpforFTL" ] ]
-  - type: Sprite
-    sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
-  - type: CMAutomatedVendor
-    sections:
-    - name: Portable Transceivers
-      choices: { CMUPlatoonRTOBags: 1 }
-      entries:
-      - id: AU14BackpackRTOPackJungle
-      - id: AU14BackpackRTOPackDesert
-      - id: AU14BackpackRTOPackGray
-      - id: AU14BackpackRTOPackBlack
-    - name: Equipment
-      entries:
-      - id: RMCLaserDesignator
-        amount: 1
-      - id: RMCWhistle
-        amount: 1
-      - id: RMCPackFlareCAS
-        amount: 2
-
-- type: entity
-  parent: ColMarTechBase
   id: AU14VAIPOSpecialWeaponsVendor
   name: VAIPO special weapons rack
   description: An automated rack hooked up to a small storage of special weapons.
@@ -744,37 +716,3 @@
        - id: RMCAttachmentBipod
          amount: 1
 
-- type: entity
-  parent: ColMarTechBase
-  id: AU14VAIPOAircrewWeaponsVendor
-  name: aircrew weapons rack
-  description: An automated rack hooked up to a small storage of weapons.
-  components:
-  - type: AccessReader
-    access: [ [ "AU14AccessGovforPilot" ], [ "AU14AccessOpforPilot" ] ]
-  - type: Sprite
-    sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/guns.rsi
-  - type: CMAutomatedVendor
-    sections:
-    - name: Submachine Guns
-      entries:
-      - id: WeaponSMGM63
-        amount: 2
-    - name: Submachine Gun Ammunition
-      entries:
-      - id: CMMagazineSMGM63
-        amount: 20
-    - name: Handguns
-      entries:
-      - id: RMCWeaponPistolM77Empty
-        amount: 2
-    - name: Handgun Ammunition
-      entries:
-      - id: CMMagazinePistolM77AP
-        amount: 20
-    - name: Attachments
-      entries:
-      - id: RMCAttachmentS6ReflexSight
-        amount: 2
-      - id: RMCAttachmentFlashlightGrip
-        amount: 2

--- a/Resources/Prototypes/_AU14/gamemode/platoons.yml
+++ b/Resources/Prototypes/_AU14/gamemode/platoons.yml
@@ -246,9 +246,9 @@
     Arifleman: AU14prodigySGequipmentvendor
     Dcc: AU14prodigyaircrewvendor
     OperationsOfficer: AU14prodigycommandequipmentvendor
-    Rto: AU14prodigyRTOVendor
+    Rto: AU14RTOVendor
     SectionSergeant: AU14prodigysectionleaderequipmentvendor
-    Pilot: AU14prodigyAircrewWeaponsVendor
+    Pilot: AU14AircrewWeaponsVendor
     ExtraVendor1: VMarkerOpforDeco5
     Deco1: VMarkerOpforDeco5
   #platoonflag:  uaflag
@@ -309,9 +309,9 @@
     Arifleman: AU14VAIPOSGequipmentvendor
     Dcc: AU14VAIPOaircrewvendor
     OperationsOfficer: AU14VAIPOcommandequipmentvendor
-    Rto: AU14VAIPORTOVendor
+    Rto: AU14RTOVendor
     SectionSergeant: AU14VAIPOsectionleaderequipmentvendor
-    Pilot: AU14VAIPOAircrewWeaponsVendor
+    Pilot: AU14AircrewWeaponsVendor
     ExtraVendor1: VMarkerOpforDeco5
     Deco1: VMarkerOpforDeco5
   CompatibleDropships:


### PR DESCRIPTION
## About the PR
Removed Prodigy & VAIPO aircrew weapons vendor(s) and radio telephone operator rack(s). They had no unique gear oversight.

Enabled dropship gravity.

## Why / Balance
Cleanup, bugfix.