### PR TITLE
Fixes tunnels being broken

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -2039,7 +2039,6 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
     private void OnXenoComponentInit(Entity<XenoComponent> ent, ref ComponentInit args)
     {
         _hive.SetHive(ent.Owner, TheHive);
-        SetFriendlyHives(TheHive);
         if (!_queenBuildingBoostEnabled)
             return;
 


### PR DESCRIPTION
Previous commit had a fix for round start map placed tunnels

That caused a loop to start each time a xeno spawned or evolved, that loop was ment for round start and it ran everytime 

this should fix the tunnels disseapering randomly now.