### PR TITLE
fix WY scientist cant use medical stuff

### DIFF
--- a/Resources/Prototypes/_AU14/Roles/Jobs/WeYu/colonyscientist.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/WeYu/colonyscientist.yml
@@ -33,6 +33,7 @@
   accessGroups:
   - Colonist
   - auwy
+  - aumed
   roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
@@ -42,6 +43,7 @@
         RMCSkillFireman: 1
         RMCSkillVehicles: 1
         RMCSkillDomestics: 1
+        RMCSkillMedical: 3
         RMCSkillFirearms: 2
         RMCSkillSurgery: 4
     - type: JobPrefix


### PR DESCRIPTION
## About the PR
Gives WY Scientist access to pill bottle and ability to actually use medical stuff

## Why / Balance
ID locked pill bottle and WHY THEY CANT USE DEFIB AND CHEM DISPENSER THAT THEY GOT PROVIDED WITH

**Changelog**
:cl:
- add: medical skill for WY Scientist and access to medical stuffs