### PR TITLE
Remove Broken Maps From Rotation, Fix USCM + Other Tweaks

### DIFF
--- a/Resources/Locale/en-US/_AU14/allegiance-origin.ftl
+++ b/Resources/Locale/en-US/_AU14/allegiance-origin.ftl
@@ -2,13 +2,13 @@
 allegiance-no-matching-character = None of your characters have an allegiance that matches this platoon. Create a character with the correct allegiance or enable "Ignore Allegiance" in the lobby.
 allegiance-ua-name = United Americas
 allegiance-ua-description = The United Americas. A major interstellar superpower encompassing North and South America.
-allegiance-upp-name = UPP
+allegiance-upp-name = Union of Progressive Peoples
 allegiance-upp-description = Union of Progressive Peoples. A socialist superpower rivaling the UA.
-allegiance-cca-name = CCA
+allegiance-cca-name = Central Confederation of Africa
 allegiance-cca-description = Confederation of Central Africa. A powerful African coalition with significant colonial holdings.
-allegiance-is-name = Independent Systems
+allegiance-is-name = Independent
 allegiance-is-description = Independent Systems.
-allegiance-clf-name = CLF
+allegiance-clf-name = Colonial Liberation Front
 allegiance-clf-description = Colonial Liberation Front. A colonist militia fighting for independence from corporate and governmental control.
 allegiance-laselle-name = Laselle Bionational
 allegiance-laselle-description = Laselle Bionational. A powerful biotech corporation with its own colonial interests.
@@ -18,39 +18,39 @@ allegiance-twe-name = Three World Empire
 allegiance-twe-description = Three World Empire. A constitutional monarchy spanning the United Kingdom, Japan, India, and Australia.
 
 # Origins - United Americas
-origin-ua-mexico-name = United Americas - Mexico
+origin-ua-mexico-name = UA - Mexico
 origin-ua-mexico-description = Born in Mexico, part of the United Americas.
-origin-ua-colonies-name = United Americas - Colonies
+origin-ua-colonies-name = UA - Colonies
 origin-ua-colonies-description = Raised in one of the United Americas' extrasolar colonies.
-origin-ua-other-name = United Americas - Other
+origin-ua-other-name = UA - Other
 origin-ua-other-description = From elsewhere within the United Americas.
-origin-ua-luna-name = United Americas - Luna
-origin-ua-luna-description = Raised in a UA district on Luna.
-origin-ua-canada-name = United Americas - Canada
+origin-ua-luna-name = UA - Lunar Born
+origin-ua-luna-description = Born aboard a UA vessel or space station.
+origin-ua-canada-name = UA - Canada
 origin-ua-canada-description = Born in Canada, part of the United Americas.
-origin-ua-america-name = United Americas - America
+origin-ua-america-name = UA - America
 origin-ua-america-description = Born in the United States of America, heartland of the UA.
-origin-ua-brazil-name = United Americas - Brazil
+origin-ua-brazil-name = UA - Brazil
 origin-ua-brazil-description = Born in Brazil, part of the United Americas.
-origin-ua-argentina-name = United Americas - Argentina
+origin-ua-argentina-name = UA - Argentina
 origin-ua-argentina-description = Born in Argentina, part of the United Americas.
 
 # Origins - Three World Empire
-origin-twe-japan-name = Three World Empire - Japan
+origin-twe-japan-name = TWE - Japan
 origin-twe-japan-description = Born in Japan, a core member of the Three World Empire.
-origin-twe-india-name = Three World Empire - India
+origin-twe-india-name = TWE - India
 origin-twe-india-description = Born in India, a core member of the Three World Empire.
-origin-twe-colony-name = Three World Empire - Colony
+origin-twe-colony-name = TWE - Colony
 origin-twe-colony-description = Raised in one of the Three World Empire's extrasolar colonies.
-origin-twe-mars-name = Three World Empire - Mars
+origin-twe-mars-name = TWE - Mars
 origin-twe-mars-description = Raised in a TWE district on Mars.
