### PR TITLE
LV-112 Sheperds' Pride Update

### DIFF
--- a/Resources/Prototypes/_AU14/Maps/planets.yml
+++ b/Resources/Prototypes/_AU14/Maps/planets.yml
@@ -51,6 +51,7 @@
     - FORECONFirstRecon
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
+
 - type: entity
   id: AUPlanetShepherdsPride
   name: Shepherds' Pride
@@ -107,8 +108,6 @@
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
 
-
-
 - type: entity
   id: AUPlanetStableGarrison
   name: Stable Garrison
@@ -153,9 +152,6 @@
       AU14JobLEOBase: AU14JobCivilianCMBDeputy
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
-
-
-
 
 - type: entity
   id: AUPlanetLV624
@@ -222,7 +218,6 @@
     platoonsOpfor:
     - UPP
     - WEYU
-
     platoonsGovfor:
     - LACN
     - ProdigySF
@@ -265,7 +260,6 @@
     threats:
     - XenoThreat
     - apethreat
-
     thirdparties:
     - USArmy
     - USArmyAlt
@@ -324,6 +318,7 @@
       AU14JobLEOBase: AU14JobCiviliannspaConstable
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
+
 - type: entity
   id: AUPlanetLV327
   name: Port Neroid
@@ -415,6 +410,7 @@
       AU14JobLEOBase: AU14JobCivilianCMBDeputy
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
+
 - type: entity
   id: AUPlanetSorokyne
   name: Sorokyne Strata
@@ -503,7 +499,6 @@
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
 
-
 - type: entity
   id: AuPlanetShivasSnowball
   name: Shivas' Snowball
@@ -590,7 +585,6 @@
     - XenoThreat
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
-
 
 - type: entity
   id: AuPlanetFiorina

--- a/Resources/Prototypes/_AU14/gamemode/gamemodes.yml
+++ b/Resources/Prototypes/_AU14/gamemode/gamemodes.yml
@@ -11,11 +11,11 @@
   supportedPlanets:
   #- AUPlanetGixensCaverns Rout of rotation till fixed - eg
   - AUPlanetShepherdsPride
-  - AUPlanetFlight
+  #- AUPlanetFlight
   - AUPlanetLV759
   - AUPlanetLV327
   - AUPlanetCorsatStation
-#  - AUPlanetSorokyne
+  #- AUPlanetSorokyne
   - AUPlanetStableGarrison
   - AUPlanetTrijent
   rules:
@@ -24,7 +24,6 @@
   - AddGovfor
   - AddOpfor
   - RemoveAllJobs
-
 
 - type: gamePreset
   id: Insurgency
@@ -39,9 +38,8 @@
     - AUPlanetShepherdsPride
     - AUPlanetLV624
     #- AUPlanetLV747
-  #  - AUPlanetSorokyne
-#    - AUPlanetLV759 removed pending rework
-
+    #- AUPlanetSorokyne
+    #- AUPlanetLV759 removed pending rework
   rules:
   - AuVoteRule
   - PlatoonSpawn
@@ -49,6 +47,7 @@
   - AddClf
   - ColonyAntags
   - InsWinConditionsRule
+
 - type: gamePreset
   id: DistressSignal
   name: Distress Signal
@@ -58,9 +57,9 @@
   supportedPlanets:
   - AUPlanetShepherdsPride
   - AUPlanetLV747
-  - AUPlanetFlight
+  #- AUPlanetFlight
   - AUPlanetLV327
- # - AUPlanetSorokyne
+  #- AUPlanetSorokyne
   - AUPlanetCorsatStation
   - AUPlanetStableGarrison
   - AUPlanetTrijent
@@ -72,8 +71,6 @@
   - PlatoonSpawn
   - AddGovfor
   - RemoveAllJobs
-
-
 
 - type: gamePreset
   id: ColonyFall

--- a/Resources/Prototypes/_AU14/gamemode/wallremoves.yml
+++ b/Resources/Prototypes/_AU14/gamemode/wallremoves.yml
@@ -529,3 +529,11 @@
       preset: Fog
       inverted: true
 
+- type: entity
+  id: junglevegetationremove_colonyfall_inverted
+  suffix: ColonyFall Inverted
+  parent: CMWallJungle
+  components:
+  - type: DestroyOnPreset
+    preset: ColonyFall
+    inverted: true

--- a/Resources/Prototypes/_CMU14/Entities/Areas/areas_sheperd.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Areas/areas_sheperd.yml
@@ -776,6 +776,17 @@
 
 - type: entity
   parent: CMUAreaShepOutdoors
+  id: CMUAreaShepESTower
+  name: Experimental Sensor Tower
+  components:
+  - type: Sprite
+    state: comms
+  - type: Area
+    resinAllowed: false
+    minimapColor: '#C5A06FCC'
+
+- type: entity
+  parent: CMUAreaShepOutdoors
   id: CMUAreaShepHiddenLZ4
   name: Northwest Jungle - LZ4
   components:

--- a/Resources/Prototypes/_CMU14/Entities/IndividualMapPrototypes/sheperd_prototypes.yml
+++ b/Resources/Prototypes/_CMU14/Entities/IndividualMapPrototypes/sheperd_prototypes.yml
@@ -15,3 +15,15 @@
   id: CMUShepDropshipDestinationOpforLZ4
   name: LZ4 - Hidden LZ
   categories: [ HideSpawnMenu ]
