### PR TITLE
vehicle lock integrity break

### DIFF
--- a/Content.Shared/_RMC14/Vehicle/Core/VehicleInteriorComponents.cs
+++ b/Content.Shared/_RMC14/Vehicle/Core/VehicleInteriorComponents.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Map;
 namespace Content.Shared._RMC14.Vehicle;
 
 [RegisterComponent]
-[Access(typeof(VehicleSystem))]
+[Access(typeof(VehicleSystem), Other = AccessPermissions.Read)]
 public sealed partial class VehicleInteriorComponent : Component
 {
     public EntityUid Map = EntityUid.Invalid;

--- a/Content.Shared/_RMC14/Vehicle/Core/VehicleLockComponents.cs
+++ b/Content.Shared/_RMC14/Vehicle/Core/VehicleLockComponents.cs
@@ -12,6 +12,15 @@ public sealed partial class VehicleLockComponent : Component
 {
     [DataField]
     public bool Locked;
+
+    [DataField]
+    public float ForceOpenBelowFraction = 0.3f;
+
+    [DataField]
+    public float RelockAtFraction = 0.9f;
+
+    [DataField]
+    public bool ForcedOpen;
 }
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]

--- a/Content.Shared/_RMC14/Vehicle/Core/VehicleLockSystem.cs
+++ b/Content.Shared/_RMC14/Vehicle/Core/VehicleLockSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Vehicle.Components;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Localization;
 using Robust.Shared.Network;
+using Robust.Shared.Player;
 
 namespace Content.Shared._RMC14.Vehicle;
 
@@ -111,6 +112,16 @@ public sealed class VehicleLockSystem : EntitySystem
         }
 
         var lockComp = EnsureComp<VehicleLockComponent>(vehicle);
+
+        if (!lockComp.Locked && lockComp.ForcedOpen)
+        {
+            _popup.PopupCursor(
+                Loc.GetString("rmc-vehicle-lock-too-damaged"),
+                ent.Owner,
+                PopupType.SmallCaution);
+            return;
+        }
+
         lockComp.Locked = !lockComp.Locked;
 
         if (ent.Comp.Action is { } actionUid)
@@ -121,5 +132,63 @@ public sealed class VehicleLockSystem : EntitySystem
             ent.Owner,
             ent.Owner,
             PopupType.Small);
+    }
+
+    public void RefreshForcedOpen(EntityUid vehicle)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (!TryComp(vehicle, out VehicleLockComponent? lockComp))
+            return;
+
+        if (!TryComp(vehicle, out HardpointIntegrityComponent? frame) || frame.MaxIntegrity <= 0f)
+            return;
+
+        var fraction = frame.Integrity / frame.MaxIntegrity;
+
+        if (!lockComp.ForcedOpen)
+        {
+            if (fraction < lockComp.ForceOpenBelowFraction)
+            {
+                lockComp.ForcedOpen = true;
+
+                if (lockComp.Locked)
+                {
+                    lockComp.Locked = false;
+                    UpdateOperatorLockAction(vehicle, false);
+                    AnnounceOnVehicle(vehicle, "rmc-vehicle-lock-broken-open", PopupType.MediumCaution);
+                }
+            }
+        }
+        else if (fraction >= lockComp.RelockAtFraction)
+        {
+            lockComp.ForcedOpen = false;
+            AnnounceOnVehicle(vehicle, "rmc-vehicle-lock-operational-again", PopupType.Medium);
+        }
+    }
+
+    private void UpdateOperatorLockAction(EntityUid vehicle, bool locked)
+    {
+        if (!TryComp(vehicle, out VehicleComponent? vehicleComp) || vehicleComp.Operator is not { } op)
+            return;
+
+        if (!TryComp(op, out VehicleLockActionComponent? actionComp) || actionComp.Action is not { } actionUid)
+            return;
+
+        _actions.SetToggled(actionUid, locked);
+    }
+
+    private void AnnounceOnVehicle(EntityUid vehicle, string locString, PopupType popupType)
+    {
+        var msg = Loc.GetString(locString);
+
+        _popup.PopupEntity(msg, vehicle, popupType);
+
+        foreach (var session in Filter.Pvs(vehicle).Recipients)
+        {
+            if (session.AttachedEntity is { } viewer)
+                _popup.PopupCursor(msg, viewer, popupType);
+        }
     }
 }

--- a/Content.Shared/_RMC14/Vehicle/Grid/GridVehicleMoveSystem.Movement.cs
+++ b/Content.Shared/_RMC14/Vehicle/Grid/GridVehicleMoveSystem.Movement.cs
@@ -14,6 +14,8 @@ public sealed partial class GridVehicleMoverSystem : EntitySystem
 {
     private const float MinVehicleSpeed = 0.01f;
     private const float MinMoveDistance = 0.0001f;
+    private const float XenoOnboardSpeedMultiplier = 0.2f;
+    private const float XenoOnboardAccelerationMultiplier = 0.3f;
 
     private void UpdateMovement(
         EntityUid uid,
@@ -990,6 +992,8 @@ public sealed partial class GridVehicleMoverSystem : EntitySystem
             maxSpeed *= overcharge.SpeedMultiplier;
         if (TryComp<VehicleSpeedModifierComponent>(uid, out var speedMod))
             maxSpeed *= speedMod.SpeedMultiplier;
+        if (HasXenoOccupant(uid))
+            maxSpeed *= XenoOnboardSpeedMultiplier;
 
         return maxSpeed;
     }
@@ -1005,8 +1009,15 @@ public sealed partial class GridVehicleMoverSystem : EntitySystem
             maxSpeed *= overcharge.SpeedMultiplier;
         if (TryComp<VehicleSpeedModifierComponent>(uid, out var speedMod))
             maxSpeed *= speedMod.SpeedMultiplier;
+        if (HasXenoOccupant(uid))
+            maxSpeed *= XenoOnboardSpeedMultiplier;
 
         return maxSpeed;
+    }
+
+    private bool HasXenoOccupant(EntityUid vehicle)
+    {
+        return TryComp(vehicle, out VehicleInteriorComponent? interior) && interior.Xenos.Count > 0;
     }
 
     private float GetIntegritySpeedMultiplier(EntityUid uid, GridVehicleMoverComponent mover)
