### PR TITLE
Various Fixes + Soul Changes

### DIFF
--- a/Resources/Prototypes/_AU14/Entities/Items/Kits/Weapons/weapons.yml
+++ b/Resources/Prototypes/_AU14/Entities/Items/Kits/Weapons/weapons.yml
@@ -629,5 +629,7 @@
     contents:
       - id: AU14WeaponSMGXMP5A6HAZOPS
         amount: 1
+      - id: CMMagazineRifleM54CAP
+        amount: 1
       - id: AU14MagazineXMP5A6
         amount: 8

--- a/Resources/Prototypes/_AU14/Entities/Vendors/hazopsvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/hazopsvendors.yml
@@ -238,7 +238,6 @@
       entries:
       - id: AU14MagazineXMP5A6
         amount: 60
-      - id: CMMagazineRifleM54CAP
     - name: Handguns
       choices: { CMUHandgunsWeapon: 1 }
       entries:
@@ -248,11 +247,10 @@
       - id: CMMagazinePistolM1984
         amount: 60
     - name: Attachments
-      choices: { CMUAttachmentsVendor: 2 }
+      choices: { CMUAttachmentsVendor: 1 }
       entries:
       - id: RMCAttachmentRailFlashlight
       - id: RMCAttachmentTwoPointSling
-      - id: AU14AttachmentM203A4GrenadeLauncher
 
 - type: entity
   parent: ColMarTechBase

--- a/Resources/Prototypes/_AU14/Entities/Vendors/rmcvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/rmcvendors.yml
@@ -892,6 +892,8 @@
         amount: 4
       - id: AU14PacketGrenadeIncendiaryRMCFilled
         amount: 4
+      - id: AU14PacketGrenadeNeuroRMCFilled
+        amount: 2
       - id: RMCExplosivePlastic
         amount: 4
       - id: RMCExplosiveBreachingCharge

--- a/Resources/Prototypes/_AU14/Entities/Weapons/HAZOPS/m240a2.yml
+++ b/Resources/Prototypes/_AU14/Entities/Weapons/HAZOPS/m240a2.yml
@@ -24,10 +24,10 @@
     - Back
   - type: Gun
     cameraRecoilScalar: 0
-    fireRate: 2
-    selectedMode: SemiAuto
+    fireRate: 2.5
+    selectedMode: FullAuto
     availableModes:
-    - SemiAuto
+    - FullAuto
     soundGunshot:
       collection: RMCFlamerShoot
   - type: ShootUseDelay
@@ -103,14 +103,14 @@
       map: [ "enum.SolutionContainerLayers.Fill" ]
   - type: RMCFlamerTank
     maxIntensity: 70
-    maxRange: 8
+    maxRange: 7
   - type: SolutionContainerManager
     solutions:
       rmc_flamer_tank:
-        maxVol: 250
+        maxVol: 150
         reagents:
         - ReagentId: RMCNapalmUT
-          Quantity: 250
+          Quantity: 150
   - type: SolutionContainerVisuals
     maxFillLevels: 2
     fillBaseName: flametank_strip

--- a/Resources/Prototypes/_AU14/Entities/Weapons/HAZOPS/spas12haz.yml
+++ b/Resources/Prototypes/_AU14/Entities/Weapons/HAZOPS/spas12haz.yml
@@ -21,7 +21,7 @@
     - Burst
     modifiers:
       Burst:
-        fireDelay: 0.01 
+        fireDelay: 0.01
         maxScatterModifier: 10
         useBurstScatterMult: true
         unwieldedScatterMultiplier: 2
@@ -30,7 +30,7 @@
     recoilUnwielded: 4
     scatterWielded: 10
     scatterUnwielded: 20
-    baseFireRate: 1.666
+    baseFireRate: 0.9
     burstScatterMult: 5
   - type: RMCWeaponAccuracy
     accuracyMultiplier: 1.20

--- a/Resources/Prototypes/_AU14/Entities/clf/clfstuff.yml
+++ b/Resources/Prototypes/_AU14/Entities/clf/clfstuff.yml
@@ -24,7 +24,7 @@
       entries:
       - id: AU14WeaponRifleM16A1
         amount: 2
-        points: 5
+        points: 6
       - id: AU14WeaponRifleM16A2
         amount: 3
         points: 5
@@ -63,8 +63,8 @@
         amount: 3
         points: 4
       - id: RMCWeaponPistolHoldout
-        amount: 6
-        points: 2
+        amount: 10
+        points: 1
       - id: RMCWeaponPistolD18
         amount: 7
         points: 3
@@ -73,9 +73,15 @@
       - id: RMCWeaponLauncherHJRA12
         amount: 1
         points: 10
+      - id: RMCWeaponLauncherDisposableFolded
+        amount: 1
+        points: 8
       - id: RMCWeaponMar50LMG
         amount: 1
-        points: 16
+        points: 11
+      - id: RMCM2CMount
+        amount: 1
+        points: 19
     - name: Rifle Ammunition
       entries:
       - id: RMCMagazineRifleM16
@@ -96,6 +102,12 @@
       - id: RMCMagazineRifleType71
         amount: 9
         points: 2