+
+- type: entity
+  parent: RMCFogWallPermanent
+  id: CMUFogWall_forceonforce_inverted
+  description: It looks way too dangerous to traverse. Best wait until it has cleared up.
+  suffix: ForceOnForce Inverted, 20 minutes
+  components:
+  - type: DestroyOnPreset
+    preset: ForceOnForce
+    inverted: true
+  - type: TimedDespawn
+    lifetime: 1200

--- a/Resources/Prototypes/_CMU14/Entities/Markers/Spawners/Random/clothing.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Markers/Spawners/Random/clothing.yml
@@ -1,0 +1,110 @@
+- type: entity
+  id: CMURandomClothingCivilian
+  name: random civilian clothing spawner
+  parent: MarkerBase
+  suffix: CMU
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+  - type: RandomSpawner
+    chance: 0.5
+    prototypes:
+      #Foot Wear
+      - RMCShoesBlack
+      - RMCShoesBlue
+      - RMCShoesBrown
+      - RMCShoesGreen
+      - RMCShoesOrange
+      - RMCShoesPurple
+      - RMCShoesRed
+      - RMCShoesWhite
+      - RMCShoesYellow
+      - RMCBootsPMC
+      - RMCBootsVanBandolier
+      - RMCShoesLaceupBrown
+      - RMCShoesLaceup
+      - RMCShoesLeather
+      - CMBootsThigh #Sheperds'
+      #Work Wear
+      - AU14CivilianWorkwearYellow
+      - AU14CivilianWorkwearPink
+      - AU14CivilianWorkwearBlue
+      - AU14CivilianWorkwearGreen
+      #Business Attire
+      - CMJumpsuitLiaisonBlack
+      - CMJumpsuitLiaisonBlue
+      - CMJumpsuitLiaisonBrown
+      - CMJumpsuitLiaisonField
+      - CMJumpsuitLiaisonIvy
+      - CMJumpsuitLiaisonCorporateFormal
+      - CMJumpsuitLiaisonFormal
+      - CMJumpsuitLiaison
+      - CMJumpsuitLiaisonBlazer
+      - CMJumpsuitLiaisonCharcoal
+      #Miscellaneous Clothes
+      - RMCJumpsuitDutchBandolier
+      - RMCJumpsuitCivilian
+      - CMJumpsuitColonist
+      - CMJumpsuitTShirtWhite
+      - CMJumpsuitTShirtGray
+      - CMJumpsuitTShirtRed
+      - CMJumpsuitFishingColonist #Sheperds'
+      #Suit Jackets
+      - RMCJacketCorporateKhaki
+      - RMCJacketCorporateBlack
+      - RMCJacketCorporateBlue
+      - RMCJacketCorporateBrown
+      #Puffer Wear
+      - AU14CivilianJacketGrayPufferVest
+      - AU14CivilianJacketKhakiPufferVest
+      - AU14CivilianJacketTanPufferVest
+      - AU14CivilianJacketGrayPufferJacket
+      - AU14CivilianJacketOrangePufferJacket
+      - AU14CivilianJacketKhakiPufferJacket
+      #Windbreakers
+      - AU14WindbreakerBlue
+      - AU14WindbreakerGray
+      - AU14WindbreakerGreen
+      - AU14WindbreakerKhakiGreenMix
+      - AU14WindbreakerKhaki
+      #Parkas
+      - AU14CivilianJacketBlueParka
+      - AU14CivilianJacketGreenParka
+      - AU14CivilianJacketRedParka
+      - AU14CivilianJacketYellowParka
+      #Trench Coats
+      - AU14CivilianTanTrenchCoat
+      - AU14CivilianBrownTrenchCoat
+      - AU14CivilianGrayTrenchCoat
+      #Miscellaneous Jackets
+      - AU14CivilianJacketBomberJacket
+      - AU14CivilianJacketOldCoat
+      - AU14CivilianJacketSnowSuit
+      #Hats
+      - AU14CivBallCapBlack
+      - AU14CivBallCapBlueTrucker
+      - AU14CivBallCapRedTrucker
+      - AU14USCMVeteranCap
+      - AU14CivFedoraTan
+      - AU14CivFedoraBrown
+      - AU14CivFedoraGray
+      #Glasses
+      - RMCSunglasses
+      - RMCHipsterGlasses
+      - RMCSunglassesBig
+      - AU14GlassesPersonalOrange
+      - RMCGlassesAviators
+      - RMCGlassesTriMaxYellow
+      - RMCGlassesTriMaxBlack
+      - RMCGlassesTriMaxBronze
+      - AU14GlassesBiMexOrange
+      #Gloves
+      - CMHandsBrown
+      - CMHandsLightBrown
+      #Storage
+      - CMSatchel
+      - AU14SlingSatchelBlack
+      - AU14SlingSatchelBlue
+      - RMCBeltUtilityGeneral
+      - RMCPouchGeneral


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added inverted wall removes for FOF and Colony Fall. Added hijack consoles. Added req lines. Made CLF bases more even. Fixed some airlock and brig timer accesses. Added random clothing spawners around the colony. Added Experimental Sensor Tower.

Area around checkpoint nerfed.

## Why / Balance
Maintenance

**Changelog**
:cl:
- remove: Flight is out of rotation.
- add: Random Clothing Spawner for map use
- add: 20 minute fog wall for FOF
- add: Inverted wall remove jungle vegetation for Colony Fall
