### PR TITLE
Fix skill to use blood bag and iv drip

### DIFF
--- a/Content.Shared/_RMC14/Medical/IV/BloodPackComponent.cs
+++ b/Content.Shared/_RMC14/Medical/IV/BloodPackComponent.cs
@@ -55,7 +55,7 @@ public sealed partial class BloodPackComponent : Component
     public ProtoId<EmotePrototype> RipEmote = "Scream";
 
     [DataField, AutoNetworkedField]
-    public Dictionary<EntProtoId<SkillDefinitionComponent>, int> SkillRequired = new() { ["RMCSkillSurgery"] = 1 };
+    public Dictionary<EntProtoId<SkillDefinitionComponent>, int> SkillRequired = new() { ["RMCSkillMedical"] = 1 };
 
     // TODO RMC-14 blood types
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Medical/IV/BloodPackComponent.cs
+++ b/Content.Shared/_RMC14/Medical/IV/BloodPackComponent.cs
@@ -55,7 +55,7 @@ public sealed partial class BloodPackComponent : Component
     public ProtoId<EmotePrototype> RipEmote = "Scream";
 
     [DataField, AutoNetworkedField]
-    public Dictionary<EntProtoId<SkillDefinitionComponent>, int> SkillRequired = new() { ["RMCSkillMedical"] = 1 };
+    public Dictionary<EntProtoId<SkillDefinitionComponent>, int> SkillRequired = new() { ["RMCSkillMedical"] = 2 };
 
     // TODO RMC-14 blood types
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Medical/IV/IVDripComponent.cs
+++ b/Content.Shared/_RMC14/Medical/IV/IVDripComponent.cs
@@ -61,7 +61,7 @@ public sealed partial class IVDripComponent : Component
     public ProtoId<EmotePrototype> RipEmote = "Scream";
 
     [DataField, AutoNetworkedField]
-    public Dictionary<EntProtoId<SkillDefinitionComponent>, int> SkillRequired = new() { ["RMCSkillSurgery"] = 1 };
+    public Dictionary<EntProtoId<SkillDefinitionComponent>, int> SkillRequired = new() { ["RMCSkillMedical"] = 1 };
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
## About the PR
WHY YOU NEED SURGERY SKILL TO JUST ATTACH A BLOOD BAG AND IV + poor ERO cant attach blood bag on dying colonist

## Why / Balance
Increases colony survival because emergency response officer could actually give blood bag

**Changelog**
:cl:
- tweak: Changed from surgery to medical skill requirement for using blood bag or iv drip