### PR TITLE
WY Guard Headset Swap

### DIFF
--- a/Resources/Prototypes/_AU14/Roles/Jobs/WeYu/weyucorporateguard.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/WeYu/weyucorporateguard.yml
@@ -71,7 +71,7 @@
     head: AU14CivBallCapBlack
     belt: AU14BeltUtilityGeneralBlack
     back: RMCSatchelLightpackWeYa
-    ears2: AU14ColonyAdminHeadset
+    ears2: AU14ColonyWeylandHeadset
     ears: RMCM5CameraGear
     suitstorage: RMCM77BeltPMCFilled
 


### PR DESCRIPTION
## About the PR
Swaps the Admin Headset they get for WY.

## Why / Balance
Oversight

## Technical details
Swaps Admin Headset for WY Headset for WY Guards


## Requirements
Its one line change. Yes

**Changelog**
- fix: WY Sec not getting WY comms fixed.