+      - id: RMCMagazineRifleType71AP
+        amount: 9
+        points: 6
+      - id: RMCMagazineM2C
+        amount: 9
+        points: 4
     - name: Shotgun Ammunition
       entries:
       - id: RMCBoxShotgunFlechette
@@ -135,6 +147,9 @@
       - id: CMGrenadeSmoke
         amount: 5
         points: 2
+      - id: AU14GrenadeNeuroRMC
+        amount: 2
+        points: 9
       - id: RMCGrenadeIED
         amount: 4
         points: 5
@@ -142,8 +157,11 @@
         amount: 2
         points: 8
       - id: RMCRocketHJRA12HE
-        amount: 2
-        points: 10
+        amount: 4
+        points: 9
+      - id: RMCRocketHJRA12AT
+        amount: 5
+        points: 11
     - name: Improvised Explosive Devices
       entries:
       - id: CMMultitool
@@ -161,6 +179,23 @@
       - id: AU14IEDLarge
         amount: 3
         points: 15
+    - name: Protective Equipment
+      entries:
+      - id: ArmorHelmetPMCRiot
+        amount: 5
+        points: 3
+      - id: AU14UACGHelmet
+        amount: 5
+        points: 3
+      - id: RMCCoatMilitiaVest
+        amount: 5
+        points: 7
+      - id: CMMaskGas
+        amount: 5
+        points: 3
+      - id: CMUGasMaskFilter
+        amount: 5
+        points: 2
     - name: Special Equipment
       entries:
       - id: CMUCLFSynthSubversionKey

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Cases/secure_crates.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Cases/secure_crates.yml
@@ -60,8 +60,8 @@
 - type: entity
   parent: RMCSecureCaseStrapped
   id: RMCSecureCaseStrappedWater
-  name: We-Ya Bottled Water crate (x50)
-  description: A crate containing fifty Weston-Yamada Bottled Spring Water bottles.
+  name: Bottled Water crate (x50)
+  description: A crate containing fifty Bottled Spring Water bottles.
   components:
   - type: CrateOpenable
     spawn:
@@ -71,8 +71,8 @@
 - type: entity
   parent: RMCSecureCaseStrapped
   id: RMCSecureCaseStrappedMRE
-  name: UNMC MRE crate (x60)
-  description: A supply crate containing sixty UNMC MRE packets.
+  name: MRE crate (x60)
+  description: A supply crate containing sixty MRE packets.
   components:
   - type: CrateOpenable
     spawn:
@@ -82,8 +82,8 @@
 - type: entity
   parent: RMCSecureCaseStrapped
   id: RMCSecureCaseStrappedTSEMRE
-  name: TSE ORP rations crate (x60)
-  description: A supply crate containing sixty TSE ORP ration packets.
+  name: TWE ORP rations crate (x60)
+  description: A supply crate containing sixty TWE ORP ration packets.
   components:
   - type: CrateOpenable
     spawn:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/tools.yml
@@ -122,8 +122,8 @@
 - type: entity
   parent: Multitool
   id: CMMultitool
-  name: security access tuner
-  description: A small handheld tool used to override various machine functions.
+  name: access tuner
+  description: A small handheld tool used to override or connect various machine functions.
   suffix: Multitool
   components:
   - type: Sprite

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34_flamer.yml
@@ -27,10 +27,10 @@
     - Back
   - type: Gun
     cameraRecoilScalar: 0
-    fireRate: 1
-    selectedMode: SemiAuto
+    fireRate: 1.9
+    selectedMode: FullAuto
     availableModes:
-    - SemiAuto
+    - FullAuto
     soundGunshot:
       collection: RMCFlamerShoot
   - type: ShootUseDelay

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -485,13 +485,8 @@
     CMFlash: 5
     RMCFoodDonut: 12
     # Evidence box 6
-    CMArmorHelmetM10MP: 6
     # PeakedMPCap: 6
-    CMHeadCapMP: 6
-    CMJumpsuitMP: 2
-    CMHeadBeretRed: 6
     CMGlassesSecurity: 3
-    CMHeadset: 6
     #RegulationTape: 5
     #TapeRecorder: 3
     #ClueScanner: 3

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1489,3 +1489,7 @@ RMCSpawnerShuttleZSPA: RMCSpawnerShuttleTSEPA
 # 2026-02-05
 RMCWeaponSMGP90: RMCWeaponSMGPDW90
 RMCMagazineSMGP90: RMCMagazineSMGPDW90
+
+# 2026-04-023 - CMU
+CMVendorMedical: AU14GeneralMedicalVendor
+CMVendorBlood: AU14VendorBlood


### PR DESCRIPTION
- HAZOPs infinite AP glitch patched.
- HAZOPs GL removed from the vendor as its already on the gun anyway (noob bait).
- HAZOPs Spaz 12 firerate nerfed.
- HAZOPs flamethrower given less fuel.
- Royal Marines given their gas grenades back now that we have working gas masks/filters.
- Flamethrowers now act like flamethrowers (this is probably OP as fuck, I do not care).
- CLF vendor balancing + new equipment (M2C, gas masks, armor, etc)
- The RUCM Almayer added to the maps folder for use on the mapping server.
- Basic loreifications.
- Base RMC medical vendors migrated to the AU14 entities.