-origin-twe-luna-name = Three World Empire - Luna
-origin-twe-luna-description = Raised in a TWE district on Luna.
-origin-twe-australia-name = Three World Empire - Australia
+origin-twe-luna-name = TWE - Lunar Born
+origin-twe-luna-description = Born aboard a TWE vessel or space station.
+origin-twe-australia-name = TWE - Australia
 origin-twe-australia-description = Born in Australia, a core member of the Three World Empire.
-origin-twe-other-name = Three World Empire - Other
+origin-twe-other-name = TWE - Other
 origin-twe-other-description = From elsewhere within the Three World Empire.
-origin-twe-tian-name = Three World Empire - Tian
+origin-twe-tian-name = TWE - Tian
 origin-twe-tian-description = Raised on Tian, a TWE world.
 
 # Origins - Confederation of Central Africa
@@ -68,8 +68,8 @@ origin-cca-tunisia-name = CCA - Tunisia
 origin-cca-tunisia-description = Born in Tunisia, part of the Confederation of Central Africa.
 origin-cca-other-name = CCA - Other
 origin-cca-other-description = From elsewhere within the Confederation of Central Africa.
-origin-cca-luna-name = CCA - Luna
-origin-cca-luna-description = Raised in a CCA district on Luna.
+origin-cca-luna-name = CCA - Lunar Born
+origin-cca-luna-description = Born aboard a CCA vessel or space station.
 
 # Origins - Union of Progressive Peoples
 origin-upp-russia-name = UPP - Russia
@@ -82,8 +82,8 @@ origin-upp-china-name = UPP - China
 origin-upp-china-description = Born in China, a core member of the Union of Progressive Peoples.
 origin-upp-indonesia-name = UPP - Indonesia
 origin-upp-indonesia-description = Born in Indonesia, part of the Union of Progressive Peoples.
-origin-upp-luna-name = UPP - Luna
-origin-upp-luna-description = Raised in a UPP district on Luna.
+origin-upp-luna-name = UPP - Lunar Born
+origin-upp-luna-description = Born aboard a UPP vessel or space station.
 origin-upp-vietnam-name = UPP - Vietnam
 origin-upp-vietnam-description = Born in Vietnam, part of the Union of Progressive Peoples.
 origin-upp-korea-name = UPP - Korea
@@ -118,6 +118,8 @@ origin-is-ghana-name = Independent - Ghana
 origin-is-ghana-description = Born in Ghana, an independent nation.
 origin-is-egypt-name = Independent - Egypt
 origin-is-egypt-description = Born in Egypt, an independent nation.
+origin-is-icsc-name = ICSC - Colonial
+origin-is-icsc-description = Born on a colony with ICSC membership.
 
 # Origins - Corporate
 origin-corp-madagascar-name = Corporate - Madagascar
@@ -128,8 +130,8 @@ origin-corp-mars-name = Corporate - Mars
 origin-corp-mars-description = Raised in a corporate district on Mars.
 origin-corp-prodigycity-name = Corporate - Prodigy City
 origin-corp-prodigycity-description = From Prodigy City, a corporate arcology.
-origin-corp-luna-name = Corporate - Luna
-origin-corp-luna-description = Raised in a corporate district on Luna.
+origin-corp-luna-name = Corporate - Lunar Born
+origin-corp-luna-description = Born aboard a UA vessel or space station.
 origin-corp-colonies-name = Corporate - Colonies
 origin-corp-colonies-description = Raised in a corporate-owned extrasolar colony.
 origin-corp-other-name = Corporate - Other

--- a/Resources/Prototypes/_AU14/Entities/clf/clfstuff.yml
+++ b/Resources/Prototypes/_AU14/Entities/clf/clfstuff.yml
@@ -39,15 +39,15 @@
         points: 10
       - id: RMCWeaponRifleType71C
         amount: 1
-        points: 3
+        points: 7
     - name: Shotguns
       entries:
       - id: RMCWeaponShotgunHG3712
         amount: 1
-        points: 5
+        points: 7
       - id: WeaponShotgunM357Sawn
         amount: 2
