### PR TITLE
PMC Minor Update

### DIFF
--- a/Resources/Prototypes/_AU14/Entities/Clothing/WY-PMC/helmets.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/WY-PMC/helmets.yml
@@ -32,7 +32,7 @@
     sprite: _AU14/Clothing/WY_PMC/pmchelmet_closed.rsi
   - type: CMArmor
     bullet: 25
-    bio: 15
+    bio: 25
     # armor_internaldamage = 15
   - type: HideLayerClothing
     slots:

--- a/Resources/Prototypes/_AU14/thirdParties/WeYu/PMCParty/PMCLeader.yml
+++ b/Resources/Prototypes/_AU14/thirdParties/WeYu/PMCParty/PMCLeader.yml
@@ -75,6 +75,7 @@
     jumpsuit: AU14WYPMCFatigues
     shoes: RMCBootsPMCFilled
     mask: RMCMaskCoifPMC
+    eyes: RMCGlassesMedicalHUDGlasses
     head: ArmorHelmetPMCFieldOfficer
     gloves: AU14PVEHandsInsulatedBlackMarine
     belt: RMCMK80BeltPMCFilled

--- a/Resources/Prototypes/_AU14/thirdParties/WeYu/PMCParty/PMCMedic.yml
+++ b/Resources/Prototypes/_AU14/thirdParties/WeYu/PMCParty/PMCMedic.yml
@@ -20,6 +20,7 @@
     components:
     - type: Skills
       skills:
+        RMCSkillEndurance: 1
         RMCSkillFirearms: 2
         RMCSkillFireman: 1
         RMCSkillJtac: 1
@@ -69,6 +70,7 @@
     outerClothing: AU14WYPMCArmor
     jumpsuit: AU14WYPMCFatigues
     shoes: RMCBootsPMCFilled
+    eyes: RMCGlassesMedicalHUDGlasses
     head: AU14ArmorHelmetPMCTactical
     gloves: AU14PVEHandsInsulatedBlackMarine
     belt: CMUBeltMedicBagSupportSynth

--- a/Resources/Prototypes/_AU14/thirdParties/WeYu/PMCParty/PMCSmartgunner.yml
+++ b/Resources/Prototypes/_AU14/thirdParties/WeYu/PMCParty/PMCSmartgunner.yml
@@ -20,6 +20,7 @@
     components:
     - type: Skills
       skills:
+        RMCSkillEndurance: 2
         RMCSkillFirearms: 2
         RMCSkillFireman: 1
         RMCSkillJtac: 1


### PR DESCRIPTION
## About the PR
Gives Medic and Smartgunner Endurance. 1 for Medic, 2 for SG.

Gives PMC Medic and Leader medhuds.

Buffs bio to 25 from 15. Doesn't make sense that PMCs get worse bio when they have full face protection and more.

## Why / Balance

Buffs PMC in a Minor way and fixes oversight. Makes them more inline with the CM13 counterparts.

## Technical details
Adds Skills to PMC Medic, SG, Leader

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- add: PMC Leader also gets a medhud
- add: PMC SG and Medic now get Endurance Skills
- tweak: PMC Helmets from 15 to 25 (Base RMC helmets give 20)
- fix: PMC Medic not getting a Medhud