@@ -1023,10 +1034,14 @@ public sealed partial class GridVehicleMoverSystem : EntitySystem
 
     private float GetAccelerationModifier(EntityUid uid)
     {
+        var multiplier = 1f;
         if (TryComp<VehicleAccelerationModifierComponent>(uid, out var accelMod))
-            return MathF.Max(0.05f, accelMod.AccelerationMultiplier);
+            multiplier = MathF.Max(0.05f, accelMod.AccelerationMultiplier);
 
-        return 1f;
+        if (HasXenoOccupant(uid))
+            multiplier *= XenoOnboardAccelerationMultiplier;
+
+        return multiplier;
     }
 
     private void StopMover(GridVehicleMoverComponent mover)

--- a/Content.Shared/_RMC14/Vehicle/Hardpoint/HardpointSystem.cs
+++ b/Content.Shared/_RMC14/Vehicle/Hardpoint/HardpointSystem.cs
@@ -60,6 +60,7 @@ public sealed class HardpointSystem : EntitySystem
     [Dependency] private readonly SharedExplosionSystem _explosion = default!;
     [Dependency] private readonly VehicleTopologySystem _topology = default!;
     [Dependency] private readonly SkillsSystem _skills = default!;
+    [Dependency] private readonly VehicleLockSystem _vehicleLock = default!;
 
     public override void Initialize()
     {
@@ -875,6 +876,9 @@ public sealed class HardpointSystem : EntitySystem
         if (previous > 0f && integrity.Integrity <= 0f)
             RefreshCanRun(vehicle);
 
+        if (hardpoint == vehicle)
+            _vehicleLock.RefreshForcedOpen(vehicle);
+
         UpdateHardpointUi(vehicle);
         return true;
     }
@@ -1004,6 +1008,9 @@ public sealed class HardpointSystem : EntitySystem
 
         if (ent.Comp.BypassEntryOnZero)
             RefreshCanRun(vehicle);
+
+        if (ent.Owner == vehicle)
+            _vehicleLock.RefreshForcedOpen(vehicle);
 
         UpdateHardpointUi(vehicle);
 

--- a/Resources/Locale/en-US/_RMC14/vehicle.ftl
+++ b/Resources/Locale/en-US/_RMC14/vehicle.ftl
@@ -102,4 +102,7 @@ rmc-vehicle-exit-busy = Someone is already using this exit.
 rmc-vehicle-lock-not-driver = You need to be in the driver seat to lock or unlock the vehicle.
 rmc-vehicle-lock-set-locked = Vehicle doors locked.
 rmc-vehicle-lock-set-unlocked = Vehicle doors unlocked.
+rmc-vehicle-lock-too-damaged = The lock is too damaged to engage.
+rmc-vehicle-lock-broken-open = The vehicle's lock breaks open from the damage!
+rmc-vehicle-lock-operational-again = The vehicle's lock is operational again.
 rmc-hardpoint-remove-blocked = That hardpoint is fixed in place.

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/vehicle_tank.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/vehicle_tank.yml
@@ -81,9 +81,9 @@
     centerRadius: 1
   - type: Explosive
     explosionType: RMCLTBCannon
-    maxIntensity: 40
-    intensitySlope: 18
-    totalIntensity: 650
+    maxIntensity: 11
+    intensitySlope: 4
+    totalIntensity: 150
     tileBreakScale: 0
     maxTileBreak: 0
 

--- a/Resources/Prototypes/_RMC14/Vehicles/APC/hardpoints.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/APC/hardpoints.yml
@@ -10,6 +10,9 @@
   - type: PowerLoaderGrabbable
     virtualRight: RMCVirtualPowerLoaderRight
     virtualLeft: RMCVirtualPowerLoaderLeft
+  - type: RemoveComponents
+    components:
+    - type: Pullable
 
 - type: entity
   parent: RMCAPCHardpointBase

--- a/Resources/Prototypes/_RMC14/Vehicles/Tank/Hardpoints/hardpoints_base.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Tank/Hardpoints/hardpoints_base.yml
@@ -10,6 +10,9 @@
   - type: PowerLoaderGrabbable
     virtualRight: RMCVirtualPowerLoaderRight
     virtualLeft: RMCVirtualPowerLoaderLeft
+  - type: RemoveComponents
+    components:
+    - type: Pullable
 
 - type: entity
   parent: VehicleTankHardpointBase


### PR DESCRIPTION
[Vehicles locks can be broken if intengrity is below 30%](https://github.com/AU-14/ColonialMarinesUniverse/commit/294e028723c49083cb3d60c31ef0d1a9e4d1f264)
[Xenos in vehicles make the vehicles move at crawling speeds](https://github.com/AU-14/ColonialMarinesUniverse/commit/05994868c6aff935e4435bc86532c46a3e464700)
[Vehicle hardpoints can't be dragged](https://github.com/AU-14/ColonialMarinesUniverse/commit/bcda02116e32c36d57f23e66b6b2b5149a1ea424)