-        points: 6
+        points: 4
       - id: WeaponShotgunM357
         amount: 3
         points: 5
@@ -135,9 +135,9 @@
       - id: CMGrenadeSmoke
         amount: 5
         points: 2
-      - id: CMGrenadeFragOld
+      - id: RMCGrenadeIED
         amount: 4
-        points: 3
+        points: 5
       - id: RMCExplosivePlastic
         amount: 2
         points: 8
@@ -146,18 +146,21 @@
         points: 10
     - name: Improvised Explosive Devices
       entries:
+      - id: CMMultitool
+        amount: 10
+        points: 1
       - id: AU14RemoteSignallerAdvanced
-        amount: 5
+        amount: 10
         points: 1
       - id: AU14IED
         amount: 6
         points: 6
-      - id: AU14IEDLarge
-        amount: 3
-        points: 17
       - id: AU14IEDVest
         amount: 2
-        points: 12
+        points: 10
+      - id: AU14IEDLarge
+        amount: 3
+        points: 15
     - name: Special Equipment
       entries:
       - id: CMUCLFSynthSubversionKey
@@ -169,6 +172,26 @@
       - id: AU14TattooGun
         amount: 3
         points: 8
+    - name: Mortar
+      entries:
+      - id: RMCRangefinder
+        amount: 5
+        points: 3
+      - id: RMCMortarKit
+        amount: 1
+        points: 20
+      - id: RMCMortarShellFlare
+        amount: 10
+        points: 3
+      - id: RMCMortarShellHE
+        amount: 10
+        points: 6
+      - id: AU14MortarShellHEATMP
+        amount: 10
+        points: 8
+      - id: RMCMortarShellIncendiary
+        amount: 5
+        points: 12
   - type: Transform
     anchored: false
     noRot: true

--- a/Resources/Prototypes/_AU14/Origin/origins.yml
+++ b/Resources/Prototypes/_AU14/Origin/origins.yml
@@ -279,6 +279,12 @@
   description: origin-is-egypt-description
   roundStart: true
 
+- type: Origin
+  id: ICSCColonies
+  name: origin-is-icsc-name
+  description: origin-is-icsc-description
+  roundStart: true
+
 # Corporate
 - type: Origin
   id: CorpMadagascar

--- a/Resources/Prototypes/_AU14/gamemode/gamemodes.yml
+++ b/Resources/Prototypes/_AU14/gamemode/gamemodes.yml
@@ -65,7 +65,7 @@
   - AUPlanetCorsatStation
   - AUPlanetStableGarrison
   - AUPlanetTrijent
-  - AuPlanetFiorina
+#  - AuPlanetFiorina -removed due to load errors
   - AuPlanetKutjevo
   - AuPlanetShivasSnowball
   - CMUPlanetLament

--- a/Resources/Prototypes/_AU14/gamemode/platoons.yml
+++ b/Resources/Prototypes/_AU14/gamemode/platoons.yml
@@ -46,8 +46,6 @@
     Pilot: AU14AircrewWeaponsVendor
     combattech: AU14ComtechGearVendor
     JuniorOfficer: AU14JOGenericVendor
-    ExtraVendor1: VMarkerOpforDeco5
-    Deco1: VMarkerOpforDeco5
   #platoonflag:  uaflag
   CompatibleDropships:
   - /Maps/_CMU14/Shuttles/alamo.yml

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -331,7 +331,7 @@
 - type: entity
   parent: CMGrenadeBase
   id: RMCGrenadeIED
-  name: improvised explosive device
+  name: throwable improvised explosive device
   description: An improvised chemical explosive grenade. Designed to kill through fragmentation.
   components:
   - type: Sprite


### PR DESCRIPTION
Removes Fiorina from rotation until fixed.
Tweaks origins to be a little more comprehensible to new players and replaces luna with lunar born (parity).
CLF are now able to purchase a mortar for a high price alongside some other goodies. Minor price rebalances.
Hopefully fixes USCM load issues.