### PR TITLE
USS Bush and Garrison Updates

### DIFF
--- a/Resources/Maps/_AU14/USSBush.yml
+++ b/Resources/Maps/_AU14/USSBush.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: v264.0.2-fix-physics
   forkId: ""
   forkVersion: ""
-  time: 04/25/2026 05:51:22
-  entityCount: 5970
+  time: 04/26/2026 15:38:30
+  entityCount: 5977
 maps:
 - 1
 grids:
@@ -933,23 +933,6 @@ entities:
             584: -6,-47
             635: -6,-51
             636: -6,-49
-        - node:
-            angle: 1.5707963267948966 rad
-            color: '#FFFFFFFF'
-            id: RMCDecalOilFloor1
-          decals:
-            342: 6,39
-        - node:
-            color: '#FFFFFFFF'
-            id: RMCDecalOilFloor2
-          decals:
-            530: 6,42
-        - node:
-            angle: 1.5707963267948966 rad
-            color: '#FFFFFFFF'
-            id: RMCDecalOilFloor6
-          decals:
-            341: 6,40
     - type: GridAtmosphere
       version: 2
       data:
@@ -7197,201 +7180,187 @@ entities:
     - type: Action
       originalIconColor: '#FFFFFFFF'
       container: 14
-- proto: AU14AmbassadorConsoleUA
-  entities:
-  - uid: 16
-    components:
-    - type: Transform
-      pos: -11.5,46.5
-      parent: 1
-- proto: AU14AmbassadorConsoleUPP
+- proto: AU14CivilianPrisonJumpsuit
   entities:
   - uid: 17
     components:
     - type: Transform
-      pos: -16.5,46.5
-      parent: 1
-- proto: AU14CivilianPrisonJumpsuit
-  entities:
+      parent: 16
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 18
+    components:
+    - type: Transform
+      parent: 16
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
   - uid: 19
     components:
     - type: Transform
-      parent: 18
+      parent: 16
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 20
     components:
     - type: Transform
-      parent: 18
+      parent: 16
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 21
+  - uid: 26
     components:
     - type: Transform
-      parent: 18
+      parent: 25
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 22
+  - uid: 27
     components:
     - type: Transform
-      parent: 18
+      parent: 25
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 28
     components:
     - type: Transform
-      parent: 27
+      parent: 25
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 29
     components:
     - type: Transform
-      parent: 27
+      parent: 25
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 30
+  - uid: 35
     components:
     - type: Transform
-      parent: 27
+      parent: 34
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 31
+  - uid: 36
     components:
     - type: Transform
-      parent: 27
+      parent: 34
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 37
     components:
     - type: Transform
-      parent: 36
+      parent: 34
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 38
     components:
     - type: Transform
-      parent: 36
+      parent: 34
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 39
+  - uid: 44
     components:
     - type: Transform
-      parent: 36
+      parent: 43
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 40
+  - uid: 45
     components:
     - type: Transform
-      parent: 36
+      parent: 43
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 46
     components:
     - type: Transform
-      parent: 45
+      parent: 43
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 47
     components:
     - type: Transform
-      parent: 45
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 48
-    components:
-    - type: Transform
-      parent: 45
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 49
-    components:
-    - type: Transform
-      parent: 45
+      parent: 43
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: AU14CMDefibrillator
   entities:
-  - uid: 55
+  - uid: 53
     components:
     - type: Transform
-      parent: 54
+      parent: 52
     - type: Physics
       canCollide: False
 - proto: AU14ContainerTartarusLeftKellandAlt
   entities:
-  - uid: 56
+  - uid: 54
     components:
     - type: Transform
       pos: -3.5,36.5
       parent: 1
 - proto: AU14ContainerTartarusLeftMedicalEmpty
   entities:
-  - uid: 57
+  - uid: 55
     components:
     - type: Transform
       pos: 25.5,24.5
       parent: 1
 - proto: AU14ContainerTartarusLeftTanWYWings
   entities:
-  - uid: 58
+  - uid: 56
     components:
     - type: Transform
       pos: 24.5,25.5
       parent: 1
 - proto: AU14ContainerTartarusRightKelland
   entities:
-  - uid: 59
+  - uid: 57
     components:
     - type: Transform
       pos: -2.5,36.5
       parent: 1
 - proto: AU14ContainerTartarusRightMedicalEmptyAlt
   entities:
-  - uid: 60
+  - uid: 58
     components:
     - type: Transform
       pos: 26.5,24.5
       parent: 1
 - proto: AU14ContainerTartarusRightTanWYWings
   entities:
-  - uid: 61
+  - uid: 59
     components:
     - type: Transform
       pos: 25.5,25.5
       parent: 1
 - proto: AU14CrateMedicalBloodVendor
   entities:
-  - uid: 62
+  - uid: 60
     components:
     - type: Transform
       pos: 13.5,37.5
       parent: 1
 - proto: AU14CrateMedicalVendor
   entities:
-  - uid: 63
+  - uid: 61
     components:
     - type: Transform
-      pos: 24.5,24.5
+      pos: -6.5,39.5
       parent: 1
 - proto: AU14DefibrillatorCabinet
   entities:
-  - uid: 54
+  - uid: 52
     components:
     - type: Transform
       pos: -27.5,19.5
@@ -7401,108 +7370,87 @@ entities:
         ItemCabinet: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 55
+          ent: 53
 - proto: AU14GeneralMedicalVendor
   entities:
-  - uid: 64
+  - uid: 62
     components:
     - type: Transform
       pos: -25.5,17.5
       parent: 1
 - proto: AU14GogglesM1A1OrangeBallistic
   entities:
-  - uid: 65
+  - uid: 63
     components:
     - type: Transform
       pos: 1.4628435,-26.41722
       parent: 1
 - proto: AU14GogglesM1A1PolarizedBallistic
   entities:
-  - uid: 66
+  - uid: 64
     components:
     - type: Transform
       pos: 1.4628435,-26.681107
       parent: 1
-- proto: AU14HeadsetMob
-  entities:
-  - uid: 67
-    components:
-    - type: Transform
-      pos: 11.6938925,-50.47192
-      parent: 1
 - proto: AU14HemostaticGauze
   entities:
-  - uid: 68
+  - uid: 65
     components:
     - type: Transform
       pos: -26.708347,15.156866
       parent: 1
 - proto: AU14HemostaticGauzePacketTrash
   entities:
-  - uid: 69
+  - uid: 66
     components:
     - type: Transform
       pos: -26.257448,17.45147
       parent: 1
 - proto: AU14JOGenericVendor
   entities:
-  - uid: 71
+  - uid: 67
     components:
     - type: Transform
       pos: -0.5,43.5
       parent: 1
-- proto: AU14PropVTOL1
-  entities:
-  - uid: 74
-    components:
-    - type: Transform
-      pos: 5.5,40.5
-      parent: 1
-- proto: AU14TeleBaton
-  entities:
-  - uid: 75
-    components:
-    - type: Transform
-      pos: 11.868814,-31.992285
-      parent: 1
 - proto: AU14Tourniquet
   entities:
-  - uid: 76
+  - uid: 68
     components:
     - type: Transform
       pos: -26.70696,14.33289
       parent: 1
 - proto: AU14UADeskFlag
   entities:
-  - uid: 77
+  - uid: 69
     components:
     - type: Transform
       pos: -12.671261,46.71221
       parent: 1
 - proto: AU14VendorBlood
   entities:
-  - uid: 78
+  - uid: 70
     components:
     - type: Transform
       pos: -27.5,17.5
       parent: 1
 - proto: AU14VendorKoorCigs
   entities:
-  - uid: 79
+  - uid: 71
     components:
     - type: Transform
       pos: -11.5,-11.5
       parent: 1
 - proto: AU14WallFlagUA
   entities:
-  - uid: 80
+  - uid: 72
     components:
     - type: Transform
       pos: -9.5,49.5
       parent: 1
 - proto: AU14WallFlagUPP
   entities:
-  - uid: 81
+  - uid: 73
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7510,69 +7458,69 @@ entities:
       parent: 1
 - proto: AU14WeymartRacks1
   entities:
-  - uid: 82
+  - uid: 74
     components:
     - type: Transform
       pos: -1.5,-24.5
       parent: 1
 - proto: AU14WeymartRacks2
   entities:
-  - uid: 83
+  - uid: 75
     components:
     - type: Transform
       pos: 1.5,-21.5
       parent: 1
 - proto: AU14WeymartRacks3
   entities:
-  - uid: 84
+  - uid: 76
     components:
     - type: Transform
       pos: 2.5,-21.5
       parent: 1
-  - uid: 85
+  - uid: 77
     components:
     - type: Transform
       pos: 2.5,-24.5
       parent: 1
 - proto: AU14WeymartRacks4
   entities:
-  - uid: 86
+  - uid: 78
     components:
     - type: Transform
       pos: 0.5,-21.5
       parent: 1
-  - uid: 87
+  - uid: 79
     components:
     - type: Transform
       pos: -0.5,-24.5
       parent: 1
 - proto: AU14WeymartRacks5
   entities:
-  - uid: 88
+  - uid: 80
     components:
     - type: Transform
       pos: -0.5,-21.5
       parent: 1
-  - uid: 89
+  - uid: 81
     components:
     - type: Transform
       pos: 0.5,-24.5
       parent: 1
 - proto: AU14WeymartRacks6
   entities:
-  - uid: 90
+  - uid: 82
     components:
     - type: Transform
       pos: -1.5,-21.5
       parent: 1
-  - uid: 91
+  - uid: 83
     components:
     - type: Transform
       pos: 1.5,-24.5
       parent: 1
 - proto: CMAirlock
   entities:
-  - uid: 92
+  - uid: 84
     components:
     - type: Transform
       pos: -4.5,-25.5
@@ -7581,15 +7529,15 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -76864.18
+      secondsUntilStateChange: -77487.74
       state: Opening
-  - uid: 93
+  - uid: 85
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,42.5
       parent: 1
-  - uid: 94
+  - uid: 86
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7597,13 +7545,13 @@ entities:
       parent: 1
 - proto: CMApcAlmayer
   entities:
-  - uid: 95
+  - uid: 87
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,-13.5
       parent: 1
-  - uid: 96
+  - uid: 88
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7611,42 +7559,42 @@ entities:
       parent: 1
 - proto: CMApcConstructed
   entities:
-  - uid: 97
+  - uid: 89
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-22.5
       parent: 1
     - type: SpriteSetRenderOrder
-  - uid: 98
+  - uid: 90
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-25.5
       parent: 1
     - type: SpriteSetRenderOrder
-  - uid: 99
+  - uid: 91
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,-25.5
       parent: 1
     - type: SpriteSetRenderOrder
-  - uid: 100
+  - uid: 92
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-25.5
       parent: 1
     - type: SpriteSetRenderOrder
-  - uid: 101
+  - uid: 93
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-29.5
       parent: 1
     - type: SpriteSetRenderOrder
-  - uid: 102
+  - uid: 94
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7655,43 +7603,29 @@ entities:
     - type: SpriteSetRenderOrder
 - proto: CMApcHighCapacity
   entities:
-  - uid: 103
+  - uid: 95
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-13.5
       parent: 1
     - type: SpriteSetRenderOrder
-  - uid: 104
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-38.5
-      parent: 1
-    - type: SpriteSetRenderOrder
-  - uid: 105
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,-61.5
-      parent: 1
-    - type: SpriteSetRenderOrder
 - proto: CMAutolathe
   entities:
-  - uid: 106
+  - uid: 96
     components:
     - type: Transform
       pos: 23.5,14.5
       parent: 1
 - proto: CMBarricadeTurnstile
   entities:
-  - uid: 107
+  - uid: 97
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-22.5
       parent: 1
-  - uid: 108
+  - uid: 98
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7699,2347 +7633,2358 @@ entities:
       parent: 1
 - proto: CMBed
   entities:
-  - uid: 109
+  - uid: 99
     components:
     - type: Transform
       pos: -4.5,46.5
       parent: 1
-  - uid: 110
+  - uid: 100
     components:
     - type: Transform
       pos: 9.5,45.5
       parent: 1
 - proto: CMBedsheetPurple
   entities:
-  - uid: 111
+  - uid: 101
     components:
     - type: Transform
       pos: 9.5,45.5
       parent: 1
 - proto: CMBucketMop
   entities:
-  - uid: 112
+  - uid: 102
     components:
     - type: Transform
       pos: -5.5383024,-14.637215
       parent: 1
-  - uid: 113
+  - uid: 103
     components:
     - type: Transform
       pos: -5.5278854,-14.355965
       parent: 1
-  - uid: 114
+  - uid: 104
     components:
     - type: Transform
       pos: 2.4028835,-21.903234
       parent: 1
 - proto: CMCarpetPrison
   entities:
-  - uid: 115
+  - uid: 105
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-5.5
       parent: 1
-  - uid: 116
+  - uid: 106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,45.5
       parent: 1
-  - uid: 117
+  - uid: 107
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,46.5
       parent: 1
-  - uid: 118
+  - uid: 108
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,45.5
       parent: 1
-  - uid: 119
+  - uid: 109
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,46.5
       parent: 1
-  - uid: 120
+  - uid: 110
     components:
     - type: Transform
       pos: 1.5,-31.5
       parent: 1
-  - uid: 121
+  - uid: 111
     components:
     - type: Transform
       pos: 1.5,-30.5
       parent: 1
-  - uid: 122
+  - uid: 112
     components:
     - type: Transform
       pos: 1.5,-29.5
       parent: 1
-  - uid: 123
+  - uid: 113
     components:
     - type: Transform
       pos: 2.5,-30.5
       parent: 1
-  - uid: 124
+  - uid: 114
     components:
     - type: Transform
       pos: 2.5,-29.5
       parent: 1
-  - uid: 125
+  - uid: 115
     components:
     - type: Transform
       pos: 3.5,-31.5
       parent: 1
-  - uid: 126
+  - uid: 116
     components:
     - type: Transform
       pos: 3.5,-30.5
       parent: 1
-  - uid: 127
+  - uid: 117
     components:
     - type: Transform
       pos: 3.5,-29.5
       parent: 1
-  - uid: 128
+  - uid: 118
     components:
     - type: Transform
       pos: 2.5,-31.5
       parent: 1
 - proto: CMCatwalk
   entities:
-  - uid: 129
+  - uid: 119
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
-  - uid: 130
+  - uid: 120
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 1
-  - uid: 131
+  - uid: 121
     components:
     - type: Transform
       pos: -5.5,-11.5
       parent: 1
-  - uid: 132
+  - uid: 122
     components:
     - type: Transform
       pos: -11.5,-14.5
       parent: 1
-  - uid: 133
+  - uid: 123
     components:
     - type: Transform
       pos: -12.5,-14.5
       parent: 1
-  - uid: 134
+  - uid: 124
     components:
     - type: Transform
       pos: -13.5,-14.5
       parent: 1
-  - uid: 135
+  - uid: 125
     components:
     - type: Transform
       pos: -14.5,-14.5
       parent: 1
-  - uid: 136
+  - uid: 126
     components:
     - type: Transform
       pos: -16.5,-14.5
       parent: 1
-  - uid: 137
+  - uid: 127
     components:
     - type: Transform
       pos: -17.5,-14.5
       parent: 1
-  - uid: 138
+  - uid: 128
     components:
     - type: Transform
       pos: -15.5,-14.5
       parent: 1
-  - uid: 139
+  - uid: 129
     components:
     - type: Transform
       pos: -16.5,-8.5
       parent: 1
-  - uid: 140
+  - uid: 130
     components:
     - type: Transform
       pos: -16.5,-7.5
       parent: 1
-  - uid: 141
+  - uid: 131
     components:
     - type: Transform
       pos: -16.5,-5.5
       parent: 1
-  - uid: 142
+  - uid: 132
     components:
     - type: Transform
       pos: -16.5,-4.5
       parent: 1
-  - uid: 143
+  - uid: 133
     components:
     - type: Transform
       pos: -16.5,-3.5
       parent: 1
-  - uid: 144
+  - uid: 134
     components:
     - type: Transform
       pos: -16.5,-5.5
       parent: 1
-  - uid: 145
+  - uid: 135
     components:
     - type: Transform
       pos: -16.5,-6.5
       parent: 1
-  - uid: 146
+  - uid: 136
     components:
     - type: Transform
       pos: -16.5,-2.5
       parent: 1
-  - uid: 147
+  - uid: 137
     components:
     - type: Transform
       pos: -12.5,-2.5
       parent: 1
-  - uid: 148
+  - uid: 138
     components:
     - type: Transform
       pos: -12.5,-3.5
       parent: 1
-  - uid: 149
+  - uid: 139
     components:
     - type: Transform
       pos: -12.5,-4.5
       parent: 1
-  - uid: 150
+  - uid: 140
     components:
     - type: Transform
       pos: -12.5,-6.5
       parent: 1
-  - uid: 151
+  - uid: 141
     components:
     - type: Transform
       pos: -12.5,-6.5
       parent: 1
-  - uid: 152
+  - uid: 142
     components:
     - type: Transform
       pos: -12.5,-7.5
       parent: 1
-  - uid: 153
+  - uid: 143
     components:
     - type: Transform
       pos: -12.5,-5.5
       parent: 1
-  - uid: 154
+  - uid: 144
     components:
     - type: Transform
       pos: -12.5,-8.5
       parent: 1
-  - uid: 155
+  - uid: 145
     components:
     - type: Transform
       pos: -8.5,-8.5
       parent: 1
-  - uid: 156
+  - uid: 146
     components:
     - type: Transform
       pos: -8.5,-9.5
       parent: 1
-  - uid: 157
+  - uid: 147
     components:
     - type: Transform
       pos: -8.5,-5.5
       parent: 1
-  - uid: 158
+  - uid: 148
     components:
     - type: Transform
       pos: -8.5,-13.5
       parent: 1
-  - uid: 159
+  - uid: 149
     components:
     - type: Transform
       pos: -5.5,-14.5
       parent: 1
-  - uid: 160
+  - uid: 150
     components:
     - type: Transform
       pos: -4.5,-14.5
       parent: 1
-  - uid: 161
+  - uid: 151
     components:
     - type: Transform
       pos: -3.5,-14.5
       parent: 1
-  - uid: 162
+  - uid: 152
     components:
     - type: Transform
       pos: -16.5,21.5
       parent: 1
-  - uid: 163
+  - uid: 153
     components:
     - type: Transform
       pos: -16.5,17.5
       parent: 1
-  - uid: 164
+  - uid: 154
     components:
     - type: Transform
       pos: -16.5,16.5
       parent: 1
-  - uid: 165
+  - uid: 155
     components:
     - type: Transform
       pos: -12.5,-32.5
       parent: 1
-  - uid: 166
+  - uid: 156
     components:
     - type: Transform
       pos: -12.5,-31.5
       parent: 1
-  - uid: 167
+  - uid: 157
     components:
     - type: Transform
       pos: -12.5,-30.5
       parent: 1
-  - uid: 168
+  - uid: 158
     components:
     - type: Transform
       pos: -8.5,-30.5
       parent: 1
-  - uid: 169
+  - uid: 159
     components:
     - type: Transform
       pos: -8.5,-31.5
       parent: 1
-  - uid: 170
+  - uid: 160
     components:
     - type: Transform
       pos: -4.5,-31.5
       parent: 1
-  - uid: 171
+  - uid: 161
     components:
     - type: Transform
       pos: -4.5,-30.5
       parent: 1
-  - uid: 172
+  - uid: 162
     components:
     - type: Transform
       pos: -12.5,-27.5
       parent: 1
-  - uid: 173
+  - uid: 163
     components:
     - type: Transform
       pos: -11.5,-27.5
       parent: 1
-  - uid: 174
+  - uid: 164
     components:
     - type: Transform
       pos: -9.5,-27.5
       parent: 1
-  - uid: 175
+  - uid: 165
     components:
     - type: Transform
       pos: -8.5,-27.5
       parent: 1
-  - uid: 176
+  - uid: 166
     components:
     - type: Transform
       pos: -7.5,-27.5
       parent: 1
-  - uid: 177
+  - uid: 167
     components:
     - type: Transform
       pos: -5.5,-27.5
       parent: 1
-  - uid: 178
+  - uid: 168
     components:
     - type: Transform
       pos: -4.5,-27.5
       parent: 1
-  - uid: 179
+  - uid: 169
     components:
     - type: Transform
       pos: -3.5,-27.5
       parent: 1
-  - uid: 180
+  - uid: 170
     components:
     - type: Transform
       pos: 13.5,-13.5
       parent: 1
-  - uid: 181
+  - uid: 171
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-13.5
       parent: 1
-  - uid: 182
+  - uid: 172
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-13.5
       parent: 1
-  - uid: 183
+  - uid: 173
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-8.5
       parent: 1
-  - uid: 184
+  - uid: 174
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-6.5
       parent: 1
-  - uid: 185
+  - uid: 175
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,1.5
       parent: 1
-  - uid: 186
+  - uid: 176
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,6.5
       parent: 1
-  - uid: 187
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,1.5
-      parent: 1
-  - uid: 188
+  - uid: 177
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 189
+  - uid: 178
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 190
+  - uid: 179
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 191
+  - uid: 180
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 192
+  - uid: 181
     components:
     - type: Transform
       pos: -2.5,52.5
       parent: 1
-  - uid: 193
+  - uid: 182
     components:
     - type: Transform
       pos: -2.5,51.5
       parent: 1
-  - uid: 194
+  - uid: 183
     components:
     - type: Transform
       pos: -2.5,50.5
       parent: 1
-  - uid: 195
+  - uid: 184
     components:
     - type: Transform
       pos: -1.5,50.5
       parent: 1
-  - uid: 196
+  - uid: 185
     components:
     - type: Transform
       pos: -0.5,50.5
       parent: 1
-  - uid: 197
+  - uid: 186
     components:
     - type: Transform
       pos: -0.5,51.5
       parent: 1
-  - uid: 198
+  - uid: 187
     components:
     - type: Transform
       pos: -0.5,52.5
       parent: 1
-  - uid: 199
+  - uid: 188
     components:
     - type: Transform
       pos: -1.5,52.5
       parent: 1
-  - uid: 200
+  - uid: 189
     components:
     - type: Transform
       pos: -3.5,56.5
       parent: 1
-  - uid: 201
+  - uid: 190
     components:
     - type: Transform
       pos: -3.5,56.5
       parent: 1
-  - uid: 202
+  - uid: 191
     components:
     - type: Transform
       pos: -3.5,57.5
       parent: 1
-  - uid: 203
+  - uid: 192
     components:
     - type: Transform
       pos: -3.5,58.5
       parent: 1
-  - uid: 204
+  - uid: 193
     components:
     - type: Transform
       pos: -3.5,59.5
       parent: 1
-  - uid: 205
+  - uid: 194
     components:
     - type: Transform
       pos: -3.5,60.5
       parent: 1
-  - uid: 206
+  - uid: 195
     components:
     - type: Transform
       pos: -3.5,61.5
       parent: 1
-  - uid: 207
+  - uid: 196
     components:
     - type: Transform
       pos: -3.5,62.5
       parent: 1
-  - uid: 208
+  - uid: 197
     components:
     - type: Transform
       pos: -3.5,62.5
       parent: 1
-  - uid: 209
+  - uid: 198
     components:
     - type: Transform
       pos: -2.5,62.5
       parent: 1
-  - uid: 210
+  - uid: 199
     components:
     - type: Transform
       pos: -1.5,62.5
       parent: 1
-  - uid: 211
+  - uid: 200
     components:
     - type: Transform
       pos: -0.5,62.5
       parent: 1
-  - uid: 212
+  - uid: 201
     components:
     - type: Transform
       pos: 0.5,62.5
       parent: 1
-  - uid: 213
+  - uid: 202
     components:
     - type: Transform
       pos: 0.5,62.5
       parent: 1
-  - uid: 214
+  - uid: 203
     components:
     - type: Transform
       pos: 0.5,61.5
       parent: 1
-  - uid: 215
+  - uid: 204
     components:
     - type: Transform
       pos: 0.5,60.5
       parent: 1
-  - uid: 216
+  - uid: 205
     components:
     - type: Transform
       pos: 0.5,59.5
       parent: 1
-  - uid: 217
+  - uid: 206
     components:
     - type: Transform
       pos: 0.5,58.5
       parent: 1
-  - uid: 218
+  - uid: 207
     components:
     - type: Transform
       pos: 0.5,57.5
       parent: 1
-  - uid: 219
+  - uid: 208
     components:
     - type: Transform
       pos: 0.5,56.5
       parent: 1
-  - uid: 220
+  - uid: 209
     components:
     - type: Transform
       pos: 0.5,56.5
       parent: 1
-  - uid: 221
+  - uid: 210
     components:
     - type: Transform
       pos: -0.5,56.5
       parent: 1
-  - uid: 222
+  - uid: 211
     components:
     - type: Transform
       pos: -1.5,56.5
       parent: 1
-  - uid: 223
+  - uid: 212
     components:
     - type: Transform
       pos: -2.5,56.5
       parent: 1
-  - uid: 224
+  - uid: 213
     components:
     - type: Transform
       pos: -1.5,68.5
       parent: 1
-  - uid: 225
+  - uid: 214
     components:
     - type: Transform
       pos: 0.5,64.5
       parent: 1
-  - uid: 226
+  - uid: 215
     components:
     - type: Transform
       pos: 0.5,65.5
       parent: 1
-  - uid: 227
+  - uid: 216
     components:
     - type: Transform
       pos: 0.5,66.5
       parent: 1
-  - uid: 228
+  - uid: 217
     components:
     - type: Transform
       pos: 0.5,67.5
       parent: 1
-  - uid: 229
+  - uid: 218
     components:
     - type: Transform
       pos: -3.5,67.5
       parent: 1
-  - uid: 230
+  - uid: 219
     components:
     - type: Transform
       pos: -3.5,66.5
       parent: 1
-  - uid: 231
+  - uid: 220
     components:
     - type: Transform
       pos: -3.5,65.5
       parent: 1
-  - uid: 232
+  - uid: 221
     components:
     - type: Transform
       pos: -3.5,64.5
       parent: 1
-  - uid: 233
+  - uid: 222
     components:
     - type: Transform
       pos: -2.5,68.5
       parent: 1
-  - uid: 234
+  - uid: 223
     components:
     - type: Transform
       pos: -0.5,68.5
       parent: 1
-  - uid: 235
+  - uid: 224
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,40.5
       parent: 1
-  - uid: 236
+  - uid: 225
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,38.5
       parent: 1
-  - uid: 237
+  - uid: 226
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,39.5
       parent: 1
-  - uid: 238
+  - uid: 227
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,43.5
       parent: 1
-  - uid: 239
+  - uid: 228
     components:
     - type: Transform
       pos: 15.5,34.5
       parent: 1
-  - uid: 240
+  - uid: 229
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,38.5
       parent: 1
-  - uid: 241
+  - uid: 230
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,43.5
       parent: 1
-  - uid: 242
+  - uid: 231
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,43.5
       parent: 1
-  - uid: 243
+  - uid: 232
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,38.5
       parent: 1
-  - uid: 244
+  - uid: 233
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,41.5
       parent: 1
-  - uid: 245
+  - uid: 234
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,40.5
       parent: 1
-  - uid: 246
+  - uid: 235
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,43.5
       parent: 1
-  - uid: 247
+  - uid: 236
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,43.5
       parent: 1
-  - uid: 248
+  - uid: 237
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,43.5
       parent: 1
-  - uid: 249
+  - uid: 238
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,42.5
       parent: 1
-  - uid: 250
+  - uid: 239
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,41.5
       parent: 1
-  - uid: 251
+  - uid: 240
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,39.5
       parent: 1
-  - uid: 252
+  - uid: 241
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,42.5
       parent: 1
-  - uid: 253
+  - uid: 242
     components:
     - type: Transform
       pos: -16.5,24.5
       parent: 1
-  - uid: 254
+  - uid: 243
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-32.5
       parent: 1
-  - uid: 255
+  - uid: 244
     components:
     - type: Transform
       pos: 8.5,-42.5
       parent: 1
-  - uid: 256
+  - uid: 245
     components:
     - type: Transform
       pos: 3.5,-51.5
       parent: 1
-  - uid: 257
+  - uid: 246
     components:
     - type: Transform
       pos: 1.5,-51.5
       parent: 1
-  - uid: 258
+  - uid: 247
     components:
     - type: Transform
       pos: 2.5,-51.5
       parent: 1
-  - uid: 259
+  - uid: 248
     components:
     - type: Transform
       pos: 4.5,-51.5
       parent: 1
-  - uid: 260
+  - uid: 249
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,38.5
       parent: 1
-  - uid: 261
+  - uid: 250
     components:
     - type: Transform
       pos: 1.5,-49.5
       parent: 1
-  - uid: 262
+  - uid: 251
     components:
     - type: Transform
       pos: 2.5,-49.5
       parent: 1
-  - uid: 263
+  - uid: 252
     components:
     - type: Transform
       pos: -16.5,14.5
       parent: 1
-  - uid: 264
+  - uid: 253
     components:
     - type: Transform
       pos: -16.5,13.5
       parent: 1
-  - uid: 265
+  - uid: 254
     components:
     - type: Transform
       pos: -16.5,7.5
       parent: 1
-  - uid: 266
+  - uid: 255
     components:
     - type: Transform
       pos: -16.5,8.5
       parent: 1
-  - uid: 267
+  - uid: 256
     components:
     - type: Transform
       pos: -16.5,15.5
       parent: 1
-  - uid: 268
+  - uid: 257
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-41.5
       parent: 1
-  - uid: 269
+  - uid: 258
     components:
     - type: Transform
       pos: 5.5,-41.5
       parent: 1
-  - uid: 270
+  - uid: 259
     components:
     - type: Transform
       pos: 5.5,-51.5
       parent: 1
-  - uid: 271
+  - uid: 260
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,38.5
       parent: 1
-  - uid: 272
+  - uid: 261
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,38.5
       parent: 1
-  - uid: 273
+  - uid: 262
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,40.5
       parent: 1
-  - uid: 274
+  - uid: 263
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,41.5
       parent: 1
-  - uid: 275
+  - uid: 264
     components:
     - type: Transform
       pos: 15.5,8.5
       parent: 1
-  - uid: 276
+  - uid: 265
     components:
     - type: Transform
       pos: 15.5,13.5
       parent: 1
-  - uid: 277
+  - uid: 266
     components:
     - type: Transform
       pos: 15.5,9.5
       parent: 1
-  - uid: 278
+  - uid: 267
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 1
-  - uid: 279
+  - uid: 268
     components:
     - type: Transform
       pos: -0.5,22.5
       parent: 1
-  - uid: 280
+  - uid: 269
     components:
     - type: Transform
       pos: -0.5,21.5
       parent: 1
-  - uid: 281
+  - uid: 270
     components:
     - type: Transform
       pos: -0.5,23.5
       parent: 1
-  - uid: 282
+  - uid: 271
     components:
     - type: Transform
       pos: 0.5,28.5
       parent: 1
-  - uid: 283
+  - uid: 272
     components:
     - type: Transform
       pos: -0.5,24.5
       parent: 1
-  - uid: 284
+  - uid: 273
     components:
     - type: Transform
       pos: 4.5,28.5
       parent: 1
-  - uid: 285
+  - uid: 274
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
-  - uid: 286
+  - uid: 275
     components:
     - type: Transform
       pos: 3.5,28.5
       parent: 1
-  - uid: 287
+  - uid: 276
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 1
-  - uid: 288
+  - uid: 277
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 1
-  - uid: 289
+  - uid: 278
     components:
     - type: Transform
       pos: -0.5,15.5
       parent: 1
-  - uid: 290
+  - uid: 279
     components:
     - type: Transform
       pos: 9.5,28.5
       parent: 1
-  - uid: 291
+  - uid: 280
     components:
     - type: Transform
       pos: 5.5,28.5
       parent: 1
-  - uid: 292
+  - uid: 281
     components:
     - type: Transform
       pos: 6.5,28.5
       parent: 1
-  - uid: 293
+  - uid: 282
     components:
     - type: Transform
       pos: 15.5,23.5
       parent: 1
-  - uid: 294
+  - uid: 283
     components:
     - type: Transform
       pos: 10.5,28.5
       parent: 1
-  - uid: 295
+  - uid: 284
     components:
     - type: Transform
       pos: 11.5,28.5
       parent: 1
-  - uid: 296
+  - uid: 285
     components:
     - type: Transform
       pos: -16.5,22.5
       parent: 1
-  - uid: 297
+  - uid: 286
     components:
     - type: Transform
       pos: -4.5,28.5
       parent: 1
-  - uid: 298
+  - uid: 287
     components:
     - type: Transform
       pos: -6.5,28.5
       parent: 1
-  - uid: 299
+  - uid: 288
     components:
     - type: Transform
       pos: -5.5,28.5
       parent: 1
-  - uid: 300
+  - uid: 289
     components:
     - type: Transform
       pos: -1.5,28.5
       parent: 1
-  - uid: 301
+  - uid: 290
     components:
     - type: Transform
       pos: -0.5,28.5
       parent: 1
-  - uid: 302
+  - uid: 291
     components:
     - type: Transform
       pos: 15.5,17.5
       parent: 1
-  - uid: 303
+  - uid: 292
     components:
     - type: Transform
       pos: 15.5,22.5
       parent: 1
-  - uid: 304
+  - uid: 293
     components:
     - type: Transform
       pos: 15.5,21.5
       parent: 1
-  - uid: 305
+  - uid: 294
     components:
     - type: Transform
       pos: 15.5,16.5
       parent: 1
-  - uid: 306
+  - uid: 295
     components:
     - type: Transform
       pos: 15.5,15.5
       parent: 1
-  - uid: 307
+  - uid: 296
     components:
     - type: Transform
       pos: 8.5,-41.5
       parent: 1
-  - uid: 308
+  - uid: 297
     components:
     - type: Transform
       pos: 11.5,-41.5
       parent: 1
-  - uid: 309
+  - uid: 298
     components:
     - type: Transform
       pos: -10.5,2.5
       parent: 1
-  - uid: 310
+  - uid: 299
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,28.5
       parent: 1
-  - uid: 311
+  - uid: 300
     components:
     - type: Transform
       pos: -11.5,38.5
       parent: 1
-  - uid: 312
+  - uid: 301
     components:
     - type: Transform
       pos: -12.5,28.5
       parent: 1
-  - uid: 313
+  - uid: 302
     components:
     - type: Transform
       pos: -16.5,23.5
       parent: 1
-  - uid: 314
+  - uid: 303
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 1
-  - uid: 315
+  - uid: 304
     components:
     - type: Transform
       pos: 15.5,7.5
       parent: 1
-  - uid: 316
+  - uid: 305
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,40.5
       parent: 1
-  - uid: 317
+  - uid: 306
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,39.5
       parent: 1
-  - uid: 318
+  - uid: 307
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,38.5
       parent: 1
-  - uid: 319
+  - uid: 308
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,43.5
       parent: 1
-  - uid: 320
+  - uid: 309
     components:
     - type: Transform
       pos: 11.5,-42.5
       parent: 1
-  - uid: 321
+  - uid: 310
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,42.5
       parent: 1
-  - uid: 322
+  - uid: 311
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,40.5
       parent: 1
-  - uid: 323
+  - uid: 312
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,41.5
       parent: 1
-  - uid: 324
+  - uid: 313
     components:
     - type: Transform
       pos: 0.5,33.5
       parent: 1
-  - uid: 325
+  - uid: 314
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,41.5
       parent: 1
-  - uid: 326
+  - uid: 315
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,43.5
       parent: 1
-  - uid: 327
+  - uid: 316
     components:
     - type: Transform
       pos: 10.5,2.5
       parent: 1
-  - uid: 328
+  - uid: 317
     components:
     - type: Transform
       pos: 15.5,6.5
       parent: 1
-  - uid: 329
+  - uid: 318
     components:
     - type: Transform
       pos: 1.5,33.5
       parent: 1
-  - uid: 330
+  - uid: 319
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 331
+  - uid: 320
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-13.5
       parent: 1
-  - uid: 332
+  - uid: 321
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-13.5
       parent: 1
-  - uid: 333
+  - uid: 322
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,43.5
       parent: 1
-  - uid: 334
+  - uid: 323
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,42.5
       parent: 1
-  - uid: 335
+  - uid: 324
     components:
     - type: Transform
       pos: 15.5,14.5
       parent: 1
-  - uid: 336
+  - uid: 325
     components:
     - type: Transform
       pos: -16.5,9.5
       parent: 1
-  - uid: 337
+  - uid: 326
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,39.5
       parent: 1
-  - uid: 338
+  - uid: 327
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,37.5
       parent: 1
-  - uid: 339
+  - uid: 328
     components:
     - type: Transform
       pos: 15.5,33.5
       parent: 1
-  - uid: 340
+  - uid: 329
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,38.5
       parent: 1
-  - uid: 341
+  - uid: 330
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,38.5
       parent: 1
-  - uid: 342
+  - uid: 331
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,38.5
       parent: 1
-  - uid: 343
+  - uid: 332
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,39.5
       parent: 1
-  - uid: 344
+  - uid: 333
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-6.5
       parent: 1
-  - uid: 345
+  - uid: 334
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-6.5
       parent: 1
-  - uid: 346
+  - uid: 335
     components:
     - type: Transform
       pos: 3.5,-49.5
       parent: 1
-  - uid: 347
+  - uid: 336
     components:
     - type: Transform
       pos: 4.5,-49.5
       parent: 1
-  - uid: 348
+  - uid: 337
     components:
     - type: Transform
       pos: 5.5,-49.5
       parent: 1
-  - uid: 349
+  - uid: 338
     components:
     - type: Transform
       pos: -16.5,6.5
       parent: 1
-  - uid: 350
+  - uid: 339
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,38.5
       parent: 1
-  - uid: 351
+  - uid: 340
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,43.5
       parent: 1
-  - uid: 352
+  - uid: 341
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 1
-  - uid: 353
+  - uid: 342
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-6.5
       parent: 1
-  - uid: 354
+  - uid: 343
     components:
     - type: Transform
       pos: -11.5,2.5
       parent: 1
-  - uid: 355
+  - uid: 344
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 356
+  - uid: 345
     components:
     - type: Transform
       pos: -6.5,1.5
       parent: 1
-  - uid: 357
+  - uid: 346
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 358
+  - uid: 347
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 359
+  - uid: 348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-6.5
       parent: 1
-  - uid: 360
+  - uid: 349
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-6.5
       parent: 1
-  - uid: 361
+  - uid: 350
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-6.5
       parent: 1
-  - uid: 362
+  - uid: 351
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-6.5
       parent: 1
-  - uid: 363
+  - uid: 352
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-6.5
       parent: 1
-  - uid: 364
+  - uid: 353
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-6.5
       parent: 1
-  - uid: 365
+  - uid: 354
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-10.5
       parent: 1
-  - uid: 366
+  - uid: 355
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-13.5
       parent: 1
-  - uid: 367
+  - uid: 356
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-13.5
       parent: 1
-  - uid: 368
+  - uid: 357
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-13.5
       parent: 1
-  - uid: 369
+  - uid: 358
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-11.5
       parent: 1
-  - uid: 370
+  - uid: 359
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-13.5
       parent: 1
-  - uid: 371
+  - uid: 360
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-13.5
       parent: 1
-  - uid: 372
+  - uid: 361
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-13.5
       parent: 1
-  - uid: 373
+  - uid: 362
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-13.5
       parent: 1
-  - uid: 374
+  - uid: 363
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-9.5
       parent: 1
-  - uid: 375
+  - uid: 364
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-6.5
       parent: 1
-  - uid: 376
+  - uid: 365
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-6.5
       parent: 1
-  - uid: 377
+  - uid: 366
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-13.5
       parent: 1
-  - uid: 378
+  - uid: 367
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,43.5
       parent: 1
-  - uid: 379
+  - uid: 368
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,43.5
       parent: 1
-  - uid: 380
+  - uid: 369
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,39.5
       parent: 1
-  - uid: 381
+  - uid: 370
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,43.5
       parent: 1
-  - uid: 382
+  - uid: 371
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,42.5
       parent: 1
-  - uid: 383
+  - uid: 372
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,41.5
       parent: 1
-  - uid: 384
+  - uid: 373
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,38.5
       parent: 1
-  - uid: 385
+  - uid: 374
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,40.5
       parent: 1
-  - uid: 386
+  - uid: 375
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,41.5
       parent: 1
-  - uid: 387
+  - uid: 376
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,38.5
       parent: 1
-  - uid: 388
+  - uid: 377
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,42.5
       parent: 1
-  - uid: 389
+  - uid: 378
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,41.5
       parent: 1
-  - uid: 390
+  - uid: 379
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,40.5
       parent: 1
-  - uid: 391
+  - uid: 380
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,40.5
       parent: 1
-  - uid: 392
+  - uid: 381
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 393
+  - uid: 382
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 394
+  - uid: 383
     components:
     - type: Transform
       pos: 11.5,2.5
       parent: 1
-  - uid: 395
+  - uid: 384
     components:
     - type: Transform
       pos: -11.5,28.5
       parent: 1
-  - uid: 396
+  - uid: 385
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-42.5
       parent: 1
-  - uid: 397
+  - uid: 386
     components:
     - type: Transform
       pos: 7.5,-37.5
       parent: 1
-  - uid: 398
+  - uid: 387
     components:
     - type: Transform
       pos: 3.5,-37.5
       parent: 1
-  - uid: 399
+  - uid: 388
     components:
     - type: Transform
       pos: 8.5,-37.5
       parent: 1
-  - uid: 400
+  - uid: 389
     components:
     - type: Transform
       pos: 5.5,-37.5
       parent: 1
-  - uid: 401
+  - uid: 390
     components:
     - type: Transform
       pos: 4.5,-37.5
       parent: 1
-  - uid: 402
+  - uid: 391
     components:
     - type: Transform
       pos: 15.5,-51.5
       parent: 1
-  - uid: 403
+  - uid: 392
     components:
     - type: Transform
       pos: 9.5,-37.5
       parent: 1
-  - uid: 404
+  - uid: 393
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-42.5
       parent: 1
-  - uid: 405
+  - uid: 394
     components:
     - type: Transform
       pos: -5.5,-60.5
       parent: 1
-  - uid: 406
+  - uid: 395
     components:
     - type: Transform
       pos: -15.5,-51.5
       parent: 1
-  - uid: 407
+  - uid: 396
     components:
     - type: Transform
       pos: -16.5,33.5
       parent: 1
-  - uid: 408
+  - uid: 397
     components:
     - type: Transform
       pos: -6.5,34.5
       parent: 1
-  - uid: 409
+  - uid: 398
     components:
     - type: Transform
       pos: -7.5,34.5
       parent: 1
-  - uid: 410
+  - uid: 399
     components:
     - type: Transform
       pos: -15.5,33.5
       parent: 1
-  - uid: 411
+  - uid: 400
     components:
     - type: Transform
       pos: -0.5,33.5
       parent: 1
-  - uid: 412
+  - uid: 401
     components:
     - type: Transform
       pos: 14.5,34.5
       parent: 1
-  - uid: 413
+  - uid: 402
     components:
     - type: Transform
       pos: -2.5,33.5
       parent: 1
-  - uid: 414
+  - uid: 403
     components:
     - type: Transform
       pos: -1.5,33.5
       parent: 1
-  - uid: 415
+  - uid: 404
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,7.5
       parent: 1
-  - uid: 416
+  - uid: 405
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,37.5
       parent: 1
-  - uid: 417
+  - uid: 406
     components:
     - type: Transform
       pos: 15.5,24.5
       parent: 1
-  - uid: 418
+  - uid: 407
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,7.5
       parent: 1
-  - uid: 419
+  - uid: 408
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,5.5
       parent: 1
-  - uid: 420
+  - uid: 409
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,5.5
       parent: 1
-  - uid: 421
+  - uid: 410
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,5.5
       parent: 1
-  - uid: 422
+  - uid: 411
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,5.5
       parent: 1
-  - uid: 423
+  - uid: 412
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,3.5
       parent: 1
-  - uid: 424
+  - uid: 413
     components:
     - type: Transform
       pos: -32.5,14.5
       parent: 1
-  - uid: 425
+  - uid: 414
     components:
     - type: Transform
       pos: -32.5,18.5
       parent: 1
-  - uid: 426
+  - uid: 415
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,7.5
       parent: 1
-  - uid: 427
+  - uid: 416
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,7.5
       parent: 1
-  - uid: 428
+  - uid: 417
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,7.5
       parent: 1
-  - uid: 429
+  - uid: 418
     components:
     - type: Transform
       pos: 5.5,-58.5
       parent: 1
-  - uid: 430
+  - uid: 419
     components:
     - type: Transform
       pos: -5.5,-62.5
       parent: 1
-  - uid: 431
+  - uid: 420
     components:
     - type: Transform
       pos: -5.5,-63.5
       parent: 1
-  - uid: 432
+  - uid: 421
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,2.5
       parent: 1
-  - uid: 433
+  - uid: 422
     components:
     - type: Transform
       pos: -5.5,-61.5
       parent: 1
-  - uid: 434
+  - uid: 423
     components:
     - type: Transform
       pos: -5.5,-64.5
       parent: 1
-  - uid: 435
+  - uid: 424
     components:
     - type: Transform
       pos: -7.5,-62.5
       parent: 1
-  - uid: 436
+  - uid: 425
     components:
     - type: Transform
       pos: -6.5,-62.5
       parent: 1
-  - uid: 437
+  - uid: 426
     components:
     - type: Transform
       pos: -5.5,-62.5
       parent: 1
-  - uid: 438
+  - uid: 427
     components:
     - type: Transform
       pos: -4.5,-62.5
       parent: 1
-  - uid: 439
+  - uid: 428
     components:
     - type: Transform
       pos: -3.5,-62.5
       parent: 1
-  - uid: 440
+  - uid: 429
     components:
     - type: Transform
       pos: 8.5,-62.5
       parent: 1
-  - uid: 441
+  - uid: 430
     components:
     - type: Transform
       pos: 9.5,-58.5
       parent: 1
-  - uid: 442
+  - uid: 431
     components:
     - type: Transform
       pos: 8.5,-58.5
       parent: 1
-  - uid: 443
+  - uid: 432
     components:
     - type: Transform
       pos: 8.5,-60.5
       parent: 1
-  - uid: 444
+  - uid: 433
     components:
     - type: Transform
       pos: 8.5,-61.5
       parent: 1
-  - uid: 445
+  - uid: 434
     components:
     - type: Transform
       pos: 9.5,-62.5
       parent: 1
-  - uid: 446
+  - uid: 435
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,7.5
       parent: 1
-  - uid: 447
+  - uid: 436
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,7.5
       parent: 1
-  - uid: 448
+  - uid: 437
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,7.5
       parent: 1
-  - uid: 449
+  - uid: 438
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,5.5
       parent: 1
-  - uid: 450
+  - uid: 439
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,5.5
       parent: 1
-  - uid: 451
+  - uid: 440
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,5.5
       parent: 1
-  - uid: 452
+  - uid: 441
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,5.5
       parent: 1
-  - uid: 453
+  - uid: 442
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,3.5
       parent: 1
-  - uid: 454
+  - uid: 443
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,2.5
       parent: 1
-  - uid: 455
+  - uid: 444
     components:
     - type: Transform
       pos: 14.5,-51.5
       parent: 1
-  - uid: 456
+  - uid: 445
     components:
     - type: Transform
       pos: 3.5,-61.5
       parent: 1
-  - uid: 457
+  - uid: 446
     components:
     - type: Transform
       pos: 3.5,-62.5
       parent: 1
-  - uid: 458
+  - uid: 447
     components:
     - type: Transform
       pos: 6.5,-58.5
       parent: 1
-  - uid: 459
+  - uid: 448
     components:
     - type: Transform
       pos: -16.5,-51.5
       parent: 1
-  - uid: 460
+  - uid: 449
     components:
     - type: Transform
       pos: 7.5,42.5
       parent: 1
-  - uid: 461
+  - uid: 450
     components:
     - type: Transform
       pos: 4.5,40.5
       parent: 1
-  - uid: 462
+  - uid: 451
     components:
     - type: Transform
       pos: -16.5,-51.5
       parent: 1
-  - uid: 463
+  - uid: 452
     components:
     - type: Transform
       pos: 0.5,40.5
       parent: 1
-  - uid: 464
+  - uid: 453
     components:
     - type: Transform
       pos: 0.5,39.5
       parent: 1
-  - uid: 465
+  - uid: 454
     components:
     - type: Transform
       pos: 5.5,34.5
       parent: 1
-  - uid: 466
+  - uid: 455
     components:
     - type: Transform
       pos: 6.5,34.5
       parent: 1
-  - uid: 467
+  - uid: 456
     components:
     - type: Transform
       pos: 0.5,41.5
       parent: 1
-  - uid: 468
+  - uid: 457
     components:
     - type: Transform
       pos: 6.5,43.5
       parent: 1
-  - uid: 469
+  - uid: 458
     components:
     - type: Transform
       pos: -17.5,-22.5
       parent: 1
-  - uid: 470
+  - uid: 459
     components:
     - type: Transform
       pos: 16.5,-22.5
       parent: 1
-  - uid: 471
+  - uid: 460
     components:
     - type: Transform
       pos: 4.5,39.5
       parent: 1
-  - uid: 472
+  - uid: 461
     components:
     - type: Transform
       pos: 5.5,38.5
       parent: 1
-  - uid: 473
+  - uid: 462
     components:
     - type: Transform
       pos: 4.5,38.5
       parent: 1
-  - uid: 474
+  - uid: 463
     components:
     - type: Transform
       pos: 4.5,43.5
       parent: 1
-  - uid: 475
+  - uid: 464
     components:
     - type: Transform
       pos: 4.5,42.5
       parent: 1
-  - uid: 476
+  - uid: 465
     components:
     - type: Transform
       pos: 6.5,38.5
       parent: 1
-  - uid: 477
+  - uid: 466
     components:
     - type: Transform
       pos: 7.5,43.5
       parent: 1
-  - uid: 478
+  - uid: 467
     components:
     - type: Transform
       pos: 7.5,41.5
       parent: 1
-  - uid: 479
+  - uid: 468
     components:
     - type: Transform
       pos: 4.5,41.5
       parent: 1
-  - uid: 480
+  - uid: 469
     components:
     - type: Transform
       pos: 7.5,40.5
       parent: 1
-  - uid: 481
+  - uid: 470
     components:
     - type: Transform
       pos: 5.5,43.5
       parent: 1
-  - uid: 482
+  - uid: 471
     components:
     - type: Transform
       pos: 7.5,39.5
       parent: 1
-  - uid: 483
+  - uid: 472
     components:
     - type: Transform
       pos: 7.5,38.5
       parent: 1
-  - uid: 484
+  - uid: 473
     components:
     - type: Transform
       pos: -4.5,-44.5
       parent: 1
-  - uid: 485
+  - uid: 474
     components:
     - type: Transform
       pos: -9.5,-47.5
       parent: 1
-  - uid: 486
+  - uid: 475
     components:
     - type: Transform
       pos: -9.5,-43.5
       parent: 1
-  - uid: 487
+  - uid: 476
     components:
     - type: Transform
       pos: -7.5,-43.5
       parent: 1
-  - uid: 488
+  - uid: 477
     components:
     - type: Transform
       pos: -8.5,-43.5
       parent: 1
-  - uid: 489
+  - uid: 478
     components:
     - type: Transform
       pos: -10.5,-47.5
       parent: 1
-  - uid: 490
+  - uid: 479
     components:
     - type: Transform
       pos: -8.5,-47.5
       parent: 1
-  - uid: 491
+  - uid: 480
     components:
     - type: Transform
       pos: -10.5,-43.5
       parent: 1
-  - uid: 492
+  - uid: 481
     components:
     - type: Transform
       pos: -7.5,-47.5
       parent: 1
-  - uid: 493
+  - uid: 482
     components:
     - type: Transform
       pos: -4.5,-40.5
       parent: 1
-  - uid: 494
+  - uid: 483
     components:
     - type: Transform
       pos: -4.5,-42.5
       parent: 1
-  - uid: 495
+  - uid: 484
     components:
     - type: Transform
       pos: -4.5,-41.5
       parent: 1
-  - uid: 496
+  - uid: 485
     components:
     - type: Transform
       pos: -4.5,-45.5
       parent: 1
-  - uid: 497
+  - uid: 486
     components:
     - type: Transform
       pos: -4.5,-46.5
       parent: 1
-  - uid: 498
+  - uid: 487
     components:
     - type: Transform
       pos: -4.5,-48.5
       parent: 1
-  - uid: 499
+  - uid: 488
     components:
     - type: Transform
       pos: -4.5,-49.5
       parent: 1
-  - uid: 500
+  - uid: 489
     components:
     - type: Transform
       pos: -4.5,-50.5
       parent: 1
+  - uid: 490
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
 - proto: CMChair
   entities:
-  - uid: 501
+  - uid: 491
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-11.5
       parent: 1
-  - uid: 502
+  - uid: 492
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
-  - uid: 503
+  - uid: 493
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-7.5
       parent: 1
-  - uid: 504
+  - uid: 494
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 505
+  - uid: 495
     components:
     - type: Transform
       pos: -13.5,-1.5
       parent: 1
-  - uid: 506
+  - uid: 496
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-30.5
       parent: 1
-  - uid: 507
+  - uid: 497
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-31.5
       parent: 1
-  - uid: 508
+  - uid: 498
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-32.5
       parent: 1
-  - uid: 509
+  - uid: 499
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-33.5
       parent: 1
-  - uid: 510
+  - uid: 500
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-30.5
       parent: 1
-  - uid: 511
+  - uid: 501
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-31.5
       parent: 1
-  - uid: 512
+  - uid: 502
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-32.5
       parent: 1
-  - uid: 513
+  - uid: 503
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-33.5
       parent: 1
-  - uid: 514
+  - uid: 504
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-30.5
       parent: 1
-  - uid: 515
+  - uid: 505
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-32.5
       parent: 1
-  - uid: 516
+  - uid: 506
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-33.5
       parent: 1
-  - uid: 517
+  - uid: 507
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-31.5
       parent: 1
-  - uid: 518
+  - uid: 508
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-30.5
       parent: 1
-  - uid: 519
+  - uid: 509
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-31.5
       parent: 1
-  - uid: 520
+  - uid: 510
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-32.5
       parent: 1
-  - uid: 521
+  - uid: 511
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-33.5
       parent: 1
-  - uid: 522
+  - uid: 512
     components:
     - type: Transform
       pos: 3.5,-45.5
       parent: 1
-  - uid: 523
+  - uid: 513
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-46.5
       parent: 1
-  - uid: 524
+  - uid: 514
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-46.5
       parent: 1
-  - uid: 525
+  - uid: 515
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-47.5
       parent: 1
-  - uid: 526
+  - uid: 516
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-46.5
       parent: 1
-  - uid: 527
+  - uid: 517
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-45.5
       parent: 1
-  - uid: 528
+  - uid: 518
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-45.5
       parent: 1
-  - uid: 530
+  - uid: 519
+    components:
+    - type: Transform
+      pos: -8.5,41.5
+      parent: 1
+  - uid: 520
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,40.5
       parent: 1
-  - uid: 531
+  - uid: 521
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,38.5
+      parent: 1
+  - uid: 522
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-67.5
       parent: 1
-  - uid: 532
+  - uid: 523
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-68.5
       parent: 1
-  - uid: 533
+  - uid: 524
     components:
     - type: Transform
       pos: 26.5,4.5
       parent: 1
-  - uid: 534
+  - uid: 525
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,3.5
       parent: 1
-  - uid: 535
+  - uid: 526
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,2.5
       parent: 1
-  - uid: 536
+  - uid: 527
     components:
     - type: Transform
       pos: 9.5,-60.5
       parent: 1
-  - uid: 537
+  - uid: 528
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-62.5
       parent: 1
-  - uid: 538
+  - uid: 529
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-33.5
       parent: 1
-  - uid: 539
+  - uid: 530
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-30.5
       parent: 1
-  - uid: 540
+  - uid: 531
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-31.5
       parent: 1
-  - uid: 541
+  - uid: 532
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-32.5
       parent: 1
-  - uid: 542
+  - uid: 533
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-30.5
       parent: 1
-  - uid: 543
+  - uid: 534
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-31.5
       parent: 1
-  - uid: 544
+  - uid: 535
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-33.5
       parent: 1
-  - uid: 545
+  - uid: 536
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10047,494 +9992,494 @@ entities:
       parent: 1
 - proto: CMChairComfyBlack
   entities:
-  - uid: 546
+  - uid: 537
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,45.5
       parent: 1
-  - uid: 547
+  - uid: 538
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,45.5
       parent: 1
-  - uid: 548
+  - uid: 539
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-48.5
       parent: 1
-  - uid: 549
+  - uid: 540
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-24.5
       parent: 1
-  - uid: 550
+  - uid: 541
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-21.5
       parent: 1
-  - uid: 551
+  - uid: 542
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-40.5
       parent: 1
-  - uid: 552
+  - uid: 543
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-44.5
       parent: 1
-  - uid: 553
+  - uid: 544
     components:
     - type: Transform
       pos: 2.5,-29.5
       parent: 1
-  - uid: 554
+  - uid: 545
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-41.5
       parent: 1
-  - uid: 555
+  - uid: 546
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-50.5
       parent: 1
-  - uid: 556
+  - uid: 547
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-49.5
       parent: 1
-  - uid: 557
+  - uid: 548
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-44.5
       parent: 1
-  - uid: 558
+  - uid: 549
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-48.5
       parent: 1
-  - uid: 559
+  - uid: 550
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-45.5
       parent: 1
-  - uid: 560
+  - uid: 551
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-48.5
       parent: 1
-  - uid: 561
+  - uid: 552
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-45.5
       parent: 1
-  - uid: 562
+  - uid: 553
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-50.5
       parent: 1
-  - uid: 563
+  - uid: 554
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-48.5
       parent: 1
-  - uid: 564
+  - uid: 555
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-40.5
       parent: 1
-  - uid: 565
+  - uid: 556
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-49.5
       parent: 1
-  - uid: 566
+  - uid: 557
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-50.5
       parent: 1
-  - uid: 567
+  - uid: 558
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-50.5
       parent: 1
-  - uid: 568
+  - uid: 559
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-46.5
       parent: 1
-  - uid: 569
+  - uid: 560
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-45.5
       parent: 1
-  - uid: 570
+  - uid: 561
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-46.5
       parent: 1
-  - uid: 571
+  - uid: 562
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-42.5
       parent: 1
-  - uid: 572
+  - uid: 563
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-49.5
       parent: 1
-  - uid: 573
+  - uid: 564
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-42.5
       parent: 1
-  - uid: 574
+  - uid: 565
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-41.5
       parent: 1
-  - uid: 575
+  - uid: 566
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-42.5
       parent: 1
-  - uid: 576
+  - uid: 567
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-41.5
       parent: 1
-  - uid: 577
+  - uid: 568
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-50.5
       parent: 1
-  - uid: 578
+  - uid: 569
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-46.5
       parent: 1
-  - uid: 579
+  - uid: 570
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-42.5
       parent: 1
-  - uid: 580
+  - uid: 571
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-40.5
       parent: 1
-  - uid: 581
+  - uid: 572
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-49.5
       parent: 1
-  - uid: 582
+  - uid: 573
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-41.5
       parent: 1
-  - uid: 583
+  - uid: 574
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,0.5
       parent: 1
-  - uid: 584
+  - uid: 575
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,17.5
       parent: 1
-  - uid: 585
+  - uid: 576
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,18.5
       parent: 1
-  - uid: 586
+  - uid: 577
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,16.5
       parent: 1
-  - uid: 587
+  - uid: 578
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,15.5
       parent: 1
-  - uid: 588
+  - uid: 579
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,25.5
       parent: 1
-  - uid: 589
+  - uid: 580
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,18.5
       parent: 1
-  - uid: 590
+  - uid: 581
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,46.5
       parent: 1
-  - uid: 591
+  - uid: 582
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,26.5
       parent: 1
-  - uid: 592
+  - uid: 583
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,27.5
       parent: 1
-  - uid: 593
+  - uid: 584
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,28.5
       parent: 1
-  - uid: 594
+  - uid: 585
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,17.5
       parent: 1
-  - uid: 595
+  - uid: 586
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,16.5
       parent: 1
-  - uid: 596
+  - uid: 587
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,15.5
       parent: 1
-  - uid: 597
+  - uid: 588
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,25.5
       parent: 1
-  - uid: 598
+  - uid: 589
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,26.5
       parent: 1
-  - uid: 599
+  - uid: 590
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,27.5
       parent: 1
-  - uid: 600
+  - uid: 591
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,28.5
       parent: 1
-  - uid: 601
+  - uid: 592
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,48.5
       parent: 1
-  - uid: 602
+  - uid: 593
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,47.5
       parent: 1
-  - uid: 603
+  - uid: 594
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-45.5
       parent: 1
-  - uid: 604
+  - uid: 595
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-46.5
       parent: 1
-  - uid: 605
+  - uid: 596
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-49.5
       parent: 1
-  - uid: 606
+  - uid: 597
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-40.5
       parent: 1
-  - uid: 607
+  - uid: 598
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-44.5
       parent: 1
-  - uid: 608
+  - uid: 599
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-45.5
       parent: 1
-  - uid: 609
+  - uid: 600
     components:
     - type: Transform
       pos: -17.5,47.5
       parent: 1
-  - uid: 610
+  - uid: 601
     components:
     - type: Transform
       pos: -15.5,47.5
       parent: 1
-  - uid: 611
+  - uid: 602
     components:
     - type: Transform
       pos: -12.5,47.5
       parent: 1
-  - uid: 612
+  - uid: 603
     components:
     - type: Transform
       pos: -10.5,47.5
       parent: 1
-  - uid: 613
+  - uid: 604
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-40.5
       parent: 1
-  - uid: 614
+  - uid: 605
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-42.5
       parent: 1
-  - uid: 615
+  - uid: 606
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-44.5
       parent: 1
-  - uid: 616
+  - uid: 607
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-44.5
       parent: 1
-  - uid: 617
+  - uid: 608
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-41.5
       parent: 1
-  - uid: 618
+  - uid: 609
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-50.5
       parent: 1
-  - uid: 619
+  - uid: 610
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-49.5
       parent: 1
-  - uid: 620
+  - uid: 611
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-48.5
       parent: 1
-  - uid: 621
+  - uid: 612
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-46.5
       parent: 1
-  - uid: 622
+  - uid: 613
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-44.5
       parent: 1
-  - uid: 623
+  - uid: 614
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-45.5
       parent: 1
-  - uid: 624
+  - uid: 615
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-42.5
       parent: 1
-  - uid: 625
+  - uid: 616
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-41.5
       parent: 1
-  - uid: 626
+  - uid: 617
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-40.5
       parent: 1
-  - uid: 627
+  - uid: 618
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-46.5
       parent: 1
-  - uid: 628
+  - uid: 619
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10542,43 +10487,43 @@ entities:
       parent: 1
 - proto: CMChairComfyBlue
   entities:
-  - uid: 629
+  - uid: 620
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,60.5
       parent: 1
-  - uid: 630
+  - uid: 621
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,59.5
       parent: 1
-  - uid: 631
+  - uid: 622
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,64.5
       parent: 1
-  - uid: 632
+  - uid: 623
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,69.5
       parent: 1
-  - uid: 633
+  - uid: 624
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,69.5
       parent: 1
-  - uid: 634
+  - uid: 625
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,66.5
       parent: 1
-  - uid: 635
+  - uid: 626
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10586,130 +10531,130 @@ entities:
       parent: 1
 - proto: CMChairOfficeDark
   entities:
-  - uid: 636
+  - uid: 627
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.487244,22.64452
       parent: 1
-  - uid: 637
+  - uid: 628
     components:
     - type: Transform
       pos: 24.514614,20.681509
       parent: 1
-  - uid: 638
+  - uid: 629
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.560934,-1.5271522
       parent: 1
-  - uid: 639
+  - uid: 630
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.340255,46.67434
       parent: 1
-  - uid: 640
+  - uid: 631
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.544651,-34.456234
       parent: 1
-  - uid: 641
+  - uid: 632
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.586423,-35.2227
       parent: 1
-  - uid: 642
+  - uid: 633
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.742673,-35.31645
       parent: 1
-  - uid: 643
+  - uid: 634
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.41152,-31.438345
       parent: 1
-  - uid: 644
+  - uid: 635
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.004555,-51.359215
       parent: 1
-  - uid: 645
+  - uid: 636
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5316849,-45.29527
       parent: 1
-  - uid: 646
+  - uid: 637
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.513339,-43.845943
       parent: 1
-  - uid: 647
+  - uid: 638
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.513339,-46.72625
       parent: 1
-  - uid: 648
+  - uid: 639
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.577616,0.5845001
       parent: 1
-  - uid: 649
+  - uid: 640
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.8728759,-31.246939
       parent: 1
-  - uid: 650
+  - uid: 641
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.185376,-31.231314
       parent: 1
-  - uid: 651
+  - uid: 642
     components:
     - type: Transform
       pos: -25.495476,20.558926
       parent: 1
-  - uid: 652
+  - uid: 643
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.480335,22.589205
       parent: 1
-  - uid: 653
+  - uid: 644
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5071983,-61.61803
       parent: 1
-  - uid: 654
+  - uid: 645
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5228233,-63.258656
       parent: 1
-  - uid: 655
+  - uid: 646
     components:
     - type: Transform
       pos: 1.9667745,40.538128
       parent: 1
-  - uid: 656
+  - uid: 647
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.3761005,42.692123
       parent: 1
-  - uid: 657
+  - uid: 648
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10717,48 +10662,48 @@ entities:
       parent: 1
 - proto: CMChemMaster
   entities:
-  - uid: 658
-    components:
-    - type: Transform
-      pos: -24.5,25.5
-      parent: 1
-  - uid: 659
+  - uid: 649
     components:
     - type: Transform
       pos: -24.5,21.5
       parent: 1
+  - uid: 650
+    components:
+    - type: Transform
+      pos: -24.5,24.5
+      parent: 1
 - proto: CMClipboard
   entities:
-  - uid: 660
+  - uid: 651
     components:
     - type: Transform
       pos: 10.268515,-50.42956
       parent: 1
-  - uid: 661
+  - uid: 652
     components:
     - type: Transform
       pos: -2.281715,-47.0066
       parent: 1
-  - uid: 662
+  - uid: 653
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.9286177,-30.437569
       parent: 1
-  - uid: 663
+  - uid: 654
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.402259,-31.808285
       parent: 1
-  - uid: 664
+  - uid: 655
     components:
     - type: Transform
       pos: -26.36173,15.543395
       parent: 1
 - proto: CMClosetBase
   entities:
-  - uid: 18
+  - uid: 16
     components:
     - type: Transform
       pos: 4.5,-39.5
@@ -10769,19 +10714,19 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 19
-          - 22
-          - 24
-          - 25
-          - 23
           - 20
           - 21
-          - 26
+          - 19
+          - 18
+          - 24
+          - 23
+          - 22
+          - 17
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
-  - uid: 27
+  - uid: 25
     components:
     - type: Transform
       pos: 1.5,-39.5
@@ -10792,19 +10737,19 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 35
-          - 31
-          - 30
+          - 33
           - 29
           - 28
-          - 34
-          - 33
+          - 27
+          - 26
           - 32
+          - 31
+          - 30
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
-  - uid: 36
+  - uid: 34
     components:
     - type: Transform
       pos: 10.5,-39.5
@@ -10815,19 +10760,19 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 44
-          - 40
-          - 39
+          - 42
           - 38
           - 37
-          - 43
-          - 42
+          - 36
+          - 35
           - 41
+          - 40
+          - 39
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
-  - uid: 45
+  - uid: 43
     components:
     - type: Transform
       pos: 7.5,-39.5
@@ -10838,55 +10783,55 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 53
-          - 49
-          - 48
+          - 51
           - 47
           - 46
-          - 52
-          - 51
+          - 45
+          - 44
           - 50
+          - 49
+          - 48
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
-  - uid: 665
+  - uid: 656
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 666
+  - uid: 657
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 1
-  - uid: 667
+  - uid: 658
     components:
     - type: Transform
       pos: -4.5,-9.5
       parent: 1
 - proto: CMClosetTool
   entities:
-  - uid: 668
+  - uid: 659
     components:
     - type: Transform
       pos: 1.5,-57.5
       parent: 1
-  - uid: 669
+  - uid: 660
     components:
     - type: Transform
       pos: 2.5,-57.5
       parent: 1
 - proto: CMCrematorium
   entities:
-  - uid: 670
+  - uid: 661
     components:
     - type: Transform
       pos: -33.5,11.5
       parent: 1
 - proto: CMDispenserBooze
   entities:
-  - uid: 671
+  - uid: 662
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10894,17 +10839,17 @@ entities:
       parent: 1
 - proto: CMDispenserSoda
   entities:
-  - uid: 672
+  - uid: 663
     components:
     - type: Transform
       pos: -5.5,-34.5
       parent: 1
-  - uid: 673
+  - uid: 664
     components:
     - type: Transform
       pos: -7.5,-34.5
       parent: 1
-  - uid: 674
+  - uid: 665
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10912,29 +10857,29 @@ entities:
       parent: 1
 - proto: CMDisposalUnit
   entities:
-  - uid: 675
+  - uid: 666
     components:
     - type: Transform
       pos: -7.5,-3.5
       parent: 1
-  - uid: 676
+  - uid: 667
     components:
     - type: Transform
       pos: -17.5,-10.5
       parent: 1
-  - uid: 677
+  - uid: 668
     components:
     - type: Transform
       pos: -10.5,-21.5
       parent: 1
 - proto: CMDoubleDoorAlmayerGlass
   entities:
-  - uid: 678
+  - uid: 669
     components:
     - type: Transform
       pos: 12.5,-22.5
       parent: 1
-  - uid: 679
+  - uid: 670
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10942,285 +10887,277 @@ entities:
       parent: 1
 - proto: CMDoubleDoorMedicalGlass
   entities:
-  - uid: 680
+  - uid: 671
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,11.5
       parent: 1
-  - uid: 681
+  - uid: 672
     components:
     - type: Transform
       pos: -23.5,12.5
       parent: 1
 - proto: CMDoubleDoorSecurityGlass
   entities:
-  - uid: 682
+  - uid: 673
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-38.5
       parent: 1
-  - uid: 683
+  - uid: 674
     components:
     - type: Transform
       pos: 12.5,-37.5
       parent: 1
 - proto: CMDrinkCanFruitBeer
   entities:
-  - uid: 684
+  - uid: 675
     components:
     - type: Transform
       pos: 1.2885551,-27.363768
       parent: 1
-  - uid: 685
+  - uid: 676
     components:
     - type: Transform
       pos: 1.3093886,-27.717934
       parent: 1
-  - uid: 686
+  - uid: 677
     components:
     - type: Transform
       pos: 1.5802221,-27.6971
       parent: 1
-  - uid: 687
+  - uid: 678
     components:
     - type: Transform
       pos: 1.7885551,-27.332518
       parent: 1
-  - uid: 688
+  - uid: 679
     components:
     - type: Transform
       pos: 1.8198051,-27.72835
       parent: 1
-  - uid: 689
+  - uid: 680
     components:
     - type: Transform
       pos: 1.5698051,-27.35335
       parent: 1
 - proto: CMDrinkWEYAWaterBottle30
   entities:
-  - uid: 690
+  - uid: 681
     components:
     - type: Transform
       pos: 7.7278223,-27.1163
       parent: 1
-  - uid: 691
+  - uid: 682
     components:
     - type: Transform
       pos: 7.4778223,-27.1163
       parent: 1
-  - uid: 692
+  - uid: 683
     components:
     - type: Transform
       pos: 7.2069893,-27.126719
       parent: 1
-  - uid: 693
+  - uid: 684
     components:
     - type: Transform
       pos: 6.9465723,-27.126719
       parent: 1
-  - uid: 694
+  - uid: 685
     components:
     - type: Transform
       pos: 6.967406,-27.574635
       parent: 1
-  - uid: 695
+  - uid: 686
     components:
     - type: Transform
       pos: 7.2069893,-27.58505
       parent: 1
-  - uid: 696
+  - uid: 687
     components:
     - type: Transform
       pos: 7.4465723,-27.58505
       parent: 1
-  - uid: 697
+  - uid: 688
     components:
     - type: Transform
       pos: 7.717406,-27.58505
       parent: 1
 - proto: CMDropshipHijackDestination
   entities:
-  - uid: 698
+  - uid: 689
     components:
+    - type: MetaData
+      name: Combat Information Center
     - type: Transform
       pos: -0.5,39.5
       parent: 1
-  - uid: 699
-    components:
-    - type: Transform
-      pos: -6.5,41.5
-      parent: 1
-  - uid: 700
-    components:
-    - type: Transform
-      pos: 0.5,-46.5
-      parent: 1
 - proto: CMFax
   entities:
-  - uid: 701
+  - uid: 690
     components:
     - type: Transform
       pos: -2.5,58.5
       parent: 1
     - type: FaxMachine
       name: USS George Bush CIC Office
-  - uid: 702
+  - uid: 691
     components:
     - type: Transform
       pos: -2.5,64.5
       parent: 1
     - type: FaxMachine
       name: USS George Bush CIC
-  - uid: 703
+  - uid: 692
     components:
     - type: Transform
       pos: 5.5,-35.5
       parent: 1
-  - uid: 704
+  - uid: 693
     components:
     - type: Transform
       pos: 1.5,-60.5
       parent: 1
     - type: FaxMachine
       name: USS George Bush Engineering
-  - uid: 705
+  - uid: 694
     components:
     - type: Transform
       pos: 13.5,48.5
       parent: 1
-  - uid: 706
+  - uid: 695
     components:
     - type: Transform
       pos: 23.5,23.5
       parent: 1
     - type: FaxMachine
-      name: 'USS Bush Requisitions '
-  - uid: 707
+      name: 'USS George Requisitions '
+  - uid: 696
     components:
     - type: Transform
       pos: 2.5,43.5
       parent: 1
-  - uid: 708
+  - uid: 697
     components:
     - type: Transform
       pos: -2.5,-42.5
       parent: 1
 - proto: CMFilingCabinet
   entities:
-  - uid: 709
+  - uid: 698
     components:
     - type: Transform
       pos: 1.5,47.5
       parent: 1
-  - uid: 710
+  - uid: 699
     components:
     - type: Transform
       pos: -0.49015808,58.5
       parent: 1
-  - uid: 711
+  - uid: 700
     components:
     - type: Transform
       pos: 1.5,64.5
       parent: 1
-  - uid: 712
+  - uid: 701
     components:
     - type: Transform
       pos: 17.7146,3.5
       parent: 1
-  - uid: 713
+  - uid: 702
     components:
     - type: Transform
       pos: 1.3117617,-29.5
       parent: 1
-  - uid: 714
+  - uid: 703
     components:
     - type: Transform
       pos: -4.5,69.5
       parent: 1
-  - uid: 715
+  - uid: 704
     components:
     - type: Transform
       pos: 4.733697,-60.5
       parent: 1
-  - uid: 716
+  - uid: 705
     components:
     - type: Transform
       pos: 4.218072,-60.5
       parent: 1
-  - uid: 717
+  - uid: 706
     components:
     - type: Transform
       pos: 1.5,46.5
       parent: 1
-  - uid: 718
+  - uid: 707
     components:
     - type: Transform
       pos: 1.5,45.5
       parent: 1
-  - uid: 719
+  - uid: 708
     components:
     - type: Transform
       pos: 0.5,39.5
       parent: 1
-  - uid: 720
+  - uid: 709
     components:
     - type: Transform
       pos: -17.283484,48.5
       parent: 1
-  - uid: 721
+  - uid: 710
     components:
     - type: Transform
       pos: -17.752234,48.5
       parent: 1
 - proto: CMFilingCabinetTall
   entities:
-  - uid: 722
+  - uid: 711
     components:
     - type: Transform
       pos: -12.752598,48.5
       parent: 1
-  - uid: 723
+  - uid: 712
     components:
     - type: Transform
       pos: -1.2969089,-51.5
       parent: 1
-  - uid: 724
+  - uid: 713
     components:
     - type: Transform
       pos: -1.7813426,-51.5
       parent: 1
-  - uid: 725
+  - uid: 714
     components:
     - type: Transform
       pos: 17.230225,3.5
       parent: 1
-  - uid: 726
+  - uid: 715
     components:
     - type: Transform
       pos: -12.299473,48.5
       parent: 1
 - proto: CMFolderBase
   entities:
-  - uid: 727
+  - uid: 716
     components:
     - type: Transform
       pos: -2.5752492,-43.52088
       parent: 1
-  - uid: 728
+  - uid: 717
     components:
     - type: Transform
       pos: 1.3353233,-62.52428
       parent: 1
 - proto: CMFolderBlack
   entities:
-  - uid: 729
+  - uid: 718
     components:
     - type: Transform
       pos: -1.6102567,46.53652
       parent: 1
-  - uid: 730
+  - uid: 719
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11228,103 +11165,113 @@ entities:
       parent: 1
 - proto: CMFolderBlue
   entities:
-  - uid: 731
+  - uid: 720
     components:
     - type: Transform
       pos: -5.6144915,65.69247
       parent: 1
 - proto: CMFolderRed
   entities:
-  - uid: 732
+  - uid: 721
     components:
     - type: Transform
       pos: -5.4165745,65.51538
       parent: 1
-  - uid: 733
+  - uid: 722
+    components:
+    - type: Transform
+      pos: -0.7284808,67.67744
+      parent: 1
+  - uid: 723
     components:
     - type: Transform
       pos: 11.604243,-32.601
       parent: 1
-  - uid: 734
+  - uid: 724
     components:
     - type: Transform
       pos: 7.017124,-34.323338
       parent: 1
-  - uid: 735
+  - uid: 725
     components:
     - type: Transform
       pos: 5.5916724,-34.925255
       parent: 1
-  - uid: 736
+  - uid: 726
     components:
     - type: Transform
       pos: -1.8304074,46.66494
       parent: 1
 - proto: CMFolderRedEmpty
   entities:
-  - uid: 737
+  - uid: 727
     components:
     - type: Transform
       pos: 9.100159,-50.508278
       parent: 1
-  - uid: 738
+  - uid: 728
     components:
     - type: Transform
       pos: 8.943909,-50.305153
       parent: 1
 - proto: CMFolderWhite
   entities:
-  - uid: 739
+  - uid: 729
+    components:
+    - type: Transform
+      pos: -0.48889732,67.42744
+      parent: 1
+  - uid: 730
     components:
     - type: Transform
       pos: -2.484354,60.44643
       parent: 1
 - proto: CMFolderYellow
   entities:
-  - uid: 740
+  - uid: 731
     components:
     - type: Transform
       pos: -2.6486328,-45.740734
       parent: 1
 - proto: CMGear
   entities:
-  - uid: 741
+  - uid: 732
     components:
     - type: Transform
       pos: 26.5,19.5
       parent: 1
-  - uid: 742
+  - uid: 733
     components:
     - type: Transform
       pos: 32.5,19.5
       parent: 1
-  - uid: 743
+  - uid: 734
     components:
     - type: Transform
       pos: 32.5,13.5
       parent: 1
-  - uid: 744
+  - uid: 735
     components:
     - type: Transform
       pos: 26.5,13.5
       parent: 1
 - proto: CMHandsLatex
   entities:
-  - uid: 745
+  - uid: 736
     components:
     - type: Transform
       pos: -26.444906,13.930593
       parent: 1
 - proto: CMHemostat
   entities:
-  - uid: 746
+  - uid: 737
     components:
     - type: Transform
       pos: -26.746672,17.63493
       parent: 1
 - proto: CMJanitorialCart
   entities:
-  - uid: 747
+  - uid: 738
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11339,7 +11286,7 @@ entities:
         mop_slot: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 748
+          ent: 739
         trashbag_slot: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -11347,7 +11294,7 @@ entities:
         bucket_slot: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 749
+          ent: 740
         wetfloorsign_slot4: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -11372,7 +11319,7 @@ entities:
           showEnts: False
           occludes: True
           ent: null
-  - uid: 750
+  - uid: 741
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11395,7 +11342,7 @@ entities:
         bucket_slot: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 751
+          ent: 742
         wetfloorsign_slot4: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -11422,14 +11369,14 @@ entities:
           ent: null
 - proto: CMLockerCMDCabinetFilled
   entities:
-  - uid: 752
+  - uid: 743
     components:
     - type: Transform
       pos: -5.5,59.5
       parent: 1
 - proto: CMLockerFridge
   entities:
-  - uid: 753
+  - uid: 744
     components:
     - type: Transform
       pos: -5.5,56.5
@@ -11442,99 +11389,99 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 754
+          - 745
+          - 746
+          - 747
+          - 748
+          - 749
           - 755
           - 756
           - 757
           - 758
-          - 764
-          - 765
-          - 766
-          - 767
-          - 768
-          - 769
           - 759
           - 760
-          - 761
-          - 762
-          - 763
+          - 750
+          - 751
+          - 752
+          - 753
+          - 754
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: CMMicrowave
   entities:
-  - uid: 770
+  - uid: 761
     components:
     - type: Transform
       pos: -5.5,57.5
       parent: 1
-  - uid: 771
+  - uid: 762
     components:
     - type: Transform
       pos: -5.326966,-21.314306
       parent: 1
-  - uid: 772
+  - uid: 763
     components:
     - type: Transform
       pos: -4.4219017,-21.314306
       parent: 1
-  - uid: 773
+  - uid: 764
     components:
     - type: Transform
       pos: 11.5,-47.5
       parent: 1
 - proto: CMMop
   entities:
-  - uid: 748
+  - uid: 739
     components:
     - type: Transform
-      parent: 747
+      parent: 738
     - type: Physics
       canCollide: False
-  - uid: 774
+  - uid: 765
     components:
     - type: Transform
       rot: 6.283185307179586 rad
       pos: -4.771082,-14.533049
       parent: 1
-  - uid: 775
+  - uid: 766
     components:
     - type: Transform
       pos: -4.6695557,-14.53261
       parent: 1
-  - uid: 776
+  - uid: 767
     components:
     - type: Transform
       pos: 2.8091335,-21.840734
       parent: 1
 - proto: CMMorgue
   entities:
-  - uid: 777
+  - uid: 768
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,6.5
       parent: 1
-  - uid: 778
+  - uid: 769
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,5.5
       parent: 1
-  - uid: 779
+  - uid: 770
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,7.5
       parent: 1
-  - uid: 780
+  - uid: 771
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,8.5
       parent: 1
-  - uid: 781
+  - uid: 772
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11542,102 +11489,102 @@ entities:
       parent: 1
 - proto: CMOperatingTable
   entities:
-  - uid: 782
+  - uid: 773
     components:
     - type: Transform
       pos: -31.5,9.5
       parent: 1
-  - uid: 783
+  - uid: 774
     components:
     - type: Transform
       pos: -32.5,13.5
       parent: 1
-  - uid: 784
+  - uid: 775
     components:
     - type: Transform
       pos: -32.5,17.5
       parent: 1
 - proto: CMPaper
   entities:
-  - uid: 785
+  - uid: 776
     components:
     - type: Transform
       pos: -2.0799463,-48.262493
       parent: 1
-  - uid: 786
+  - uid: 777
     components:
     - type: Transform
       pos: -3.8229485,-7.3801465
       parent: 1
-  - uid: 787
+  - uid: 778
     components:
     - type: Transform
       pos: -3.544691,-11.337372
       parent: 1
-  - uid: 788
+  - uid: 779
     components:
     - type: Transform
       rot: 6.283185307179586 rad
       pos: -2.5684605,59.0136
       parent: 1
-  - uid: 789
+  - uid: 780
     components:
     - type: Transform
       rot: 6.283185307179586 rad
       pos: -2.3601265,58.9511
       parent: 1
-  - uid: 790
+  - uid: 781
     components:
     - type: Transform
       pos: -1.6207304,70.609795
       parent: 1
-  - uid: 791
+  - uid: 782
     components:
     - type: Transform
       pos: -1.4853144,70.453545
       parent: 1
-  - uid: 792
+  - uid: 783
     components:
     - type: Transform
       pos: 9.615784,-50.414528
       parent: 1
-  - uid: 793
+  - uid: 784
     components:
     - type: Transform
       pos: 11.274017,-32.43589
       parent: 1
-  - uid: 794
+  - uid: 785
     components:
     - type: Transform
       pos: 11.1455965,-32.362507
       parent: 1
-  - uid: 795
+  - uid: 786
     components:
     - type: Transform
       pos: 5.0768623,-34.552948
       parent: 1
-  - uid: 796
+  - uid: 787
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.375398,-35.0694
       parent: 1
-  - uid: 797
+  - uid: 788
     components:
     - type: Transform
       pos: 1.4134483,-63.446156
       parent: 1
-  - uid: 798
+  - uid: 789
     components:
     - type: Transform
       pos: 13.434285,47.692436
       parent: 1
-  - uid: 799
+  - uid: 790
     components:
     - type: Transform
       pos: 13.305863,47.839203
       parent: 1
-  - uid: 800
+  - uid: 791
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11645,737 +11592,732 @@ entities:
       parent: 1
 - proto: CMPaperBin10
   entities:
-  - uid: 801
+  - uid: 792
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.4856653,46.870464
       parent: 1
-  - uid: 802
+  - uid: 793
     components:
     - type: Transform
       pos: 1.4915733,-61.164906
       parent: 1
-  - uid: 803
+  - uid: 794
     components:
     - type: Transform
       pos: 13.5076685,46.775143
       parent: 1
 - proto: CMPaperBin20
   entities:
-  - uid: 804
+  - uid: 795
     components:
     - type: Transform
       pos: -17.563957,46.67388
       parent: 1
-  - uid: 805
+  - uid: 796
     components:
     - type: Transform
       pos: -1.5488391,-48.32288
       parent: 1
-  - uid: 806
+  - uid: 797
     components:
     - type: Transform
       pos: -10.813957,46.595757
       parent: 1
 - proto: CMPaperBin30
   entities:
-  - uid: 807
+  - uid: 798
     components:
     - type: Transform
       pos: -2.635992,57.974407
       parent: 1
-  - uid: 808
+  - uid: 799
     components:
     - type: Transform
       pos: -2.5,67.5
       parent: 1
-  - uid: 809
+  - uid: 800
     components:
     - type: Transform
       pos: -2.3381913,65.68711
       parent: 1
-  - uid: 810
+  - uid: 801
     components:
     - type: Transform
       pos: 2.5194857,65.71038
       parent: 1
-  - uid: 811
+  - uid: 802
     components:
     - type: Transform
       pos: 8.5,-50.5
       parent: 1
-  - uid: 812
+  - uid: 803
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.43636,-46.31406
       parent: 1
-  - uid: 813
+  - uid: 804
     components:
     - type: Transform
       pos: 23.5,19.5
       parent: 1
-  - uid: 814
+  - uid: 805
     components:
     - type: Transform
       pos: -0.51494706,46.683285
       parent: 1
 - proto: CMPen
   entities:
-  - uid: 815
+  - uid: 806
     components:
     - type: Transform
       pos: -3.8229485,-7.5023937
       parent: 1
-  - uid: 816
+  - uid: 807
     components:
     - type: Transform
       pos: -2.708908,57.922325
       parent: 1
-  - uid: 817
+  - uid: 808
     components:
     - type: Transform
       pos: -2.6320257,57.797573
       parent: 1
-  - uid: 818
+  - uid: 809
     components:
     - type: Transform
       pos: -2.603199,67.450356
       parent: 1
-  - uid: 819
+  - uid: 810
     components:
     - type: Transform
       pos: -2.3381913,65.61072
       parent: 1
-  - uid: 820
+  - uid: 811
     components:
     - type: Transform
       pos: -0.5122509,64.631096
       parent: 1
-  - uid: 821
+  - uid: 812
     components:
     - type: Transform
       pos: 2.4569855,65.658295
       parent: 1
-  - uid: 822
+  - uid: 813
     components:
     - type: Transform
       pos: 2.540319,65.51246
       parent: 1
-  - uid: 823
+  - uid: 814
     components:
     - type: Transform
       pos: -2.519866,67.31494
       parent: 1
-  - uid: 824
+  - uid: 815
     components:
     - type: Transform
       pos: 10.930148,-32.203907
       parent: 1
-  - uid: 825
+  - uid: 816
     components:
     - type: Transform
       pos: -1.5855308,-48.50634
       parent: 1
-  - uid: 826
+  - uid: 817
     components:
     - type: Transform
       pos: 9.756409,-50.336403
       parent: 1
-  - uid: 827
+  - uid: 818
     components:
     - type: Transform
       pos: -1.5855308,-48.304535
       parent: 1
-  - uid: 828
+  - uid: 819
     components:
     - type: Transform
       pos: 2.37386,-46.28281
       parent: 1
-  - uid: 829
+  - uid: 820
     components:
     - type: Transform
       pos: 2.389485,-46.360935
       parent: 1
-  - uid: 830
+  - uid: 821
     components:
     - type: Transform
       pos: 2.40511,-46.53281
       parent: 1
-  - uid: 831
+  - uid: 822
     components:
     - type: Transform
       pos: 5.2436876,-34.519024
       parent: 1
-  - uid: 832
+  - uid: 823
     components:
     - type: Transform
       pos: 11.502667,-34.82479
       parent: 1
-  - uid: 833
+  - uid: 824
     components:
     - type: Transform
       pos: 7.2005835,-34.482334
       parent: 1
-  - uid: 834
+  - uid: 825
     components:
     - type: Transform
       pos: 1.6165733,-62.477406
       parent: 1
-  - uid: 835
+  - uid: 826
     components:
     - type: Transform
       pos: 1.4915733,-63.49303
       parent: 1
-  - uid: 836
+  - uid: 827
     components:
     - type: Transform
       pos: -1.1700239,46.481483
       parent: 1
-  - uid: 837
+  - uid: 828
     components:
     - type: Transform
       pos: 2.1880455,39.593014
       parent: 1
-  - uid: 838
-    components:
-    - type: Transform
-      pos: 23.467064,19.370108
-      parent: 1
 - proto: CMPenFountain
   entities:
-  - uid: 839
+  - uid: 829
     components:
     - type: Transform
       pos: -6.4634523,46.82073
       parent: 1
-  - uid: 840
+  - uid: 830
     components:
     - type: Transform
       pos: 13.434285,46.720104
       parent: 1
-  - uid: 841
+  - uid: 831
     components:
     - type: Transform
-      pos: 13.562706,46.536644
+      pos: 13.492126,46.590565
       parent: 1
 - proto: CMPlatform
   entities:
-  - uid: 842
+  - uid: 832
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,41.5
       parent: 1
-  - uid: 843
+  - uid: 833
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,39.5
       parent: 1
-  - uid: 844
+  - uid: 834
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-45.5
       parent: 1
-  - uid: 845
+  - uid: 835
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,43.5
       parent: 1
-  - uid: 846
+  - uid: 836
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,42.5
       parent: 1
-  - uid: 847
+  - uid: 837
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,40.5
       parent: 1
-  - uid: 848
+  - uid: 838
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,38.5
       parent: 1
-  - uid: 849
+  - uid: 839
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,43.5
       parent: 1
-  - uid: 850
+  - uid: 840
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-9.5
       parent: 1
-  - uid: 851
+  - uid: 841
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,-9.5
       parent: 1
-  - uid: 852
+  - uid: 842
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-9.5
       parent: 1
-  - uid: 853
+  - uid: 843
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-9.5
       parent: 1
-  - uid: 854
+  - uid: 844
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-9.5
       parent: 1
-  - uid: 855
+  - uid: 845
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-9.5
       parent: 1
-  - uid: 856
+  - uid: 846
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-4.5
       parent: 1
-  - uid: 857
+  - uid: 847
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-4.5
       parent: 1
-  - uid: 858
+  - uid: 848
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-5.5
       parent: 1
-  - uid: 859
+  - uid: 849
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-5.5
       parent: 1
-  - uid: 860
+  - uid: 850
     components:
     - type: Transform
       pos: -1.5,62.5
       parent: 1
-  - uid: 861
+  - uid: 851
     components:
     - type: Transform
       pos: -2.5,62.5
       parent: 1
-  - uid: 862
+  - uid: 852
     components:
     - type: Transform
       pos: -0.5,62.5
       parent: 1
-  - uid: 863
+  - uid: 853
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,59.5
       parent: 1
-  - uid: 864
+  - uid: 854
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,61.5
       parent: 1
-  - uid: 865
+  - uid: 855
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,60.5
       parent: 1
-  - uid: 866
+  - uid: 856
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,58.5
       parent: 1
-  - uid: 867
+  - uid: 857
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,56.5
       parent: 1
-  - uid: 868
+  - uid: 858
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,56.5
       parent: 1
-  - uid: 869
+  - uid: 859
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,56.5
       parent: 1
-  - uid: 870
+  - uid: 860
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,61.5
       parent: 1
-  - uid: 871
+  - uid: 861
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,60.5
       parent: 1
-  - uid: 872
+  - uid: 862
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,59.5
       parent: 1
-  - uid: 873
+  - uid: 863
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,59.5
       parent: 1
-  - uid: 874
+  - uid: 864
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,57.5
       parent: 1
-  - uid: 875
+  - uid: 865
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,58.5
       parent: 1
-  - uid: 876
+  - uid: 866
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,65.5
       parent: 1
-  - uid: 877
+  - uid: 867
     components:
     - type: Transform
       pos: -2.5,66.5
       parent: 1
-  - uid: 878
+  - uid: 868
     components:
     - type: Transform
       pos: -1.5,66.5
       parent: 1
-  - uid: 879
+  - uid: 869
     components:
     - type: Transform
       pos: -0.5,66.5
       parent: 1
-  - uid: 880
+  - uid: 870
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,65.5
       parent: 1
-  - uid: 881
+  - uid: 871
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-46.5
       parent: 1
-  - uid: 882
+  - uid: 872
     components:
     - type: Transform
       pos: -2.5,-50.5
       parent: 1
-  - uid: 883
+  - uid: 873
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-51.5
       parent: 1
-  - uid: 884
+  - uid: 874
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-44.5
       parent: 1
-  - uid: 885
+  - uid: 875
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,37.5
       parent: 1
-  - uid: 886
+  - uid: 876
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-47.5
       parent: 1
-  - uid: 887
+  - uid: 877
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-43.5
       parent: 1
-  - uid: 888
+  - uid: 878
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,39.5
       parent: 1
-  - uid: 889
+  - uid: 879
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,39.5
       parent: 1
-  - uid: 890
+  - uid: 880
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,38.5
       parent: 1
-  - uid: 891
+  - uid: 881
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,41.5
       parent: 1
-  - uid: 892
+  - uid: 882
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,40.5
       parent: 1
-  - uid: 893
+  - uid: 883
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,43.5
       parent: 1
-  - uid: 894
+  - uid: 884
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,42.5
       parent: 1
-  - uid: 895
+  - uid: 885
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,43.5
       parent: 1
-  - uid: 896
+  - uid: 886
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,38.5
       parent: 1
-  - uid: 897
+  - uid: 887
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,42.5
       parent: 1
-  - uid: 898
+  - uid: 888
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,40.5
       parent: 1
-  - uid: 899
+  - uid: 889
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,41.5
       parent: 1
-  - uid: 900
+  - uid: 890
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-48.5
       parent: 1
-  - uid: 901
+  - uid: 891
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-42.5
       parent: 1
-  - uid: 902
+  - uid: 892
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,43.5
       parent: 1
-  - uid: 903
+  - uid: 893
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,43.5
       parent: 1
-  - uid: 904
+  - uid: 894
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,37.5
       parent: 1
-  - uid: 905
+  - uid: 895
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,45.5
       parent: 1
-  - uid: 906
+  - uid: 896
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,46.5
       parent: 1
-  - uid: 907
+  - uid: 897
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,40.5
       parent: 1
-  - uid: 908
+  - uid: 898
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,43.5
       parent: 1
-  - uid: 909
+  - uid: 899
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,39.5
       parent: 1
-  - uid: 910
+  - uid: 900
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,37.5
       parent: 1
-  - uid: 911
+  - uid: 901
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,42.5
       parent: 1
-  - uid: 912
+  - uid: 902
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,43.5
       parent: 1
-  - uid: 913
+  - uid: 903
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,37.5
       parent: 1
-  - uid: 914
+  - uid: 904
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,41.5
       parent: 1
-  - uid: 915
+  - uid: 905
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,38.5
       parent: 1
-  - uid: 916
+  - uid: 906
     components:
     - type: Transform
       pos: -0.5,-39.5
       parent: 1
-  - uid: 917
+  - uid: 907
     components:
     - type: Transform
       pos: -1.5,-39.5
       parent: 1
-  - uid: 918
+  - uid: 908
     components:
     - type: Transform
       pos: -2.5,-41.5
       parent: 1
-  - uid: 919
+  - uid: 909
     components:
     - type: Transform
       pos: -2.5,-39.5
       parent: 1
 - proto: CMPlatformCorner
   entities:
-  - uid: 920
+  - uid: 910
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,43.5
       parent: 1
-  - uid: 921
+  - uid: 911
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,43.5
       parent: 1
-  - uid: 922
+  - uid: 912
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,43.5
       parent: 1
-  - uid: 923
+  - uid: 913
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,43.5
       parent: 1
-  - uid: 924
+  - uid: 914
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,-9.5
       parent: 1
-  - uid: 925
+  - uid: 915
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,43.5
       parent: 1
-  - uid: 926
+  - uid: 916
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,43.5
       parent: 1
-  - uid: 927
+  - uid: 917
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,43.5
       parent: 1
-  - uid: 928
+  - uid: 918
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,43.5
       parent: 1
-  - uid: 929
+  - uid: 919
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12383,26 +12325,26 @@ entities:
       parent: 1
 - proto: CMPlushieFarwa
   entities:
-  - uid: 930
+  - uid: 920
     components:
     - type: Transform
       pos: -4.541855,46.443382
       parent: 1
 - proto: CMPostEat
   entities:
-  - uid: 931
+  - uid: 921
     components:
     - type: Transform
       pos: 8.5,-20.5
       parent: 1
-  - uid: 932
+  - uid: 922
     components:
     - type: Transform
       pos: 5.5,-20.5
       parent: 1
 - proto: CMPosterRememberIo
   entities:
-  - uid: 933
+  - uid: 923
     components:
     - type: MetaData
       desc: This faded propaganda poster proudly demands you to, 'Remember Mars'. The surprise commando raid on the repair/refit yard on Mars, was the event that kicked off the war with the UPP a very long time ago. You may not be at war anymore, but old wounds run deep.
@@ -12412,491 +12354,506 @@ entities:
       parent: 1
 - proto: CMPottedPlant1
   entities:
-  - uid: 934
+  - uid: 924
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
 - proto: CMPottedPlant10
   entities:
-  - uid: 935
+  - uid: 925
     components:
     - type: Transform
       pos: -26.5,20.5
       parent: 1
-  - uid: 936
+  - uid: 926
     components:
     - type: Transform
       pos: 7.5,-61.5
       parent: 1
 - proto: CMPottedPlant12
   entities:
-  - uid: 937
+  - uid: 927
     components:
     - type: Transform
       pos: -8.5,-14.5
       parent: 1
 - proto: CMPottedPlant17
   entities:
-  - uid: 938
+  - uid: 928
     components:
     - type: Transform
       pos: -2.6461124,59.87658
       parent: 1
 - proto: CMPottedPlant18
   entities:
-  - uid: 939
+  - uid: 929
     components:
     - type: Transform
       pos: 13.5,-5.5
       parent: 1
 - proto: CMPottedPlant2
   entities:
-  - uid: 940
+  - uid: 930
     components:
     - type: Transform
       pos: 9.5,-5.5
       parent: 1
-  - uid: 941
+  - uid: 931
     components:
     - type: Transform
       pos: 4.5,-29.5
       parent: 1
 - proto: CMPottedPlant21
   entities:
-  - uid: 942
+  - uid: 932
     components:
     - type: Transform
       pos: -17.5,-11.5
       parent: 1
-  - uid: 943
+  - uid: 933
     components:
     - type: Transform
       pos: -0.5,60.5
       parent: 1
-  - uid: 944
+  - uid: 934
     components:
     - type: Transform
       pos: -4.525593,64.588326
       parent: 1
-  - uid: 945
+  - uid: 935
     components:
     - type: Transform
       pos: -1.5,53.5
       parent: 1
-  - uid: 946
+  - uid: 936
     components:
     - type: Transform
       pos: -0.5,-38.5
       parent: 1
 - proto: CMPottedPlant22
   entities:
-  - uid: 947
+  - uid: 937
     components:
     - type: Transform
       pos: -12.5,-36.5
       parent: 1
-  - uid: 948
+  - uid: 938
     components:
     - type: Transform
       pos: -15.136822,48.226616
       parent: 1
 - proto: CMPottedPlant23
   entities:
-  - uid: 949
+  - uid: 939
     components:
     - type: Transform
       pos: -5.3374214,67.55818
       parent: 1
 - proto: CMPottedPlant26
   entities:
-  - uid: 950
+  - uid: 940
     components:
     - type: Transform
       pos: 7.5,-57.5
       parent: 1
 - proto: CMPottedPlant27
   entities:
-  - uid: 951
+  - uid: 941
     components:
     - type: Transform
       pos: -10.261822,48.226616
       parent: 1
-  - uid: 952
+  - uid: 942
     components:
     - type: Transform
       pos: -6.5,-26.5
       parent: 1
 - proto: CMPottedPlant28
   entities:
-  - uid: 953
+  - uid: 943
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 954
+  - uid: 944
     components:
     - type: Transform
       pos: -26.5,25.5
       parent: 1
-  - uid: 955
+  - uid: 945
     components:
     - type: Transform
       pos: -2.5,48.5
       parent: 1
 - proto: CMPottedPlant29
   entities:
-  - uid: 956
+  - uid: 946
     components:
     - type: Transform
       pos: 1.5,-37.5
       parent: 1
-  - uid: 957
+  - uid: 947
     components:
     - type: Transform
       pos: 1.5,41.5
       parent: 1
-  - uid: 958
+  - uid: 948
     components:
     - type: Transform
       pos: -7.5,-36.5
       parent: 1
 - proto: CMPottedPlant6
   entities:
-  - uid: 959
+  - uid: 949
     components:
     - type: Transform
       pos: 2.778807,67.306625
       parent: 1
-  - uid: 960
+  - uid: 950
     components:
     - type: Transform
-      pos: -1.5,40.5
+      pos: -1.4968992,40.46004
       parent: 1
 - proto: CMRack
   entities:
-  - uid: 961
+  - uid: 951
     components:
     - type: Transform
       pos: -5.5,-14.5
       parent: 1
-  - uid: 962
+  - uid: 952
     components:
     - type: Transform
       pos: -4.5,-14.5
       parent: 1
-  - uid: 963
+  - uid: 953
     components:
     - type: Transform
       pos: 1.5,-26.5
       parent: 1
-  - uid: 964
+  - uid: 954
     components:
     - type: Transform
       pos: 1.5,-27.5
       parent: 1
-  - uid: 965
+  - uid: 955
     components:
     - type: Transform
       pos: 5.5,-21.5
       parent: 1
-  - uid: 966
+  - uid: 956
     components:
     - type: Transform
       pos: 6.5,-21.5
       parent: 1
-  - uid: 967
+  - uid: 957
     components:
     - type: Transform
       pos: 6.5,-24.5
       parent: 1
-  - uid: 968
+  - uid: 958
     components:
     - type: Transform
       pos: 5.5,-24.5
       parent: 1
-  - uid: 969
+  - uid: 959
     components:
     - type: Transform
       pos: 11.5,-24.5
       parent: 1
-  - uid: 970
+  - uid: 960
     components:
     - type: Transform
       pos: 11.5,-25.5
       parent: 1
-  - uid: 971
+  - uid: 961
     components:
     - type: Transform
       pos: -10.5,43.5
       parent: 1
-  - uid: 972
+  - uid: 962
     components:
     - type: Transform
       pos: -33.5,9.5
       parent: 1
-  - uid: 973
+  - uid: 963
     components:
     - type: Transform
       pos: 10.5,-3.5
       parent: 1
-  - uid: 974
+  - uid: 964
     components:
     - type: Transform
       pos: -9.5,-68.5
       parent: 1
-  - uid: 975
+  - uid: 965
     components:
     - type: Transform
       pos: -8.5,-68.5
       parent: 1
-  - uid: 976
+  - uid: 966
     components:
     - type: Transform
       pos: -5.5,-68.5
       parent: 1
-  - uid: 977
+  - uid: 967
     components:
     - type: Transform
       pos: -4.5,-68.5
       parent: 1
-  - uid: 978
+  - uid: 968
     components:
     - type: Transform
       pos: -6.5,-68.5
       parent: 1
-  - uid: 979
+  - uid: 969
     components:
     - type: Transform
       pos: 27.5,2.5
       parent: 1
-  - uid: 980
+  - uid: 970
     components:
     - type: Transform
       pos: 27.5,1.5
       parent: 1
-  - uid: 981
+  - uid: 971
     components:
     - type: Transform
       pos: 2.5,-65.5
       parent: 1
-  - uid: 982
+  - uid: 972
     components:
     - type: Transform
       pos: 3.5,-65.5
       parent: 1
-  - uid: 983
+  - uid: 973
     components:
     - type: Transform
       pos: 4.5,-65.5
       parent: 1
-  - uid: 984
+  - uid: 974
     components:
     - type: Transform
       pos: -5.5,-57.5
       parent: 1
-  - uid: 985
+  - uid: 975
     components:
     - type: Transform
       pos: -6.5,-57.5
       parent: 1
-  - uid: 986
+  - uid: 976
     components:
     - type: Transform
       pos: 26.5,22.5
       parent: 1
-  - uid: 987
+  - uid: 977
     components:
     - type: Transform
       pos: 27.5,22.5
       parent: 1
-  - uid: 988
+  - uid: 978
     components:
     - type: Transform
       pos: 27.5,21.5
       parent: 1
-  - uid: 989
+  - uid: 979
     components:
     - type: Transform
       pos: 28.5,22.5
       parent: 1
-  - uid: 990
+  - uid: 980
     components:
     - type: Transform
       pos: 28.5,21.5
       parent: 1
-  - uid: 991
+  - uid: 981
     components:
     - type: Transform
       pos: 26.5,21.5
       parent: 1
-  - uid: 992
+  - uid: 982
     components:
     - type: Transform
       pos: 29.5,21.5
       parent: 1
-  - uid: 993
+  - uid: 983
     components:
     - type: Transform
       pos: 23.5,18.5
       parent: 1
-  - uid: 994
+  - uid: 984
     components:
     - type: Transform
       pos: 23.5,16.5
       parent: 1
-  - uid: 995
+  - uid: 985
     components:
     - type: Transform
       pos: 23.5,15.5
       parent: 1
-  - uid: 996
+  - uid: 986
     components:
     - type: Transform
       pos: 23.5,17.5
       parent: 1
-  - uid: 997
+  - uid: 987
     components:
     - type: Transform
       pos: 26.5,11.5
       parent: 1
-  - uid: 998
+  - uid: 988
     components:
     - type: Transform
       pos: 27.5,11.5
       parent: 1
-  - uid: 999
+  - uid: 989
     components:
     - type: Transform
       pos: 28.5,11.5
       parent: 1
-  - uid: 1000
+  - uid: 990
     components:
     - type: Transform
       pos: 30.5,11.5
       parent: 1
-  - uid: 1001
+  - uid: 991
     components:
     - type: Transform
       pos: 31.5,11.5
       parent: 1
-  - uid: 1002
+  - uid: 992
     components:
     - type: Transform
       pos: 29.5,11.5
       parent: 1
+  - uid: 993
+    components:
+    - type: Transform
+      pos: 32.5,9.5
+      parent: 1
+  - uid: 994
+    components:
+    - type: Transform
+      pos: 31.5,9.5
+      parent: 1
+  - uid: 995
+    components:
+    - type: Transform
+      pos: 30.5,9.5
+      parent: 1
 - proto: CMRailing
   entities:
-  - uid: 1003
+  - uid: 996
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,15.5
       parent: 1
-  - uid: 1004
+  - uid: 997
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,13.5
       parent: 1
-  - uid: 1005
+  - uid: 998
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,13.5
       parent: 1
-  - uid: 1006
+  - uid: 999
     components:
     - type: Transform
       pos: 27.5,19.5
       parent: 1
-  - uid: 1007
+  - uid: 1000
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,13.5
       parent: 1
-  - uid: 1008
+  - uid: 1001
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,16.5
       parent: 1
-  - uid: 1009
+  - uid: 1002
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,17.5
       parent: 1
-  - uid: 1010
+  - uid: 1003
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,14.5
       parent: 1
-  - uid: 1011
+  - uid: 1004
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,13.5
       parent: 1
-  - uid: 1012
+  - uid: 1005
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,13.5
       parent: 1
-  - uid: 1013
+  - uid: 1006
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,18.5
       parent: 1
-  - uid: 1014
+  - uid: 1007
     components:
     - type: Transform
       pos: 30.5,19.5
       parent: 1
-  - uid: 1015
+  - uid: 1008
     components:
     - type: Transform
       pos: 29.5,19.5
       parent: 1
-  - uid: 1016
+  - uid: 1009
     components:
     - type: Transform
       pos: 31.5,19.5
       parent: 1
-  - uid: 1017
+  - uid: 1010
     components:
     - type: Transform
       pos: 28.5,19.5
       parent: 1
-  - uid: 1018
+  - uid: 1011
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,18.5
       parent: 1
-  - uid: 1019
+  - uid: 1012
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,17.5
       parent: 1
-  - uid: 1020
+  - uid: 1013
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,16.5
       parent: 1
-  - uid: 1021
+  - uid: 1014
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,15.5
       parent: 1
-  - uid: 1022
+  - uid: 1015
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12904,68 +12861,68 @@ entities:
       parent: 1
 - proto: CMRollerBedSpawnFolded
   entities:
-  - uid: 1023
+  - uid: 1016
     components:
     - type: Transform
       pos: -33.5,9.5
       parent: 1
-  - uid: 1024
+  - uid: 1017
     components:
     - type: Transform
       pos: -33.5,9.5
       parent: 1
-  - uid: 1025
+  - uid: 1018
     components:
     - type: Transform
       pos: -33.5,9.5
       parent: 1
-  - uid: 1026
+  - uid: 1019
     components:
     - type: Transform
       pos: -33.5,9.5
       parent: 1
-  - uid: 1027
+  - uid: 1020
     components:
     - type: Transform
       pos: -33.5,9.5
       parent: 1
 - proto: CMSemioticEscapepod
   entities:
-  - uid: 1028
+  - uid: 1021
     components:
     - type: Transform
       pos: 26.5,-0.5
       parent: 1
-  - uid: 1029
+  - uid: 1022
     components:
     - type: Transform
       pos: 15,-57.5
       parent: 1
-  - uid: 1030
+  - uid: 1023
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18,-23.5
       parent: 1
-  - uid: 1031
+  - uid: 1024
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-57.5
       parent: 1
-  - uid: 1032
+  - uid: 1025
     components:
     - type: Transform
       pos: 17.5,-23.5
       parent: 1
-  - uid: 1033
+  - uid: 1026
     components:
     - type: Transform
       pos: -25.5,-0.5
       parent: 1
 - proto: CMSemioticHigh_voltage
   entities:
-  - uid: 1034
+  - uid: 1027
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12973,56 +12930,56 @@ entities:
       parent: 1
 - proto: CMSemioticOne
   entities:
-  - uid: 1035
+  - uid: 1028
     components:
     - type: Transform
       pos: 3.5,-21.5
       parent: 1
 - proto: CMSemioticSeven
   entities:
-  - uid: 1036
+  - uid: 1029
     components:
     - type: Transform
       pos: -4.0519705,-0.49589586
       parent: 1
 - proto: CMSemioticSix
   entities:
-  - uid: 1037
+  - uid: 1030
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
 - proto: CMSemioticThree
   entities:
-  - uid: 1038
+  - uid: 1031
     components:
     - type: Transform
       pos: 8.5,-27.5
       parent: 1
 - proto: CMSemioticTwo
   entities:
-  - uid: 1039
+  - uid: 1032
     components:
     - type: Transform
       pos: 3.5,-24.5
       parent: 1
 - proto: CMSheetGlass
   entities:
-  - uid: 1040
+  - uid: 1033
     components:
     - type: Transform
-      pos: -27.62094,24.582115
+      pos: -26.496798,24.404198
       parent: 1
 - proto: CMSheetMetal50
   entities:
-  - uid: 1041
+  - uid: 1034
     components:
     - type: Transform
-      pos: -27.579273,24.63767
+      pos: -26.945839,24.4389
       parent: 1
 - proto: CMShower
   entities:
-  - uid: 1042
+  - uid: 1035
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13030,7 +12987,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1043
+  - uid: 1036
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13038,7 +12995,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1044
+  - uid: 1037
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13046,7 +13003,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1045
+  - uid: 1038
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13054,7 +13011,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1046
+  - uid: 1039
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13062,7 +13019,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1047
+  - uid: 1040
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13070,7 +13027,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1048
+  - uid: 1041
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13078,7 +13035,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1049
+  - uid: 1042
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13086,7 +13043,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1050
+  - uid: 1043
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13094,7 +13051,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1051
+  - uid: 1044
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13102,7 +13059,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1052
+  - uid: 1045
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13110,7 +13067,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1053
+  - uid: 1046
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13118,7 +13075,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1054
+  - uid: 1047
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13126,7 +13083,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1055
+  - uid: 1048
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13134,7 +13091,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1056
+  - uid: 1049
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13144,190 +13101,190 @@ entities:
       fixtures: {}
 - proto: CMSink
   entities:
-  - uid: 1057
+  - uid: 1050
     components:
     - type: Transform
       pos: 10.5,49
       parent: 1
-  - uid: 1058
+  - uid: 1051
     components:
     - type: Transform
       pos: -2.5,44
       parent: 1
-  - uid: 1059
+  - uid: 1052
     components:
     - type: Transform
       pos: 7.5,-41
       parent: 1
-  - uid: 1060
+  - uid: 1053
     components:
     - type: Transform
       pos: 10.5,-41
       parent: 1
-  - uid: 1061
+  - uid: 1054
     components:
     - type: Transform
       pos: 4.5,-41
       parent: 1
-  - uid: 1062
+  - uid: 1055
     components:
     - type: Transform
       pos: -10.5,-21.5
       parent: 1
-  - uid: 1063
+  - uid: 1056
     components:
     - type: Transform
       pos: 1.5,-41
       parent: 1
-  - uid: 1064
+  - uid: 1057
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-48.5
       parent: 1
-  - uid: 1065
+  - uid: 1058
     components:
     - type: Transform
       pos: -32.5,20
       parent: 1
-  - uid: 1066
+  - uid: 1059
     components:
     - type: Transform
       pos: -32.5,16
       parent: 1
 - proto: CMSoap
   entities:
-  - uid: 1067
+  - uid: 1060
     components:
     - type: Transform
       pos: 11.652229,-25.339302
       parent: 1
-  - uid: 1068
+  - uid: 1061
     components:
     - type: Transform
       pos: 11.662645,-25.662218
       parent: 1
-  - uid: 1069
+  - uid: 1062
     components:
     - type: Transform
       pos: 11.277229,-25.651802
       parent: 1
-  - uid: 1070
+  - uid: 1063
     components:
     - type: Transform
       pos: 11.277229,-25.349718
       parent: 1
-  - uid: 1071
+  - uid: 1064
     components:
     - type: Transform
       pos: -17.70947,-11.9320755
       parent: 1
-  - uid: 1072
+  - uid: 1065
     components:
     - type: Transform
       pos: -17.261553,-11.942493
       parent: 1
-  - uid: 1073
+  - uid: 1066
     components:
     - type: Transform
       pos: -17.70947,-12.286243
       parent: 1
-  - uid: 1074
+  - uid: 1067
     components:
     - type: Transform
       pos: -17.251137,-12.286243
       parent: 1
 - proto: CMSoapNT
   entities:
-  - uid: 1075
+  - uid: 1068
     components:
     - type: Transform
-      pos: 1.5921679,-51.478252
+      pos: 1.5584004,-51.34375
       parent: 1
-  - uid: 1076
+  - uid: 1069
     components:
     - type: Transform
       pos: -33.668247,15.333546
       parent: 1
-  - uid: 1077
+  - uid: 1070
     components:
     - type: Transform
       pos: -33.70494,19.406334
       parent: 1
 - proto: CMStampApproved
   entities:
-  - uid: 1078
+  - uid: 1071
     components:
     - type: Transform
       pos: -2.2645073,58.037823
       parent: 1
 - proto: CMStampDenied
   entities:
-  - uid: 1079
+  - uid: 1072
     components:
     - type: Transform
       pos: -2.2540913,57.756573
       parent: 1
 - proto: CMSyringe
   entities:
-  - uid: 1080
+  - uid: 1073
     components:
     - type: Transform
       pos: -26.54519,14.848053
       parent: 1
-  - uid: 1081
+  - uid: 1074
     components:
     - type: Transform
       pos: -26.398422,14.640133
       parent: 1
 - proto: CMTableAlmayer
   entities:
-  - uid: 1082
+  - uid: 1075
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
-  - uid: 1083
+  - uid: 1076
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-7.5
       parent: 1
-  - uid: 1084
+  - uid: 1077
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-11.5
       parent: 1
-  - uid: 1085
+  - uid: 1078
     components:
     - type: Transform
       pos: -11.5,-1.5
       parent: 1
-  - uid: 1086
+  - uid: 1079
     components:
     - type: Transform
       pos: -17.5,-1.5
       parent: 1
-  - uid: 1087
+  - uid: 1080
     components:
     - type: Transform
       pos: -17.5,-11.5
       parent: 1
-  - uid: 1088
+  - uid: 1081
     components:
     - type: Transform
       pos: -17.5,-12.5
       parent: 1
-  - uid: 1089
+  - uid: 1082
     components:
     - type: Transform
       pos: -8.5,-14.5
       parent: 1
 - proto: CMTableReinforcedBlack
   entities:
-  - uid: 1090
+  - uid: 1083
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13335,957 +13292,952 @@ entities:
       parent: 1
 - proto: CMTableReinforcedRequisition
   entities:
-  - uid: 1091
+  - uid: 1084
     components:
     - type: Transform
       pos: -12.5,-36.5
       parent: 1
-  - uid: 1092
+  - uid: 1085
     components:
     - type: Transform
       pos: 2.5,43.5
       parent: 1
-  - uid: 1093
+  - uid: 1086
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-43.5
       parent: 1
-  - uid: 1094
+  - uid: 1087
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-48.5
       parent: 1
-  - uid: 1095
+  - uid: 1088
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-44.5
       parent: 1
-  - uid: 1096
+  - uid: 1089
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-47.5
       parent: 1
-  - uid: 1097
+  - uid: 1090
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-2.5
       parent: 1
-  - uid: 1098
+  - uid: 1091
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-2.5
       parent: 1
-  - uid: 1099
+  - uid: 1092
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-50.5
       parent: 1
-  - uid: 1100
+  - uid: 1093
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-50.5
       parent: 1
-  - uid: 1101
+  - uid: 1094
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-42.5
       parent: 1
-  - uid: 1102
+  - uid: 1095
     components:
     - type: Transform
       pos: -10.5,-32.5
       parent: 1
-  - uid: 1103
+  - uid: 1096
     components:
     - type: Transform
       pos: -10.5,-33.5
       parent: 1
-  - uid: 1104
+  - uid: 1097
     components:
     - type: Transform
       pos: -6.5,-33.5
       parent: 1
-  - uid: 1105
+  - uid: 1098
     components:
     - type: Transform
       pos: -10.5,-31.5
       parent: 1
-  - uid: 1106
+  - uid: 1099
     components:
     - type: Transform
       pos: -10.5,-30.5
       parent: 1
-  - uid: 1107
+  - uid: 1100
     components:
     - type: Transform
       pos: -6.5,-31.5
       parent: 1
-  - uid: 1108
+  - uid: 1101
     components:
     - type: Transform
       pos: -6.5,-31.5
       parent: 1
-  - uid: 1109
+  - uid: 1102
     components:
     - type: Transform
       pos: -6.5,-32.5
       parent: 1
-  - uid: 1110
+  - uid: 1103
     components:
     - type: Transform
       pos: -6.5,-30.5
       parent: 1
-  - uid: 1111
+  - uid: 1104
     components:
     - type: Transform
       pos: -2.5,-30.5
       parent: 1
-  - uid: 1112
+  - uid: 1105
     components:
     - type: Transform
       pos: -2.5,-31.5
       parent: 1
-  - uid: 1113
+  - uid: 1106
     components:
     - type: Transform
       pos: -2.5,-32.5
       parent: 1
-  - uid: 1114
+  - uid: 1107
     components:
     - type: Transform
       pos: -2.5,-33.5
       parent: 1
-  - uid: 1115
+  - uid: 1108
     components:
     - type: Transform
       pos: -7.5,-34.5
       parent: 1
-  - uid: 1116
+  - uid: 1109
     components:
     - type: Transform
       pos: -5.5,-34.5
       parent: 1
-  - uid: 1117
+  - uid: 1110
     components:
     - type: Transform
       pos: 8.5,-21.5
       parent: 1
-  - uid: 1118
+  - uid: 1111
     components:
     - type: Transform
       pos: 8.5,-24.5
       parent: 1
-  - uid: 1119
+  - uid: 1112
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-27.5
       parent: 1
-  - uid: 1120
+  - uid: 1113
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-27.5
       parent: 1
-  - uid: 1121
+  - uid: 1114
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-27.5
       parent: 1
-  - uid: 1122
+  - uid: 1115
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-27.5
       parent: 1
-  - uid: 1123
+  - uid: 1116
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-27.5
       parent: 1
-  - uid: 1124
+  - uid: 1117
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-27.5
       parent: 1
-  - uid: 1125
+  - uid: 1118
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,67.5
       parent: 1
-  - uid: 1126
+  - uid: 1119
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,67.5
       parent: 1
-  - uid: 1127
+  - uid: 1120
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,57.5
       parent: 1
-  - uid: 1128
+  - uid: 1121
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,61.5
       parent: 1
-  - uid: 1129
+  - uid: 1122
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,61.5
       parent: 1
-  - uid: 1130
+  - uid: 1123
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,61.5
       parent: 1
-  - uid: 1131
+  - uid: 1124
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,60.5
       parent: 1
-  - uid: 1132
+  - uid: 1125
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,59.5
       parent: 1
-  - uid: 1133
+  - uid: 1126
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,58.5
       parent: 1
-  - uid: 1134
+  - uid: 1127
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,57.5
       parent: 1
-  - uid: 1135
+  - uid: 1128
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,64.5
       parent: 1
-  - uid: 1136
+  - uid: 1129
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,65.5
       parent: 1
-  - uid: 1137
+  - uid: 1130
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,65.5
       parent: 1
-  - uid: 1138
+  - uid: 1131
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,65.5
       parent: 1
-  - uid: 1139
+  - uid: 1132
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,64.5
       parent: 1
-  - uid: 1140
+  - uid: 1133
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,70.5
       parent: 1
-  - uid: 1141
+  - uid: 1134
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,70.5
       parent: 1
-  - uid: 1142
+  - uid: 1135
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,70.5
       parent: 1
-  - uid: 1143
+  - uid: 1136
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,67.5
       parent: 1
-  - uid: 1144
+  - uid: 1137
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,66.5
       parent: 1
-  - uid: 1145
+  - uid: 1138
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,65.5
       parent: 1
-  - uid: 1146
+  - uid: 1139
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,65.5
       parent: 1
-  - uid: 1147
+  - uid: 1140
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,66.5
       parent: 1
-  - uid: 1148
+  - uid: 1141
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,67.5
       parent: 1
-  - uid: 1149
+  - uid: 1142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-50.5
       parent: 1
-  - uid: 1150
+  - uid: 1143
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-51.5
       parent: 1
-  - uid: 1151
+  - uid: 1144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-5.5
       parent: 1
-  - uid: 1152
+  - uid: 1145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-50.5
       parent: 1
-  - uid: 1153
+  - uid: 1146
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,-5.5
       parent: 1
-  - uid: 1154
+  - uid: 1147
     components:
     - type: Transform
       pos: 7.5,-34.5
       parent: 1
-  - uid: 1155
+  - uid: 1148
     components:
     - type: Transform
       pos: 4.5,-34.5
       parent: 1
-  - uid: 1156
+  - uid: 1149
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-34.5
       parent: 1
-  - uid: 1157
+  - uid: 1150
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-35.5
       parent: 1
-  - uid: 1158
+  - uid: 1151
     components:
     - type: Transform
       pos: 5.5,-34.5
       parent: 1
-  - uid: 1159
+  - uid: 1152
     components:
     - type: Transform
       pos: 10.5,-32.5
       parent: 1
-  - uid: 1160
+  - uid: 1153
     components:
     - type: Transform
       pos: 7.5,-32.5
       parent: 1
-  - uid: 1161
+  - uid: 1154
     components:
     - type: Transform
       pos: 6.5,-32.5
       parent: 1
-  - uid: 1162
+  - uid: 1155
     components:
     - type: Transform
       pos: 10.5,-31.5
       parent: 1
-  - uid: 1163
+  - uid: 1156
     components:
     - type: Transform
       pos: 5.5,-35.5
       parent: 1
-  - uid: 1164
+  - uid: 1157
     components:
     - type: Transform
       pos: 6.5,-34.5
       parent: 1
-  - uid: 1165
+  - uid: 1158
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-5.5
       parent: 1
-  - uid: 1166
+  - uid: 1159
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-5.5
       parent: 1
-  - uid: 1167
+  - uid: 1160
     components:
     - type: Transform
       pos: 9.5,-8.5
       parent: 1
-  - uid: 1168
+  - uid: 1161
     components:
     - type: Transform
       pos: 5.5,-11.5
       parent: 1
-  - uid: 1169
+  - uid: 1162
     components:
     - type: Transform
       pos: 5.5,-8.5
       parent: 1
-  - uid: 1170
+  - uid: 1163
     components:
     - type: Transform
       pos: 9.5,-11.5
       parent: 1
-  - uid: 1171
+  - uid: 1164
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-48.5
       parent: 1
-  - uid: 1172
+  - uid: 1165
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-2.5
       parent: 1
-  - uid: 1173
+  - uid: 1166
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-42.5
       parent: 1
-  - uid: 1174
+  - uid: 1167
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-45.5
       parent: 1
-  - uid: 1175
+  - uid: 1168
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-46.5
       parent: 1
-  - uid: 1176
+  - uid: 1169
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,39.5
       parent: 1
-  - uid: 1177
+  - uid: 1170
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-2.5
       parent: 1
-  - uid: 1178
+  - uid: 1171
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-2.5
       parent: 1
-  - uid: 1179
+  - uid: 1172
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-2.5
       parent: 1
-  - uid: 1180
+  - uid: 1173
     components:
     - type: Transform
       pos: 1.5,-37.5
       parent: 1
-  - uid: 1181
+  - uid: 1174
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,-2.5
       parent: 1
-  - uid: 1182
+  - uid: 1175
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-2.5
       parent: 1
-  - uid: 1183
+  - uid: 1176
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-2.5
       parent: 1
-  - uid: 1184
+  - uid: 1177
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,-2.5
       parent: 1
-  - uid: 1185
+  - uid: 1178
     components:
     - type: Transform
       pos: 18.5,0.5
       parent: 1
-  - uid: 1186
+  - uid: 1179
     components:
     - type: Transform
       pos: 17.5,1.5
       parent: 1
-  - uid: 1187
+  - uid: 1180
     components:
     - type: Transform
       pos: -18.5,1.5
       parent: 1
-  - uid: 1188
+  - uid: 1181
     components:
     - type: Transform
       pos: -19.5,0.5
       parent: 1
-  - uid: 1189
+  - uid: 1182
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-32.5
       parent: 1
-  - uid: 1190
+  - uid: 1183
     components:
     - type: Transform
       pos: 8.5,-48.5
       parent: 1
-  - uid: 1191
+  - uid: 1184
     components:
     - type: Transform
       pos: 9.5,-48.5
       parent: 1
-  - uid: 1192
+  - uid: 1185
     components:
     - type: Transform
       pos: 10.5,-48.5
       parent: 1
-  - uid: 1193
+  - uid: 1186
     components:
     - type: Transform
       pos: 11.5,-48.5
       parent: 1
-  - uid: 1194
+  - uid: 1187
     components:
     - type: Transform
       pos: 11.5,-47.5
       parent: 1
-  - uid: 1195
+  - uid: 1188
     components:
     - type: Transform
       pos: 2.5,-46.5
       parent: 1
-  - uid: 1196
+  - uid: 1189
     components:
     - type: Transform
       pos: 3.5,-46.5
       parent: 1
-  - uid: 1197
+  - uid: 1190
     components:
     - type: Transform
       pos: 6.5,-45.5
       parent: 1
-  - uid: 1198
+  - uid: 1191
     components:
     - type: Transform
       pos: 7.5,-45.5
       parent: 1
-  - uid: 1199
+  - uid: 1192
     components:
     - type: Transform
       pos: -31.5,15.5
       parent: 1
-  - uid: 1200
+  - uid: 1193
     components:
     - type: Transform
       pos: 8.5,-32.5
       parent: 1
-  - uid: 1201
+  - uid: 1194
     components:
     - type: Transform
       pos: -33.5,19.5
       parent: 1
-  - uid: 1202
+  - uid: 1195
     components:
     - type: Transform
       pos: -33.5,15.5
       parent: 1
-  - uid: 1203
+  - uid: 1196
     components:
     - type: Transform
       pos: -31.5,19.5
       parent: 1
-  - uid: 1204
+  - uid: 1197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,10.5
       parent: 1
-  - uid: 1205
+  - uid: 1198
     components:
     - type: Transform
       pos: -26.5,25.5
       parent: 1
-  - uid: 1206
+  - uid: 1199
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -26.5,20.5
       parent: 1
-  - uid: 1207
+  - uid: 1200
     components:
     - type: Transform
       pos: -26.5,17.5
       parent: 1
-  - uid: 1208
+  - uid: 1201
     components:
     - type: Transform
       pos: -26.5,15.5
       parent: 1
-  - uid: 1209
+  - uid: 1202
     components:
     - type: Transform
       pos: -26.5,14.5
       parent: 1
-  - uid: 1210
+  - uid: 1203
     components:
     - type: Transform
       pos: -26.5,13.5
       parent: 1
-  - uid: 1211
+  - uid: 1204
     components:
     - type: Transform
       pos: -12.5,-59.5
       parent: 1
-  - uid: 1212
+  - uid: 1205
     components:
     - type: Transform
       pos: -12.5,-58.5
       parent: 1
-  - uid: 1213
+  - uid: 1206
     components:
     - type: Transform
       pos: -12.5,-57.5
       parent: 1
-  - uid: 1214
+  - uid: 1207
     components:
     - type: Transform
       pos: -11.5,-57.5
       parent: 1
-  - uid: 1215
+  - uid: 1208
     components:
     - type: Transform
       pos: -2.5,-67.5
       parent: 1
-  - uid: 1216
+  - uid: 1209
     components:
     - type: Transform
       pos: -2.5,-68.5
       parent: 1
-  - uid: 1217
+  - uid: 1210
     components:
     - type: Transform
       pos: -10.5,-68.5
       parent: 1
-  - uid: 1218
+  - uid: 1211
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,3.5
       parent: 1
-  - uid: 1219
+  - uid: 1212
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,3.5
       parent: 1
-  - uid: 1220
+  - uid: 1213
     components:
     - type: Transform
       pos: 2.5,-60.5
       parent: 1
-  - uid: 1221
+  - uid: 1214
     components:
     - type: Transform
       pos: 1.5,-60.5
       parent: 1
-  - uid: 1222
+  - uid: 1215
     components:
     - type: Transform
       pos: 1.5,-61.5
       parent: 1
-  - uid: 1223
+  - uid: 1216
     components:
     - type: Transform
       pos: 1.5,-62.5
       parent: 1
-  - uid: 1224
+  - uid: 1217
     components:
     - type: Transform
       pos: 1.5,-63.5
       parent: 1
-  - uid: 1225
+  - uid: 1218
     components:
     - type: Transform
       pos: 8.5,-61.5
       parent: 1
-  - uid: 1226
+  - uid: 1219
     components:
     - type: Transform
       pos: 9.5,-61.5
       parent: 1
-  - uid: 1227
+  - uid: 1220
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-57.5
       parent: 1
-  - uid: 1228
+  - uid: 1221
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-57.5
       parent: 1
-  - uid: 1229
+  - uid: 1222
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-57.5
       parent: 1
-  - uid: 1230
+  - uid: 1223
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-57.5
       parent: 1
-  - uid: 1231
+  - uid: 1224
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-57.5
       parent: 1
-  - uid: 1232
+  - uid: 1225
     components:
     - type: Transform
       pos: 23.5,23.5
       parent: 1
-  - uid: 1233
+  - uid: 1226
     components:
     - type: Transform
       pos: 22.5,22.5
       parent: 1
-  - uid: 1234
+  - uid: 1227
     components:
     - type: Transform
       pos: -1.5,46.5
       parent: 1
-  - uid: 1235
+  - uid: 1228
     components:
     - type: Transform
       pos: -2.5,46.5
       parent: 1
-  - uid: 1236
+  - uid: 1229
     components:
     - type: Transform
       pos: -0.5,46.5
       parent: 1
-  - uid: 1237
+  - uid: 1230
     components:
     - type: Transform
       pos: 23.5,19.5
       parent: 1
-  - uid: 1238
+  - uid: 1231
     components:
     - type: Transform
       pos: 24.5,19.5
       parent: 1
-  - uid: 1239
+  - uid: 1232
     components:
     - type: Transform
       pos: 23.5,21.5
       parent: 1
-  - uid: 1240
+  - uid: 1233
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,39.5
       parent: 1
-  - uid: 1241
+  - uid: 1234
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,42.5
       parent: 1
-  - uid: 1242
+  - uid: 1235
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,39.5
       parent: 1
-  - uid: 1243
+  - uid: 1236
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,43.5
       parent: 1
-  - uid: 1244
+  - uid: 1237
     components:
     - type: Transform
       pos: -7.5,-36.5
       parent: 1
-  - uid: 4646
-    components:
-    - type: Transform
-      pos: 7.5,-29.5
-      parent: 1
 - proto: CMTableWoodenFancy
   entities:
-  - uid: 1245
+  - uid: 1238
     components:
     - type: Transform
       pos: -17.5,46.5
       parent: 1
-  - uid: 1246
+  - uid: 1239
     components:
     - type: Transform
       pos: -12.5,46.5
       parent: 1
-  - uid: 1247
+  - uid: 1240
     components:
     - type: Transform
       pos: -16.5,46.5
       parent: 1
-  - uid: 1248
+  - uid: 1241
     components:
     - type: Transform
       pos: -11.5,46.5
       parent: 1
-  - uid: 1249
+  - uid: 1242
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,48.5
       parent: 1
-  - uid: 1250
+  - uid: 1243
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,46.5
       parent: 1
-  - uid: 1251
+  - uid: 1244
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,45.5
       parent: 1
-  - uid: 1252
+  - uid: 1245
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,47.5
       parent: 1
-  - uid: 1253
+  - uid: 1246
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,47.5
       parent: 1
-  - uid: 1254
+  - uid: 1247
     components:
     - type: Transform
       pos: 1.5,-30.5
       parent: 1
-  - uid: 1255
+  - uid: 1248
     components:
     - type: Transform
       pos: 3.5,-30.5
       parent: 1
-  - uid: 1256
+  - uid: 1249
     components:
     - type: Transform
       pos: 2.5,-30.5
       parent: 1
-  - uid: 1257
+  - uid: 1250
     components:
     - type: Transform
       pos: 13.5,48.5
       parent: 1
-  - uid: 1258
+  - uid: 1251
     components:
     - type: Transform
       pos: 13.5,46.5
       parent: 1
-  - uid: 1259
+  - uid: 1252
     components:
     - type: Transform
       pos: 13.5,47.5
       parent: 1
-  - uid: 1260
+  - uid: 1253
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,46.5
       parent: 1
-  - uid: 1261
+  - uid: 1254
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,47.5
       parent: 1
-  - uid: 1262
+  - uid: 1255
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,46.5
       parent: 1
-  - uid: 1263
+  - uid: 1256
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14293,258 +14245,265 @@ entities:
       parent: 1
 - proto: CMTelecomServer
   entities:
-  - uid: 1264
+  - uid: 1257
     components:
     - type: Transform
       pos: -12.5,-9.5
       parent: 1
 - proto: CMToiletEmpty
   entities:
-  - uid: 1265
+  - uid: 1258
     components:
     - type: Transform
       pos: 9.5,48.5
       parent: 1
-  - uid: 1266
+    - type: Toilet
+      toggleSeat: True
+  - uid: 1259
     components:
     - type: Transform
       pos: -3.5,43.5
       parent: 1
-  - uid: 1267
+  - uid: 1260
     components:
     - type: Transform
       pos: 1.5,-49.5
       parent: 1
-  - uid: 1268
+    - type: Toilet
+      toggleSeat: True
+  - uid: 1261
     components:
     - type: Transform
       pos: 5.5,-49.5
       parent: 1
-  - uid: 1269
+    - type: Toilet
+      toggleSeat: True
+  - uid: 1262
     components:
     - type: Transform
       pos: 4.5,-49.5
       parent: 1
-  - uid: 1270
+    - type: Toilet
+      toggleSeat: True
+  - uid: 1263
     components:
     - type: Transform
       pos: 2.5,-49.5
       parent: 1
-  - uid: 1271
+    - type: Toilet
+      toggleSeat: True
+  - uid: 1264
     components:
     - type: Transform
       pos: 3.5,-49.5
       parent: 1
+    - type: Toilet
+      toggleSeat: True
 - proto: CMVendorCassettes
   entities:
-  - uid: 1272
+  - uid: 1265
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 1
-  - uid: 1273
+  - uid: 1266
     components:
     - type: Transform
       pos: -11.5,-34.5
       parent: 1
-  - uid: 1274
+  - uid: 1267
     components:
     - type: Transform
       pos: 11.5,-21.5
       parent: 1
-  - uid: 1275
+  - uid: 1268
     components:
     - type: Transform
       pos: 2.5,58.5
       parent: 1
 - proto: CMVendorChemistry
   entities:
-  - uid: 1276
+  - uid: 1269
     components:
     - type: Transform
       pos: -27.5,21.5
       parent: 1
-- proto: CMVendorChess
-  entities:
-  - uid: 1277
-    components:
-    - type: Transform
-      pos: 11.5,-45.5
-      parent: 1
 - proto: CMVendorCigs
   entities:
-  - uid: 1278
+  - uid: 1270
     components:
     - type: Transform
       pos: -8.5,-1.5
       parent: 1
-  - uid: 1279
+  - uid: 1271
     components:
     - type: Transform
       pos: -9.5,-34.5
       parent: 1
-  - uid: 1280
+  - uid: 1272
     components:
     - type: Transform
       pos: 9.5,-21.5
       parent: 1
-  - uid: 1281
+  - uid: 1273
     components:
     - type: Transform
       pos: 2.5,57.5
       parent: 1
-  - uid: 1282
+  - uid: 1274
     components:
     - type: Transform
       pos: -3.5,-37.5
       parent: 1
 - proto: CMVendorCoffee
   entities:
-  - uid: 1283
+  - uid: 1275
     components:
     - type: Transform
       pos: -4.5,68.5
       parent: 1
-  - uid: 1284
+  - uid: 1276
     components:
     - type: Transform
       pos: 1.5,-35.5
       parent: 1
-  - uid: 1285
+  - uid: 1277
     components:
     - type: Transform
       pos: -18.5,3.5
       parent: 1
-  - uid: 1286
+  - uid: 1278
+    components:
+    - type: Transform
+      pos: 11.5,-45.5
+      parent: 1
+  - uid: 1279
     components:
     - type: Transform
       pos: 4.5,-63.5
       parent: 1
-  - uid: 1287
+  - uid: 1280
     components:
     - type: Transform
       pos: -5.5,-37.5
       parent: 1
-  - uid: 1288
+  - uid: 1281
     components:
     - type: Transform
       pos: -3.5,-34.5
       parent: 1
 - proto: CMVendorCola
   entities:
-  - uid: 1289
+  - uid: 1282
     components:
     - type: Transform
       pos: 1.5,-36.5
       parent: 1
 - proto: CMVendorDinnerware
   entities:
-  - uid: 1290
+  - uid: 1283
     components:
     - type: Transform
       pos: -12.5,-21.5
       parent: 1
 - proto: CMVendorElectronics
   entities:
-  - uid: 1291
+  - uid: 1284
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
 - proto: CMVendorIngredients
   entities:
-  - uid: 1292
+  - uid: 1285
     components:
     - type: Transform
       pos: -11.5,-21.5
       parent: 1
-  - uid: 1293
+  - uid: 1286
     components:
     - type: Transform
       pos: 11.5,-46.5
       parent: 1
 - proto: CMVendorSec
   entities:
-  - uid: 4648
+  - uid: 4652
     components:
     - type: Transform
-      pos: 9.5,-29.5
+      pos: 7.5,-29.5
       parent: 1
-    - type: AccessReader
-      access:
-      - - CMAccessBrig
 - proto: CMVendorSnack
   entities:
-  - uid: 1294
+  - uid: 1287
     components:
     - type: Transform
       pos: -1.5,-34.5
       parent: 1
-  - uid: 1295
+  - uid: 1288
     components:
     - type: Transform
       pos: -4.5,-37.5
       parent: 1
-  - uid: 1296
+  - uid: 1289
     components:
     - type: Transform
       pos: 10.5,-21.5
       parent: 1
-  - uid: 1297
+  - uid: 1290
     components:
     - type: Transform
       pos: 2.5,56.5
       parent: 1
-  - uid: 1298
+  - uid: 1291
     components:
     - type: Transform
       pos: 1.5,68.5
       parent: 1
-  - uid: 1299
+  - uid: 1292
     components:
     - type: Transform
       pos: 1.5,-34.5
       parent: 1
-  - uid: 1300
+  - uid: 1293
     components:
     - type: Transform
       pos: 4.5,-62.5
       parent: 1
 - proto: CMVendorSodaSoviet
   entities:
-  - uid: 1301
+  - uid: 1294
     components:
     - type: Transform
       pos: 4.5,-21.5
       parent: 1
 - proto: CMVendorTool
   entities:
-  - uid: 1302
+  - uid: 1295
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 1
 - proto: CMVentPump
   entities:
-  - uid: 1303
+  - uid: 1296
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-6.5
       parent: 1
-  - uid: 1304
+  - uid: 1297
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-6.5
       parent: 1
-  - uid: 1305
+  - uid: 1298
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 1
-  - uid: 1306
+  - uid: 1299
     components:
     - type: Transform
       anchored: False
@@ -14554,19 +14513,19 @@ entities:
     - type: Physics
       canCollide: True
       bodyType: Dynamic
-  - uid: 1307
+  - uid: 1300
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-10.5
       parent: 1
-  - uid: 1308
+  - uid: 1301
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 1
-  - uid: 1309
+  - uid: 1302
     components:
     - type: Transform
       anchored: False
@@ -14576,13 +14535,13 @@ entities:
     - type: Physics
       canCollide: True
       bodyType: Dynamic
-  - uid: 1310
+  - uid: 1303
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-10.5
       parent: 1
-  - uid: 1311
+  - uid: 1304
     components:
     - type: Transform
       anchored: False
@@ -14592,9574 +14551,9586 @@ entities:
     - type: Physics
       canCollide: True
       bodyType: Dynamic
-  - uid: 1312
+  - uid: 1305
     components:
     - type: Transform
       pos: 9.5,-68.5
       parent: 1
-  - uid: 1313
+  - uid: 1306
     components:
     - type: Transform
       pos: 11.5,-57.5
       parent: 1
 - proto: CMVentScrubber
   entities:
-  - uid: 1314
+  - uid: 1307
     components:
     - type: Transform
       pos: 9.5,-65.5
       parent: 1
-  - uid: 1315
+  - uid: 1308
     components:
     - type: Transform
       pos: 11.5,-59.5
       parent: 1
 - proto: CMWallMetalAlmayer
   entities:
-  - uid: 1316
+  - uid: 1309
     components:
     - type: Transform
       pos: -8.5,-15.5
       parent: 1
-  - uid: 1317
+  - uid: 1310
     components:
     - type: Transform
       pos: -14.5,-7.5
       parent: 1
-  - uid: 1318
+  - uid: 1311
     components:
     - type: Transform
       pos: -14.5,-2.5
       parent: 1
-  - uid: 1319
+  - uid: 1312
     components:
     - type: Transform
       pos: -14.5,-1.5
       parent: 1
-  - uid: 1320
+  - uid: 1313
     components:
     - type: Transform
       pos: -6.5,-29.5
       parent: 1
-  - uid: 1321
+  - uid: 1314
     components:
     - type: Transform
       pos: -10.5,-29.5
       parent: 1
-  - uid: 1322
+  - uid: 1315
     components:
     - type: Transform
       pos: -2.5,-29.5
       parent: 1
-  - uid: 1323
+  - uid: 1316
     components:
     - type: Transform
       pos: -2.5,-29.5
       parent: 1
-  - uid: 1324
+  - uid: 1317
     components:
     - type: Transform
       pos: 3.5,-21.5
       parent: 1
-  - uid: 1325
+  - uid: 1318
     components:
     - type: Transform
       pos: 3.5,-24.5
       parent: 1
-  - uid: 1326
+  - uid: 1319
     components:
     - type: Transform
       pos: 1.5,-25.5
       parent: 1
-  - uid: 1327
+  - uid: 1320
     components:
     - type: Transform
       pos: 2.5,-25.5
       parent: 1
-  - uid: 1328
+  - uid: 1321
     components:
     - type: Transform
       pos: 3.5,-25.5
       parent: 1
-  - uid: 1329
+  - uid: 1322
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 1330
+  - uid: 1323
     components:
     - type: Transform
       pos: -33.5,16.5
       parent: 1
-  - uid: 1331
+  - uid: 1324
     components:
     - type: Transform
       pos: -31.5,12.5
       parent: 1
-  - uid: 1332
+  - uid: 1325
     components:
     - type: Transform
       pos: -30.5,12.5
       parent: 1
-  - uid: 1333
+  - uid: 1326
     components:
     - type: Transform
       pos: -33.5,12.5
       parent: 1
-  - uid: 1334
+  - uid: 1327
     components:
     - type: Transform
       pos: -32.5,12.5
       parent: 1
-  - uid: 1335
+  - uid: 1328
     components:
     - type: Transform
       pos: -30.5,16.5
       parent: 1
-  - uid: 1336
+  - uid: 1329
     components:
     - type: Transform
       pos: -31.5,16.5
       parent: 1
-  - uid: 1337
+  - uid: 1330
     components:
     - type: Transform
       pos: -32.5,16.5
       parent: 1
-  - uid: 1338
+  - uid: 1331
     components:
     - type: Transform
       pos: -30.5,10.5
       parent: 1
 - proto: CMWallReinforcedAlmayer
   entities:
-  - uid: 1339
+  - uid: 1332
     components:
     - type: Transform
       pos: -3.5,-36.5
       parent: 1
-  - uid: 1340
+  - uid: 1333
     components:
     - type: Transform
       pos: -2.5,-34.5
       parent: 1
-  - uid: 1341
+  - uid: 1334
     components:
     - type: Transform
       pos: -12.5,-35.5
       parent: 1
-  - uid: 1342
+  - uid: 1335
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,37.5
       parent: 1
-  - uid: 1343
+  - uid: 1336
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,44.5
       parent: 1
-  - uid: 1344
+  - uid: 1337
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,44.5
       parent: 1
-  - uid: 1345
+  - uid: 1338
     components:
     - type: Transform
       pos: 11.5,47.5
       parent: 1
-  - uid: 1346
+  - uid: 1339
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,44.5
       parent: 1
-  - uid: 1347
+  - uid: 1340
     components:
     - type: Transform
       pos: 11.5,48.5
       parent: 1
-  - uid: 1348
+  - uid: 1341
     components:
     - type: Transform
       pos: 10.5,49.5
       parent: 1
-  - uid: 1349
+  - uid: 1342
     components:
     - type: Transform
       pos: -3.5,39.5
       parent: 1
-  - uid: 1350
+  - uid: 1343
     components:
     - type: Transform
       pos: 11.5,45.5
       parent: 1
-  - uid: 1351
+  - uid: 1344
     components:
     - type: Transform
       pos: 1.5,-28.5
       parent: 1
-  - uid: 1352
+  - uid: 1345
     components:
     - type: Transform
       pos: 7.5,-28.5
       parent: 1
-  - uid: 1353
+  - uid: 1346
     components:
     - type: Transform
       pos: 9.5,-28.5
       parent: 1
-  - uid: 1354
+  - uid: 1347
     components:
     - type: Transform
       pos: 10.5,-28.5
       parent: 1
-  - uid: 1355
+  - uid: 1348
     components:
     - type: Transform
       pos: 5.5,-28.5
       parent: 1
-  - uid: 1356
+  - uid: 1349
     components:
     - type: Transform
       pos: -19.5,-16.5
       parent: 1
-  - uid: 1357
+  - uid: 1350
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 1358
+  - uid: 1351
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
-  - uid: 1359
+  - uid: 1352
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 1360
+  - uid: 1353
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 1361
+  - uid: 1354
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 1362
+  - uid: 1355
     components:
     - type: Transform
       pos: 0.5,-37.5
       parent: 1
-  - uid: 1363
+  - uid: 1356
     components:
     - type: Transform
       pos: 0.5,-29.5
       parent: 1
-  - uid: 1364
+  - uid: 1357
     components:
     - type: Transform
       pos: 9.5,-43.5
       parent: 1
-  - uid: 1365
+  - uid: 1358
     components:
     - type: Transform
       pos: 0.5,-49.5
       parent: 1
-  - uid: 1366
+  - uid: 1359
     components:
     - type: Transform
       pos: 0.5,-51.5
       parent: 1
-  - uid: 1367
+  - uid: 1360
     components:
     - type: Transform
       pos: 0.5,-50.5
       parent: 1
-  - uid: 1368
+  - uid: 1361
     components:
     - type: Transform
       pos: 8.5,-33.5
       parent: 1
-  - uid: 1369
+  - uid: 1362
     components:
     - type: Transform
       pos: 10.5,-40.5
       parent: 1
-  - uid: 1370
+  - uid: 1363
     components:
     - type: Transform
       pos: 10.5,-33.5
       parent: 1
-  - uid: 1371
+  - uid: 1364
     components:
     - type: Transform
       pos: 0.5,-31.5
       parent: 1
-  - uid: 1372
+  - uid: 1365
     components:
     - type: Transform
       pos: 4.5,-28.5
       parent: 1
-  - uid: 1373
+  - uid: 1366
     components:
     - type: Transform
       pos: 6.5,-28.5
       parent: 1
-  - uid: 1374
+  - uid: 1367
     components:
     - type: Transform
       pos: 8.5,-28.5
       parent: 1
-  - uid: 1375
+  - uid: 1368
     components:
     - type: Transform
       pos: 3.5,-42.5
       parent: 1
-  - uid: 1376
+  - uid: 1369
     components:
     - type: Transform
       pos: 5.5,-33.5
       parent: 1
-  - uid: 1377
+  - uid: 1370
     components:
     - type: Transform
       pos: 3.5,-40.5
       parent: 1
-  - uid: 1378
+  - uid: 1371
     components:
     - type: Transform
       pos: 6.5,-41.5
       parent: 1
-  - uid: 1379
+  - uid: 1372
     components:
     - type: Transform
       pos: 2.5,-28.5
       parent: 1
-  - uid: 1380
+  - uid: 1373
     components:
     - type: Transform
       pos: -10.5,-9.5
       parent: 1
-  - uid: 1381
+  - uid: 1374
     components:
     - type: Transform
       pos: 0.5,-38.5
       parent: 1
-  - uid: 1382
+  - uid: 1375
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
-  - uid: 1383
+  - uid: 1376
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 1
-  - uid: 1384
+  - uid: 1377
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 1
-  - uid: 1385
+  - uid: 1378
     components:
     - type: Transform
       pos: 13.5,-15.5
       parent: 1
-  - uid: 1386
+  - uid: 1379
     components:
     - type: Transform
       pos: 1.5,-15.5
       parent: 1
-  - uid: 1387
+  - uid: 1380
     components:
     - type: Transform
       pos: 5.5,-15.5
       parent: 1
-  - uid: 1388
+  - uid: 1381
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
-  - uid: 1389
+  - uid: 1382
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
-  - uid: 1390
+  - uid: 1383
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 1
-  - uid: 1391
+  - uid: 1384
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
-  - uid: 1392
+  - uid: 1385
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 1393
+  - uid: 1386
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
-  - uid: 1394
+  - uid: 1387
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 1395
+  - uid: 1388
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
-  - uid: 1396
+  - uid: 1389
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
-  - uid: 1397
+  - uid: 1390
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 1398
+  - uid: 1391
     components:
     - type: Transform
       pos: -2.5,-10.5
       parent: 1
-  - uid: 1399
+  - uid: 1392
     components:
     - type: Transform
       pos: -2.5,-11.5
       parent: 1
-  - uid: 1400
+  - uid: 1393
     components:
     - type: Transform
       pos: -2.5,-12.5
       parent: 1
-  - uid: 1401
+  - uid: 1394
     components:
     - type: Transform
       pos: -2.5,-13.5
       parent: 1
-  - uid: 1402
+  - uid: 1395
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 1
-  - uid: 1403
+  - uid: 1396
     components:
     - type: Transform
       pos: -2.5,-15.5
       parent: 1
-  - uid: 1404
+  - uid: 1397
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 1
-  - uid: 1405
+  - uid: 1398
     components:
     - type: Transform
       pos: -4.5,-15.5
       parent: 1
-  - uid: 1406
+  - uid: 1399
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-  - uid: 1407
+  - uid: 1400
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 1
-  - uid: 1408
+  - uid: 1401
     components:
     - type: Transform
       pos: -6.5,-15.5
       parent: 1
-  - uid: 1409
+  - uid: 1402
     components:
     - type: Transform
       pos: -12.5,-15.5
       parent: 1
-  - uid: 1410
+  - uid: 1403
     components:
     - type: Transform
       pos: -13.5,-15.5
       parent: 1
-  - uid: 1411
+  - uid: 1404
     components:
     - type: Transform
       pos: -14.5,-15.5
       parent: 1
-  - uid: 1412
+  - uid: 1405
     components:
     - type: Transform
       pos: -15.5,-15.5
       parent: 1
-  - uid: 1413
+  - uid: 1406
     components:
     - type: Transform
       pos: -16.5,-15.5
       parent: 1
-  - uid: 1414
+  - uid: 1407
     components:
     - type: Transform
       pos: -17.5,-15.5
       parent: 1
-  - uid: 1415
+  - uid: 1408
     components:
     - type: Transform
       pos: -10.5,-15.5
       parent: 1
-  - uid: 1416
+  - uid: 1409
     components:
     - type: Transform
       pos: -11.5,-15.5
       parent: 1
-  - uid: 1417
+  - uid: 1410
     components:
     - type: Transform
       pos: -10.5,-10.5
       parent: 1
-  - uid: 1418
+  - uid: 1411
     components:
     - type: Transform
       pos: -10.5,-1.5
       parent: 1
-  - uid: 1419
+  - uid: 1412
     components:
     - type: Transform
       pos: -10.5,-2.5
       parent: 1
-  - uid: 1420
+  - uid: 1413
     components:
     - type: Transform
       pos: -10.5,-3.5
       parent: 1
-  - uid: 1421
+  - uid: 1414
     components:
     - type: Transform
       pos: -10.5,-4.5
       parent: 1
-  - uid: 1422
+  - uid: 1415
     components:
     - type: Transform
       pos: -10.5,-14.5
       parent: 1
-  - uid: 1423
+  - uid: 1416
     components:
     - type: Transform
       pos: -10.5,-5.5
       parent: 1
-  - uid: 1424
+  - uid: 1417
     components:
     - type: Transform
       pos: -10.5,-6.5
       parent: 1
-  - uid: 1425
+  - uid: 1418
     components:
     - type: Transform
       pos: -10.5,-7.5
       parent: 1
-  - uid: 1426
+  - uid: 1419
     components:
     - type: Transform
       pos: -10.5,-8.5
       parent: 1
-  - uid: 1427
+  - uid: 1420
     components:
     - type: Transform
       pos: -6.5,-5.5
       parent: 1
-  - uid: 1428
+  - uid: 1421
     components:
     - type: Transform
       pos: -10.5,-11.5
       parent: 1
-  - uid: 1429
+  - uid: 1422
     components:
     - type: Transform
       pos: -6.5,-7.5
       parent: 1
-  - uid: 1430
+  - uid: 1423
     components:
     - type: Transform
       pos: -5.5,-15.5
       parent: 1
-  - uid: 1431
+  - uid: 1424
     components:
     - type: Transform
       pos: -6.5,-8.5
       parent: 1
-  - uid: 1432
+  - uid: 1425
     components:
     - type: Transform
       pos: -5.5,-8.5
       parent: 1
-  - uid: 1433
+  - uid: 1426
     components:
     - type: Transform
       pos: -4.5,-8.5
       parent: 1
-  - uid: 1434
+  - uid: 1427
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 1
-  - uid: 1435
+  - uid: 1428
     components:
     - type: Transform
       pos: -6.5,-9.5
       parent: 1
-  - uid: 1436
+  - uid: 1429
     components:
     - type: Transform
       pos: -6.5,-11.5
       parent: 1
-  - uid: 1437
+  - uid: 1430
     components:
     - type: Transform
       pos: -6.5,-12.5
       parent: 1
-  - uid: 1438
+  - uid: 1431
     components:
     - type: Transform
       pos: -5.5,-12.5
       parent: 1
-  - uid: 1439
+  - uid: 1432
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 1
-  - uid: 1440
+  - uid: 1433
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 1
-  - uid: 1441
+  - uid: 1434
     components:
     - type: Transform
       pos: -6.5,-14.5
       parent: 1
-  - uid: 1442
+  - uid: 1435
     components:
     - type: Transform
       pos: -9.5,-2.5
       parent: 1
-  - uid: 1443
+  - uid: 1436
     components:
     - type: Transform
       pos: -9.5,-1.5
       parent: 1
-  - uid: 1444
+  - uid: 1437
     components:
     - type: Transform
       pos: -9.5,-11.5
       parent: 1
-  - uid: 1445
+  - uid: 1438
     components:
     - type: Transform
       pos: 3.5,-20.5
       parent: 1
-  - uid: 1446
+  - uid: 1439
     components:
     - type: Transform
       pos: 2.5,-20.5
       parent: 1
-  - uid: 1447
+  - uid: 1440
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 1
-  - uid: 1448
+  - uid: 1441
     components:
     - type: Transform
       pos: 1.5,-19.5
       parent: 1
-  - uid: 1449
+  - uid: 1442
     components:
     - type: Transform
       pos: 4.5,-20.5
       parent: 1
-  - uid: 1450
+  - uid: 1443
     components:
     - type: Transform
       pos: -13.5,-20.5
       parent: 1
-  - uid: 1451
+  - uid: 1444
     components:
     - type: Transform
       pos: -14.5,-20.5
       parent: 1
-  - uid: 1452
+  - uid: 1445
     components:
     - type: Transform
       pos: 1.5,-20.5
       parent: 1
-  - uid: 1453
+  - uid: 1446
     components:
     - type: Transform
       pos: -2.5,-20.5
       parent: 1
-  - uid: 1454
+  - uid: 1447
     components:
     - type: Transform
       pos: -3.5,-20.5
       parent: 1
-  - uid: 1455
+  - uid: 1448
     components:
     - type: Transform
       pos: -4.5,-20.5
       parent: 1
-  - uid: 1456
+  - uid: 1449
     components:
     - type: Transform
       pos: -5.5,-20.5
       parent: 1
-  - uid: 1457
+  - uid: 1450
     components:
     - type: Transform
       pos: -6.5,-20.5
       parent: 1
-  - uid: 1458
+  - uid: 1451
     components:
     - type: Transform
       pos: -10.5,-20.5
       parent: 1
-  - uid: 1459
+  - uid: 1452
     components:
     - type: Transform
       pos: -11.5,-20.5
       parent: 1
-  - uid: 1460
+  - uid: 1453
     components:
     - type: Transform
       pos: -12.5,-20.5
       parent: 1
-  - uid: 1461
+  - uid: 1454
     components:
     - type: Transform
       pos: -2.5,-19.5
       parent: 1
-  - uid: 1462
+  - uid: 1455
     components:
     - type: Transform
       pos: -2.5,-16.5
       parent: 1
-  - uid: 1463
+  - uid: 1456
     components:
     - type: Transform
       pos: -6.5,-16.5
       parent: 1
-  - uid: 1464
+  - uid: 1457
     components:
     - type: Transform
       pos: -6.5,-19.5
       parent: 1
-  - uid: 1465
+  - uid: 1458
     components:
     - type: Transform
       pos: -10.5,-16.5
       parent: 1
-  - uid: 1466
+  - uid: 1459
     components:
     - type: Transform
       pos: -10.5,-19.5
       parent: 1
-  - uid: 1467
+  - uid: 1460
     components:
     - type: Transform
       pos: -14.5,-19.5
       parent: 1
-  - uid: 1468
+  - uid: 1461
     components:
     - type: Transform
       pos: -14.5,-16.5
       parent: 1
-  - uid: 1469
+  - uid: 1462
     components:
     - type: Transform
       pos: -13.5,-21.5
       parent: 1
-  - uid: 1470
+  - uid: 1463
     components:
     - type: Transform
       pos: -13.5,-22.5
       parent: 1
-  - uid: 1471
+  - uid: 1464
     components:
     - type: Transform
       pos: -13.5,-23.5
       parent: 1
-  - uid: 1472
+  - uid: 1465
     components:
     - type: Transform
       pos: -13.5,-24.5
       parent: 1
-  - uid: 1473
+  - uid: 1466
     components:
     - type: Transform
       pos: -17.5,-25.5
       parent: 1
-  - uid: 1474
+  - uid: 1467
     components:
     - type: Transform
       pos: -14.5,-25.5
       parent: 1
-  - uid: 1475
+  - uid: 1468
     components:
     - type: Transform
       pos: -13.5,-25.5
       parent: 1
-  - uid: 1476
+  - uid: 1469
     components:
     - type: Transform
       pos: -14.5,-30.5
       parent: 1
-  - uid: 1477
+  - uid: 1470
     components:
     - type: Transform
       pos: -13.5,-30.5
       parent: 1
-  - uid: 1478
+  - uid: 1471
     components:
     - type: Transform
       pos: -17.5,-30.5
       parent: 1
-  - uid: 1479
+  - uid: 1472
     components:
     - type: Transform
       pos: -13.5,-26.5
       parent: 1
-  - uid: 1480
+  - uid: 1473
     components:
     - type: Transform
       pos: -13.5,-29.5
       parent: 1
-  - uid: 1481
+  - uid: 1474
     components:
     - type: Transform
       pos: -17.5,-35.5
       parent: 1
-  - uid: 1482
+  - uid: 1475
     components:
     - type: Transform
       pos: -14.5,-35.5
       parent: 1
-  - uid: 1483
+  - uid: 1476
     components:
     - type: Transform
       pos: -13.5,-35.5
       parent: 1
-  - uid: 1484
+  - uid: 1477
     components:
     - type: Transform
       pos: -13.5,-31.5
       parent: 1
-  - uid: 1485
+  - uid: 1478
     components:
     - type: Transform
       pos: -13.5,-33.5
       parent: 1
-  - uid: 1486
+  - uid: 1479
     components:
     - type: Transform
       pos: -13.5,-34.5
       parent: 1
-  - uid: 1487
+  - uid: 1480
     components:
     - type: Transform
       pos: -13.5,-32.5
       parent: 1
-  - uid: 1488
+  - uid: 1481
     components:
     - type: Transform
       pos: -6.5,-34.5
       parent: 1
-  - uid: 1489
+  - uid: 1482
     components:
     - type: Transform
       pos: -10.5,-34.5
       parent: 1
-  - uid: 1490
+  - uid: 1483
     components:
     - type: Transform
       pos: -2.5,-37.5
       parent: 1
-  - uid: 1491
+  - uid: 1484
     components:
     - type: Transform
       pos: -2.5,-24.5
       parent: 1
-  - uid: 1492
+  - uid: 1485
     components:
     - type: Transform
       pos: -2.5,-23.5
       parent: 1
-  - uid: 1493
+  - uid: 1486
     components:
     - type: Transform
       pos: -2.5,-22.5
       parent: 1
-  - uid: 1494
+  - uid: 1487
     components:
     - type: Transform
       pos: -2.5,-21.5
       parent: 1
-  - uid: 1495
+  - uid: 1488
     components:
     - type: Transform
       pos: -5.5,-36.5
       parent: 1
-  - uid: 1496
+  - uid: 1489
     components:
     - type: Transform
       pos: -0.5,-37.5
       parent: 1
-  - uid: 1497
+  - uid: 1490
     components:
     - type: Transform
       pos: -1.5,-37.5
       parent: 1
-  - uid: 1498
+  - uid: 1491
     components:
     - type: Transform
       pos: -12.5,-25.5
       parent: 1
-  - uid: 1499
+  - uid: 1492
     components:
     - type: Transform
       pos: -11.5,-25.5
       parent: 1
-  - uid: 1500
+  - uid: 1493
     components:
     - type: Transform
       pos: -10.5,-25.5
       parent: 1
-  - uid: 1501
+  - uid: 1494
     components:
     - type: Transform
       pos: -5.5,-25.5
       parent: 1
-  - uid: 1502
+  - uid: 1495
     components:
     - type: Transform
       pos: -10.5,-24.5
       parent: 1
-  - uid: 1503
+  - uid: 1496
     components:
     - type: Transform
       pos: -3.5,-25.5
       parent: 1
-  - uid: 1504
+  - uid: 1497
     components:
     - type: Transform
       pos: -6.5,-24.5
       parent: 1
-  - uid: 1505
+  - uid: 1498
     components:
     - type: Transform
       pos: -6.5,-25.5
       parent: 1
-  - uid: 1506
+  - uid: 1499
     components:
     - type: Transform
       pos: -1.5,-20.5
       parent: 1
-  - uid: 1507
+  - uid: 1500
     components:
     - type: Transform
       pos: -0.5,-20.5
       parent: 1
-  - uid: 1508
+  - uid: 1501
     components:
     - type: Transform
       pos: 0.5,-20.5
       parent: 1
-  - uid: 1509
+  - uid: 1502
     components:
     - type: Transform
       pos: -2.5,-25.5
       parent: 1
-  - uid: 1510
+  - uid: 1503
     components:
     - type: Transform
       pos: -1.5,-25.5
       parent: 1
-  - uid: 1511
+  - uid: 1504
     components:
     - type: Transform
       pos: -0.5,-25.5
       parent: 1
-  - uid: 1512
+  - uid: 1505
     components:
     - type: Transform
       pos: 0.5,-25.5
       parent: 1
-  - uid: 1513
+  - uid: 1506
     components:
     - type: Transform
       pos: 0.5,-26.5
       parent: 1
-  - uid: 1514
+  - uid: 1507
     components:
     - type: Transform
       pos: 0.5,-27.5
       parent: 1
-  - uid: 1515
+  - uid: 1508
     components:
     - type: Transform
       pos: 0.5,-28.5
       parent: 1
-  - uid: 1516
+  - uid: 1509
     components:
     - type: Transform
       pos: 5.5,-19.5
       parent: 1
-  - uid: 1517
+  - uid: 1510
     components:
     - type: Transform
       pos: 5.5,-16.5
       parent: 1
-  - uid: 1518
+  - uid: 1511
     components:
     - type: Transform
       pos: 5.5,-20.5
       parent: 1
-  - uid: 1519
+  - uid: 1512
     components:
     - type: Transform
       pos: 6.5,-20.5
       parent: 1
-  - uid: 1520
+  - uid: 1513
     components:
     - type: Transform
       pos: 7.5,-20.5
       parent: 1
-  - uid: 1521
+  - uid: 1514
     components:
     - type: Transform
       pos: 8.5,-20.5
       parent: 1
-  - uid: 1522
+  - uid: 1515
     components:
     - type: Transform
       pos: 9.5,-20.5
       parent: 1
-  - uid: 1523
+  - uid: 1516
     components:
     - type: Transform
       pos: 9.5,-19.5
       parent: 1
-  - uid: 1524
+  - uid: 1517
     components:
     - type: Transform
       pos: 10.5,-20.5
       parent: 1
-  - uid: 1525
+  - uid: 1518
     components:
     - type: Transform
       pos: 11.5,-20.5
       parent: 1
-  - uid: 1526
+  - uid: 1519
     components:
     - type: Transform
       pos: 12.5,-20.5
       parent: 1
-  - uid: 1527
+  - uid: 1520
     components:
     - type: Transform
       pos: 13.5,-20.5
       parent: 1
-  - uid: 1528
+  - uid: 1521
     components:
     - type: Transform
       pos: 13.5,-19.5
       parent: 1
-  - uid: 1529
+  - uid: 1522
     components:
     - type: Transform
       pos: 13.5,-16.5
       parent: 1
-  - uid: 1530
+  - uid: 1523
     components:
     - type: Transform
       pos: -19.5,-6.5
       parent: 1
-  - uid: 1531
+  - uid: 1524
     components:
     - type: Transform
       pos: 12.5,-21.5
       parent: 1
-  - uid: 1532
+  - uid: 1525
     components:
     - type: Transform
       pos: 16.5,-20.5
       parent: 1
-  - uid: 1533
+  - uid: 1526
     components:
     - type: Transform
       pos: 12.5,-28.5
       parent: 1
-  - uid: 1534
+  - uid: 1527
     components:
     - type: Transform
       pos: 12.5,-27.5
       parent: 1
-  - uid: 1535
+  - uid: 1528
     components:
     - type: Transform
       pos: 12.5,-26.5
       parent: 1
-  - uid: 1536
+  - uid: 1529
     components:
     - type: Transform
       pos: 12.5,-25.5
       parent: 1
-  - uid: 1537
+  - uid: 1530
     components:
     - type: Transform
       pos: 12.5,-24.5
       parent: 1
-  - uid: 1538
+  - uid: 1531
     components:
     - type: Transform
       pos: 13.5,-25.5
       parent: 1
-  - uid: 1539
+  - uid: 1532
     components:
     - type: Transform
       pos: 16.5,-25.5
       parent: 1
-  - uid: 1540
+  - uid: 1533
     components:
     - type: Transform
       pos: 12.5,-29.5
       parent: 1
-  - uid: 1541
+  - uid: 1534
     components:
     - type: Transform
       pos: 16.5,-30.5
       parent: 1
-  - uid: 1542
+  - uid: 1535
     components:
     - type: Transform
       pos: 12.5,-30.5
       parent: 1
-  - uid: 1543
+  - uid: 1536
     components:
     - type: Transform
       pos: 16.5,-35.5
       parent: 1
-  - uid: 1544
+  - uid: 1537
     components:
     - type: Transform
       pos: 12.5,-33.5
       parent: 1
-  - uid: 1545
+  - uid: 1538
     components:
     - type: Transform
       pos: 12.5,-31.5
       parent: 1
-  - uid: 1546
+  - uid: 1539
     components:
     - type: Transform
       pos: 12.5,-32.5
       parent: 1
-  - uid: 1547
+  - uid: 1540
     components:
     - type: Transform
       pos: 12.5,-35.5
       parent: 1
-  - uid: 1548
+  - uid: 1541
     components:
     - type: Transform
       pos: 13.5,-30.5
       parent: 1
-  - uid: 1549
+  - uid: 1542
     components:
     - type: Transform
       pos: 13.5,-35.5
       parent: 1
-  - uid: 1550
+  - uid: 1543
     components:
     - type: Transform
       pos: 8.5,-27.5
       parent: 1
-  - uid: 1551
+  - uid: 1544
     components:
     - type: Transform
       pos: 12.5,-36.5
       parent: 1
-  - uid: 1552
+  - uid: 1545
     components:
     - type: Transform
       pos: 12.5,-39.5
       parent: 1
-  - uid: 1553
+  - uid: 1546
     components:
     - type: Transform
       pos: -13.5,-36.5
       parent: 1
-  - uid: 1554
+  - uid: 1547
     components:
     - type: Transform
       pos: -13.5,-39.5
       parent: 1
-  - uid: 1555
+  - uid: 1548
     components:
     - type: Transform
       pos: 6.5,-43.5
       parent: 1
-  - uid: 1556
+  - uid: 1549
     components:
     - type: Transform
       pos: 6.5,-42.5
       parent: 1
-  - uid: 1557
+  - uid: 1550
     components:
     - type: Transform
       pos: 9.5,-41.5
       parent: 1
-  - uid: 1558
+  - uid: 1551
     components:
     - type: Transform
       pos: 3.5,-41.5
       parent: 1
-  - uid: 1559
+  - uid: 1552
     components:
     - type: Transform
       pos: 4.5,-40.5
       parent: 1
-  - uid: 1560
+  - uid: 1553
     components:
     - type: Transform
       pos: 1.5,-40.5
       parent: 1
-  - uid: 1561
+  - uid: 1554
     components:
     - type: Transform
       pos: -22.5,-16.5
       parent: 1
-  - uid: 1562
+  - uid: 1555
     components:
     - type: Transform
       pos: 12.5,-44.5
       parent: 1
-  - uid: 1563
+  - uid: 1556
     components:
     - type: Transform
       pos: 0.5,-42.5
       parent: 1
-  - uid: 1564
+  - uid: 1557
     components:
     - type: Transform
       pos: 0.5,-40.5
       parent: 1
-  - uid: 1565
+  - uid: 1558
     components:
     - type: Transform
       pos: 0.5,-41.5
       parent: 1
-  - uid: 1566
+  - uid: 1559
     components:
     - type: Transform
       pos: 0.5,-45.5
       parent: 1
-  - uid: 1567
+  - uid: 1560
     components:
     - type: Transform
       pos: 11.5,-28.5
       parent: 1
-  - uid: 1568
+  - uid: 1561
     components:
     - type: Transform
       pos: 0.5,-34.5
       parent: 1
-  - uid: 1569
+  - uid: 1562
     components:
     - type: Transform
       pos: 0.5,-44.5
       parent: 1
-  - uid: 1570
+  - uid: 1563
     components:
     - type: Transform
       pos: 0.5,-47.5
       parent: 1
-  - uid: 1571
+  - uid: 1564
     components:
     - type: Transform
       pos: 13.5,-4.5
       parent: 1
-  - uid: 1572
+  - uid: 1565
     components:
     - type: Transform
       pos: 10.5,-4.5
       parent: 1
-  - uid: 1573
+  - uid: 1566
     components:
     - type: Transform
       pos: 9.5,-3.5
       parent: 1
-  - uid: 1574
+  - uid: 1567
     components:
     - type: Transform
       pos: 17.5,-6.5
       parent: 1
-  - uid: 1575
+  - uid: 1568
     components:
     - type: Transform
       pos: 17.5,-7.5
       parent: 1
-  - uid: 1576
+  - uid: 1569
     components:
     - type: Transform
       pos: 17.5,-4.5
       parent: 1
-  - uid: 1577
+  - uid: 1570
     components:
     - type: Transform
       pos: 0.5,-35.5
       parent: 1
-  - uid: 1578
+  - uid: 1571
     components:
     - type: Transform
       pos: 9.5,-42.5
       parent: 1
-  - uid: 1579
+  - uid: 1572
     components:
     - type: Transform
       pos: 0.5,-33.5
       parent: 1
-  - uid: 1580
+  - uid: 1573
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 1581
+  - uid: 1574
     components:
     - type: Transform
       pos: 3.5,-43.5
       parent: 1
-  - uid: 1582
+  - uid: 1575
     components:
     - type: Transform
       pos: 6.5,-40.5
       parent: 1
-  - uid: 1583
+  - uid: 1576
     components:
     - type: Transform
       pos: 9.5,-2.5
       parent: 1
-  - uid: 1584
+  - uid: 1577
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 1
-  - uid: 1585
+  - uid: 1578
     components:
     - type: Transform
       pos: 17.5,-5.5
       parent: 1
-  - uid: 1586
+  - uid: 1579
     components:
     - type: Transform
       pos: 17.5,-8.5
       parent: 1
-  - uid: 1587
+  - uid: 1580
     components:
     - type: Transform
       pos: 13.5,-3.5
       parent: 1
-  - uid: 1588
+  - uid: 1581
     components:
     - type: Transform
       pos: 13.5,-2.5
       parent: 1
-  - uid: 1589
+  - uid: 1582
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
-  - uid: 1590
+  - uid: 1583
     components:
     - type: Transform
       pos: 14.5,-4.5
       parent: 1
-  - uid: 1591
+  - uid: 1584
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
-  - uid: 1592
+  - uid: 1585
     components:
     - type: Transform
       pos: 10.5,-9.5
       parent: 1
-  - uid: 1593
+  - uid: 1586
     components:
     - type: Transform
       pos: 10.5,-8.5
       parent: 1
-  - uid: 1594
+  - uid: 1587
     components:
     - type: Transform
       pos: 10.5,-11.5
       parent: 1
-  - uid: 1595
+  - uid: 1588
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 1
-  - uid: 1596
+  - uid: 1589
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 1597
+  - uid: 1590
     components:
     - type: Transform
       pos: 0.5,-30.5
       parent: 1
-  - uid: 1598
+  - uid: 1591
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 1599
+  - uid: 1592
     components:
     - type: Transform
       pos: 12.5,-34.5
       parent: 1
-  - uid: 1600
+  - uid: 1593
     components:
     - type: Transform
       pos: 3.5,-28.5
       parent: 1
-  - uid: 1601
+  - uid: 1594
     components:
     - type: Transform
       pos: 0.5,-36.5
       parent: 1
-  - uid: 1602
+  - uid: 1595
     components:
     - type: Transform
       pos: 0.5,-46.5
       parent: 1
-  - uid: 1603
+  - uid: 1596
     components:
     - type: Transform
       pos: 0.5,-48.5
       parent: 1
-  - uid: 1604
+  - uid: 1597
     components:
     - type: Transform
       pos: 0.5,-43.5
       parent: 1
-  - uid: 1605
+  - uid: 1598
     components:
     - type: Transform
       pos: 16.5,-4.5
       parent: 1
-  - uid: 1606
+  - uid: 1599
     components:
     - type: Transform
       pos: 10.5,-10.5
       parent: 1
-  - uid: 1607
+  - uid: 1600
     components:
     - type: Transform
       pos: 13.5,-1.5
       parent: 1
-  - uid: 1608
+  - uid: 1601
     components:
     - type: Transform
       pos: 7.5,-15.5
       parent: 1
-  - uid: 1609
+  - uid: 1602
     components:
     - type: Transform
       pos: 0.5,-32.5
       parent: 1
-  - uid: 1610
+  - uid: 1603
     components:
     - type: Transform
       pos: 9.5,-40.5
       parent: 1
-  - uid: 1611
+  - uid: 1604
     components:
     - type: Transform
       pos: 7.5,-40.5
       parent: 1
-  - uid: 1612
+  - uid: 1605
     components:
     - type: Transform
       pos: 9.5,-16.5
       parent: 1
-  - uid: 1613
+  - uid: 1606
     components:
     - type: Transform
       pos: 9.5,-15.5
       parent: 1
-  - uid: 1614
+  - uid: 1607
     components:
     - type: Transform
       pos: 12.5,-4.5
       parent: 1
-  - uid: 1615
+  - uid: 1608
     components:
     - type: Transform
       pos: 17.5,-2.5
       parent: 1
-  - uid: 1616
+  - uid: 1609
     components:
     - type: Transform
       pos: 17.5,-1.5
       parent: 1
-  - uid: 1617
+  - uid: 1610
     components:
     - type: Transform
       pos: 17.5,-3.5
       parent: 1
-  - uid: 1618
+  - uid: 1611
     components:
     - type: Transform
       pos: 0.5,-39.5
       parent: 1
-  - uid: 1619
+  - uid: 1612
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 1620
+  - uid: 1613
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 1621
+  - uid: 1614
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 1
-  - uid: 1622
+  - uid: 1615
     components:
     - type: Transform
       pos: 9.5,-4.5
       parent: 1
-  - uid: 1623
+  - uid: 1616
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 1624
+  - uid: 1617
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 1
-  - uid: 1625
+  - uid: 1618
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 1626
+  - uid: 1619
     components:
     - type: Transform
       pos: -17.5,-50.5
       parent: 1
-  - uid: 1627
+  - uid: 1620
     components:
     - type: Transform
       pos: -13.5,-52.5
       parent: 1
-  - uid: 1628
+  - uid: 1621
     components:
     - type: Transform
       pos: -12.5,-52.5
       parent: 1
-  - uid: 1629
+  - uid: 1622
     components:
     - type: Transform
       pos: -12.5,-53.5
       parent: 1
-  - uid: 1630
+  - uid: 1623
     components:
     - type: Transform
       pos: -13.5,-53.5
       parent: 1
-  - uid: 1631
+  - uid: 1624
     components:
     - type: Transform
       pos: -2.5,-53.5
       parent: 1
-  - uid: 1632
+  - uid: 1625
     components:
     - type: Transform
       pos: -14.5,-52.5
       parent: 1
-  - uid: 1633
+  - uid: 1626
     components:
     - type: Transform
       pos: -13.5,-49.5
       parent: 1
-  - uid: 1634
+  - uid: 1627
     components:
     - type: Transform
       pos: -17.5,-45.5
       parent: 1
-  - uid: 1635
+  - uid: 1628
     components:
     - type: Transform
       pos: -14.5,-45.5
       parent: 1
-  - uid: 1636
+  - uid: 1629
     components:
     - type: Transform
       pos: -13.5,-51.5
       parent: 1
-  - uid: 1637
+  - uid: 1630
     components:
     - type: Transform
       pos: -17.5,-40.5
       parent: 1
-  - uid: 1638
+  - uid: 1631
     components:
     - type: Transform
       pos: -1.5,-52.5
       parent: 1
-  - uid: 1639
+  - uid: 1632
     components:
     - type: Transform
       pos: -13.5,-45.5
       parent: 1
-  - uid: 1640
+  - uid: 1633
     components:
     - type: Transform
       pos: -13.5,-44.5
       parent: 1
-  - uid: 1641
+  - uid: 1634
     components:
     - type: Transform
       pos: -13.5,-40.5
       parent: 1
-  - uid: 1642
+  - uid: 1635
     components:
     - type: Transform
       pos: -13.5,-41.5
       parent: 1
-  - uid: 1643
+  - uid: 1636
     components:
     - type: Transform
       pos: -13.5,-42.5
       parent: 1
-  - uid: 1644
+  - uid: 1637
     components:
     - type: Transform
       pos: -13.5,-43.5
       parent: 1
-  - uid: 1645
+  - uid: 1638
     components:
     - type: Transform
       pos: -14.5,-40.5
       parent: 1
-  - uid: 1646
+  - uid: 1639
     components:
     - type: Transform
       pos: -13.5,-46.5
       parent: 1
-  - uid: 1647
+  - uid: 1640
     components:
     - type: Transform
       pos: -13.5,-48.5
       parent: 1
-  - uid: 1648
+  - uid: 1641
     components:
     - type: Transform
       pos: -13.5,-47.5
       parent: 1
-  - uid: 1649
+  - uid: 1642
     components:
     - type: Transform
       pos: -17.5,-52.5
       parent: 1
-  - uid: 1650
+  - uid: 1643
     components:
     - type: Transform
       pos: -14.5,-50.5
       parent: 1
-  - uid: 1651
+  - uid: 1644
     components:
     - type: Transform
       pos: -3.5,-52.5
       parent: 1
-  - uid: 1652
+  - uid: 1645
     components:
     - type: Transform
       pos: -13.5,-50.5
       parent: 1
-  - uid: 1653
+  - uid: 1646
     components:
     - type: Transform
       pos: -14.5,-51.5
       parent: 1
-  - uid: 1654
+  - uid: 1647
     components:
     - type: Transform
       pos: -17.5,-51.5
       parent: 1
-  - uid: 1655
+  - uid: 1648
     components:
     - type: Transform
       pos: -2.5,-52.5
       parent: 1
-  - uid: 1656
+  - uid: 1649
     components:
     - type: Transform
       pos: 8.5,-64.5
       parent: 1
-  - uid: 1657
+  - uid: 1650
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,43.5
       parent: 1
-  - uid: 1658
+  - uid: 1651
     components:
     - type: Transform
       pos: 12.5,-49.5
       parent: 1
-  - uid: 1659
+  - uid: 1652
     components:
     - type: Transform
       pos: 13.5,-45.5
       parent: 1
-  - uid: 1660
+  - uid: 1653
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,36.5
       parent: 1
-  - uid: 1661
+  - uid: 1654
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,-56.5
       parent: 1
-  - uid: 1662
+  - uid: 1655
     components:
     - type: Transform
       pos: 16.5,-50.5
       parent: 1
-  - uid: 1663
+  - uid: 1656
     components:
     - type: Transform
       pos: 16.5,-45.5
       parent: 1
-  - uid: 1664
+  - uid: 1657
     components:
     - type: Transform
       pos: 16.5,-51.5
       parent: 1
-  - uid: 1665
+  - uid: 1658
     components:
     - type: Transform
       pos: -9.5,-52.5
       parent: 1
-  - uid: 1666
+  - uid: 1659
     components:
     - type: Transform
       pos: -7.5,-52.5
       parent: 1
-  - uid: 1667
+  - uid: 1660
     components:
     - type: Transform
       pos: -11.5,-52.5
       parent: 1
-  - uid: 1668
+  - uid: 1661
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,40.5
       parent: 1
-  - uid: 1669
+  - uid: 1662
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,43.5
       parent: 1
-  - uid: 1670
+  - uid: 1663
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,43.5
       parent: 1
-  - uid: 1671
+  - uid: 1664
     components:
     - type: Transform
       pos: 16.5,49.5
       parent: 1
-  - uid: 1672
+  - uid: 1665
     components:
     - type: Transform
       pos: 17.5,49.5
       parent: 1
-  - uid: 1673
+  - uid: 1666
     components:
     - type: Transform
       pos: 18.5,44.5
       parent: 1
-  - uid: 1674
+  - uid: 1667
     components:
     - type: Transform
       pos: 18.5,49.5
       parent: 1
-  - uid: 1675
+  - uid: 1668
     components:
     - type: Transform
       pos: 18.5,39.5
       parent: 1
-  - uid: 1676
+  - uid: 1669
     components:
     - type: Transform
       pos: 18.5,34.5
       parent: 1
-  - uid: 1677
+  - uid: 1670
     components:
     - type: Transform
       pos: 18.5,24.5
       parent: 1
-  - uid: 1678
+  - uid: 1671
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,29.5
       parent: 1
-  - uid: 1679
+  - uid: 1672
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,24.5
       parent: 1
-  - uid: 1680
+  - uid: 1673
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,-11.5
       parent: 1
-  - uid: 1681
+  - uid: 1674
     components:
     - type: Transform
       pos: 12.5,-47.5
       parent: 1
-  - uid: 1682
+  - uid: 1675
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,39.5
       parent: 1
-  - uid: 1683
+  - uid: 1676
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,38.5
       parent: 1
-  - uid: 1684
+  - uid: 1677
     components:
     - type: Transform
       pos: 16.5,-40.5
       parent: 1
-  - uid: 1685
+  - uid: 1678
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,36.5
       parent: 1
-  - uid: 1686
+  - uid: 1679
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,40.5
       parent: 1
-  - uid: 1687
+  - uid: 1680
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,42.5
       parent: 1
-  - uid: 1688
+  - uid: 1681
     components:
     - type: Transform
       pos: -19.5,19.5
       parent: 1
-  - uid: 1689
+  - uid: 1682
     components:
     - type: Transform
       pos: -19.5,29.5
       parent: 1
-  - uid: 1690
+  - uid: 1683
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,36.5
       parent: 1
-  - uid: 1691
+  - uid: 1684
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,41.5
       parent: 1
-  - uid: 1692
+  - uid: 1685
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,37.5
       parent: 1
-  - uid: 1693
+  - uid: 1686
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,37.5
       parent: 1
-  - uid: 1694
+  - uid: 1687
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-56.5
       parent: 1
-  - uid: 1695
+  - uid: 1688
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-57.5
       parent: 1
-  - uid: 1696
+  - uid: 1689
     components:
     - type: Transform
       pos: -22.5,9.5
       parent: 1
-  - uid: 1697
+  - uid: 1690
     components:
     - type: Transform
       pos: -22.5,19.5
       parent: 1
-  - uid: 1698
+  - uid: 1691
     components:
     - type: Transform
       pos: -22.5,14.5
       parent: 1
-  - uid: 1699
-    components:
-    - type: Transform
-      pos: -22.5,4.5
-      parent: 1
-  - uid: 1700
+  - uid: 1692
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-56.5
       parent: 1
-  - uid: 1701
+  - uid: 1693
     components:
     - type: Transform
       pos: 8.5,-52.5
       parent: 1
-  - uid: 1702
+  - uid: 1694
     components:
     - type: Transform
       pos: 13.5,-40.5
       parent: 1
-  - uid: 1703
+  - uid: 1695
     components:
     - type: Transform
       pos: -7.5,-53.5
       parent: 1
-  - uid: 1704
+  - uid: 1696
     components:
     - type: Transform
       pos: 11.5,-53.5
       parent: 1
-  - uid: 1705
+  - uid: 1697
     components:
     - type: Transform
       pos: -0.5,49.5
       parent: 1
-  - uid: 1706
+  - uid: 1698
     components:
     - type: Transform
       pos: -22.5,49.5
       parent: 1
-  - uid: 1707
+  - uid: 1699
     components:
     - type: Transform
       pos: -19.5,49.5
       parent: 1
-  - uid: 1708
+  - uid: 1700
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-56.5
       parent: 1
-  - uid: 1709
+  - uid: 1701
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-56.5
       parent: 1
-  - uid: 1710
+  - uid: 1702
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-56.5
       parent: 1
-  - uid: 1711
+  - uid: 1703
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-56.5
       parent: 1
-  - uid: 1712
+  - uid: 1704
     components:
     - type: Transform
       pos: 7.5,49.5
       parent: 1
-  - uid: 1713
+  - uid: 1705
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,34.5
       parent: 1
-  - uid: 1714
+  - uid: 1706
     components:
     - type: Transform
       pos: -2.5,49.5
       parent: 1
-  - uid: 1715
+  - uid: 1707
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,29.5
       parent: 1
-  - uid: 1716
+  - uid: 1708
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,31.5
       parent: 1
-  - uid: 1717
+  - uid: 1709
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,31.5
       parent: 1
-  - uid: 1718
+  - uid: 1710
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,31.5
       parent: 1
-  - uid: 1719
+  - uid: 1711
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,44.5
       parent: 1
-  - uid: 1720
+  - uid: 1712
     components:
     - type: Transform
       pos: -22.5,24.5
       parent: 1
-  - uid: 1721
+  - uid: 1713
     components:
     - type: Transform
       pos: 12.5,-52.5
       parent: 1
-  - uid: 1722
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,4.5
-      parent: 1
-  - uid: 1723
+  - uid: 1714
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-48.5
       parent: 1
-  - uid: 1724
+  - uid: 1715
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-48.5
       parent: 1
-  - uid: 1725
+  - uid: 1716
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-56.5
       parent: 1
-  - uid: 1726
+  - uid: 1717
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-48.5
       parent: 1
-  - uid: 1727
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,4.5
-      parent: 1
-  - uid: 1728
+  - uid: 1718
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-48.5
       parent: 1
-  - uid: 1729
+  - uid: 1719
     components:
     - type: Transform
       pos: -17.5,-20.5
       parent: 1
-  - uid: 1730
+  - uid: 1720
     components:
     - type: Transform
       pos: -17.5,-19.5
       parent: 1
-  - uid: 1731
+  - uid: 1721
     components:
     - type: Transform
       pos: -19.5,-11.5
       parent: 1
-  - uid: 1732
+  - uid: 1722
     components:
     - type: Transform
       pos: -22.5,-11.5
       parent: 1
-  - uid: 1733
+  - uid: 1723
     components:
     - type: Transform
       pos: 12.5,-53.5
       parent: 1
-  - uid: 1734
+  - uid: 1724
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-57.5
       parent: 1
-  - uid: 1735
+  - uid: 1725
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-56.5
       parent: 1
-  - uid: 1736
+  - uid: 1726
     components:
     - type: Transform
       pos: -10.5,-52.5
       parent: 1
-  - uid: 1737
+  - uid: 1727
     components:
     - type: Transform
       pos: 17.5,-9.5
       parent: 1
-  - uid: 1738
+  - uid: 1728
     components:
     - type: Transform
       pos: 12.5,-48.5
       parent: 1
-  - uid: 1739
+  - uid: 1729
     components:
     - type: Transform
       pos: 17.5,-10.5
       parent: 1
-  - uid: 1740
+  - uid: 1730
     components:
     - type: Transform
       pos: 17.5,-11.5
       parent: 1
-  - uid: 1741
+  - uid: 1731
     components:
     - type: Transform
       pos: 17.5,-13.5
       parent: 1
-  - uid: 1742
+  - uid: 1732
     components:
     - type: Transform
       pos: 17.5,-14.5
       parent: 1
-  - uid: 1743
+  - uid: 1733
     components:
     - type: Transform
       pos: 17.5,-15.5
       parent: 1
-  - uid: 1744
+  - uid: 1734
     components:
     - type: Transform
       pos: 17.5,-12.5
       parent: 1
-  - uid: 1745
+  - uid: 1735
     components:
     - type: Transform
       pos: -18.5,-15.5
       parent: 1
-  - uid: 1746
+  - uid: 1736
     components:
     - type: Transform
       pos: -18.5,-14.5
       parent: 1
-  - uid: 1747
+  - uid: 1737
     components:
     - type: Transform
       pos: -18.5,-13.5
       parent: 1
-  - uid: 1748
+  - uid: 1738
     components:
     - type: Transform
       pos: -18.5,-12.5
       parent: 1
-  - uid: 1749
+  - uid: 1739
     components:
     - type: Transform
       pos: -18.5,-11.5
       parent: 1
-  - uid: 1750
+  - uid: 1740
     components:
     - type: Transform
       pos: -18.5,-10.5
       parent: 1
-  - uid: 1751
+  - uid: 1741
     components:
     - type: Transform
       pos: -18.5,-9.5
       parent: 1
-  - uid: 1752
+  - uid: 1742
     components:
     - type: Transform
       pos: -18.5,-8.5
       parent: 1
-  - uid: 1753
+  - uid: 1743
     components:
     - type: Transform
       pos: -18.5,-7.5
       parent: 1
-  - uid: 1754
+  - uid: 1744
     components:
     - type: Transform
       pos: -18.5,-6.5
       parent: 1
-  - uid: 1755
+  - uid: 1745
     components:
     - type: Transform
       pos: -18.5,-5.5
       parent: 1
-  - uid: 1756
+  - uid: 1746
     components:
     - type: Transform
       pos: -18.5,-4.5
       parent: 1
-  - uid: 1757
+  - uid: 1747
     components:
     - type: Transform
       pos: -18.5,-3.5
       parent: 1
-  - uid: 1758
+  - uid: 1748
     components:
     - type: Transform
       pos: -18.5,-2.5
       parent: 1
-  - uid: 1759
+  - uid: 1749
     components:
     - type: Transform
       pos: -18.5,-1.5
       parent: 1
-  - uid: 1760
+  - uid: 1750
     components:
     - type: Transform
       pos: -18.5,-16.5
       parent: 1
-  - uid: 1761
+  - uid: 1751
     components:
     - type: Transform
       pos: 17.5,-16.5
       parent: 1
-  - uid: 1762
+  - uid: 1752
     components:
     - type: Transform
       pos: 16.5,-19.5
       parent: 1
-  - uid: 1763
+  - uid: 1753
     components:
     - type: Transform
       pos: 12.5,-40.5
       parent: 1
-  - uid: 1764
+  - uid: 1754
     components:
     - type: Transform
       pos: 12.5,-41.5
       parent: 1
-  - uid: 1765
+  - uid: 1755
     components:
     - type: Transform
       pos: 12.5,-42.5
       parent: 1
-  - uid: 1766
+  - uid: 1756
     components:
     - type: Transform
       pos: 12.5,-43.5
       parent: 1
-  - uid: 1767
+  - uid: 1757
     components:
     - type: Transform
       pos: 6.5,-52.5
       parent: 1
-  - uid: 1768
+  - uid: 1758
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-56.5
       parent: 1
-  - uid: 1769
+  - uid: 1759
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-56.5
       parent: 1
-  - uid: 1770
-    components:
-    - type: Transform
-      pos: -23.5,4.5
-      parent: 1
-  - uid: 1771
-    components:
-    - type: Transform
-      pos: -23.5,9.5
-      parent: 1
-  - uid: 1772
+  - uid: 1760
     components:
     - type: Transform
       pos: -23.5,14.5
       parent: 1
-  - uid: 1773
+  - uid: 1761
     components:
     - type: Transform
       pos: -23.5,19.5
       parent: 1
-  - uid: 1774
+  - uid: 1762
     components:
     - type: Transform
       pos: -23.5,24.5
       parent: 1
-  - uid: 1775
+  - uid: 1763
     components:
     - type: Transform
       pos: 21.5,-16.5
       parent: 1
-  - uid: 1776
+  - uid: 1764
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,41.5
       parent: 1
-  - uid: 1777
+  - uid: 1765
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,43.5
       parent: 1
-  - uid: 1778
+  - uid: 1766
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,42.5
       parent: 1
-  - uid: 1779
+  - uid: 1767
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,38.5
       parent: 1
-  - uid: 1780
+  - uid: 1768
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,40.5
       parent: 1
-  - uid: 1781
+  - uid: 1769
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,39.5
       parent: 1
-  - uid: 1782
+  - uid: 1770
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,36.5
       parent: 1
-  - uid: 1783
+  - uid: 1771
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,37.5
       parent: 1
-  - uid: 1784
+  - uid: 1772
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,44.5
       parent: 1
-  - uid: 1785
+  - uid: 1773
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,45.5
       parent: 1
-  - uid: 1786
+  - uid: 1774
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,37.5
       parent: 1
-  - uid: 1787
+  - uid: 1775
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,46.5
       parent: 1
-  - uid: 1788
+  - uid: 1776
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,47.5
       parent: 1
-  - uid: 1789
+  - uid: 1777
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,48.5
       parent: 1
-  - uid: 1790
+  - uid: 1778
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,49.5
       parent: 1
-  - uid: 1791
+  - uid: 1779
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,49.5
       parent: 1
-  - uid: 1792
+  - uid: 1780
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,49.5
       parent: 1
-  - uid: 1793
+  - uid: 1781
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,49.5
       parent: 1
-  - uid: 1794
+  - uid: 1782
     components:
     - type: Transform
       pos: 1.5,53.5
       parent: 1
-  - uid: 1795
+  - uid: 1783
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,53.5
       parent: 1
-  - uid: 1796
+  - uid: 1784
     components:
     - type: Transform
       pos: 1.5,54.5
       parent: 1
-  - uid: 1797
+  - uid: 1785
     components:
     - type: Transform
       pos: 0.5,54.5
       parent: 1
-  - uid: 1798
+  - uid: 1786
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,54.5
       parent: 1
-  - uid: 1799
+  - uid: 1787
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,54.5
       parent: 1
-  - uid: 1800
+  - uid: 1788
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,53.5
       parent: 1
-  - uid: 1801
+  - uid: 1789
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,53.5
       parent: 1
-  - uid: 1802
+  - uid: 1790
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,53.5
       parent: 1
-  - uid: 1803
+  - uid: 1791
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,53.5
       parent: 1
-  - uid: 1804
+  - uid: 1792
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,49.5
       parent: 1
-  - uid: 1805
+  - uid: 1793
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,49.5
       parent: 1
-  - uid: 1806
+  - uid: 1794
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,49.5
       parent: 1
-  - uid: 1807
+  - uid: 1795
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,49.5
       parent: 1
-  - uid: 1808
+  - uid: 1796
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,49.5
       parent: 1
-  - uid: 1809
+  - uid: 1797
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,49.5
       parent: 1
-  - uid: 1810
+  - uid: 1798
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,49.5
       parent: 1
-  - uid: 1811
+  - uid: 1799
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,49.5
       parent: 1
-  - uid: 1812
+  - uid: 1800
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,48.5
       parent: 1
-  - uid: 1813
+  - uid: 1801
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,47.5
       parent: 1
-  - uid: 1814
+  - uid: 1802
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,46.5
       parent: 1
-  - uid: 1815
+  - uid: 1803
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,45.5
       parent: 1
-  - uid: 1816
+  - uid: 1804
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,44.5
       parent: 1
-  - uid: 1817
+  - uid: 1805
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,44.5
       parent: 1
-  - uid: 1818
+  - uid: 1806
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,44.5
       parent: 1
-  - uid: 1819
+  - uid: 1807
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,44.5
       parent: 1
-  - uid: 1820
+  - uid: 1808
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,46.5
       parent: 1
-  - uid: 1821
+  - uid: 1809
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,47.5
       parent: 1
-  - uid: 1822
+  - uid: 1810
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,48.5
       parent: 1
-  - uid: 1823
+  - uid: 1811
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,45.5
       parent: 1
-  - uid: 1824
+  - uid: 1812
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,44.5
       parent: 1
-  - uid: 1825
+  - uid: 1813
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,44.5
       parent: 1
-  - uid: 1826
+  - uid: 1814
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,45.5
       parent: 1
-  - uid: 1827
+  - uid: 1815
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,46.5
       parent: 1
-  - uid: 1828
+  - uid: 1816
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,47.5
       parent: 1
-  - uid: 1829
+  - uid: 1817
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,48.5
       parent: 1
-  - uid: 1830
+  - uid: 1818
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,49.5
       parent: 1
-  - uid: 1831
+  - uid: 1819
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,49.5
       parent: 1
-  - uid: 1832
+  - uid: 1820
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,49.5
       parent: 1
-  - uid: 1833
+  - uid: 1821
     components:
     - type: Transform
       pos: 0.5,53.5
       parent: 1
-  - uid: 1834
+  - uid: 1822
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,53.5
       parent: 1
-  - uid: 1835
+  - uid: 1823
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,54.5
       parent: 1
-  - uid: 1836
+  - uid: 1824
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,55.5
       parent: 1
-  - uid: 1837
+  - uid: 1825
     components:
     - type: Transform
       pos: 2.5,53.5
       parent: 1
-  - uid: 1838
+  - uid: 1826
     components:
     - type: Transform
       pos: 2.5,54.5
       parent: 1
-  - uid: 1839
+  - uid: 1827
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,55.5
       parent: 1
-  - uid: 1840
+  - uid: 1828
     components:
     - type: Transform
       pos: 3.5,53.5
       parent: 1
-  - uid: 1841
+  - uid: 1829
     components:
     - type: Transform
       pos: 4.5,53.5
       parent: 1
-  - uid: 1842
+  - uid: 1830
     components:
     - type: Transform
       pos: 9.5,53.5
       parent: 1
-  - uid: 1843
+  - uid: 1831
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,35.5
       parent: 1
-  - uid: 1844
+  - uid: 1832
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,49.5
       parent: 1
-  - uid: 1845
+  - uid: 1833
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,44.5
       parent: 1
-  - uid: 1846
+  - uid: 1834
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,44.5
       parent: 1
-  - uid: 1847
+  - uid: 1835
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,44.5
       parent: 1
-  - uid: 1848
+  - uid: 1836
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,44.5
       parent: 1
-  - uid: 1849
+  - uid: 1837
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,44.5
       parent: 1
-  - uid: 1850
+  - uid: 1838
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,44.5
       parent: 1
-  - uid: 1851
+  - uid: 1839
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,44.5
       parent: 1
-  - uid: 1852
+  - uid: 1840
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,37.5
       parent: 1
-  - uid: 1853
+  - uid: 1841
     components:
     - type: Transform
       pos: 6.5,-53.5
       parent: 1
-  - uid: 1854
+  - uid: 1842
     components:
     - type: Transform
       pos: 1.5,-53.5
       parent: 1
-  - uid: 1855
+  - uid: 1843
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,44.5
       parent: 1
-  - uid: 1856
+  - uid: 1844
     components:
     - type: Transform
       pos: -22.5,39.5
       parent: 1
-  - uid: 1857
+  - uid: 1845
     components:
     - type: Transform
       pos: -22.5,44.5
       parent: 1
-  - uid: 1858
+  - uid: 1846
     components:
     - type: Transform
       pos: -19.5,44.5
       parent: 1
-  - uid: 1859
+  - uid: 1847
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,44.5
       parent: 1
-  - uid: 1860
+  - uid: 1848
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,44.5
       parent: 1
-  - uid: 1861
+  - uid: 1849
     components:
     - type: Transform
       pos: -19.5,39.5
       parent: 1
-  - uid: 1862
+  - uid: 1850
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,44.5
       parent: 1
-  - uid: 1863
+  - uid: 1851
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,44.5
       parent: 1
-  - uid: 1864
+  - uid: 1852
     components:
     - type: Transform
       pos: 7.5,-52.5
       parent: 1
-  - uid: 1865
+  - uid: 1853
     components:
     - type: Transform
       pos: 2.5,-52.5
       parent: 1
-  - uid: 1866
+  - uid: 1854
     components:
     - type: Transform
       pos: 12.5,-50.5
       parent: 1
-  - uid: 1867
+  - uid: 1855
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-56.5
       parent: 1
-  - uid: 1868
+  - uid: 1856
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-56.5
       parent: 1
-  - uid: 1869
+  - uid: 1857
     components:
     - type: Transform
       pos: 13.5,-50.5
       parent: 1
-  - uid: 1870
+  - uid: 1858
     components:
     - type: Transform
       pos: -22.5,-6.5
       parent: 1
-  - uid: 1871
+  - uid: 1859
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-56.5
       parent: 1
-  - uid: 1872
+  - uid: 1860
     components:
     - type: Transform
       pos: -6.5,-52.5
       parent: 1
-  - uid: 1873
+  - uid: 1861
     components:
     - type: Transform
       pos: 12.5,-51.5
       parent: 1
-  - uid: 1874
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,4.5
-      parent: 1
-  - uid: 1875
+  - uid: 1862
     components:
     - type: Transform
       pos: 13.5,-57.5
       parent: 1
-  - uid: 1876
+  - uid: 1863
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-56.5
       parent: 1
-  - uid: 1877
+  - uid: 1864
     components:
     - type: Transform
       pos: 12.5,-46.5
       parent: 1
-  - uid: 1878
+  - uid: 1865
     components:
     - type: Transform
       pos: 12.5,-45.5
       parent: 1
-  - uid: 1879
+  - uid: 1866
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,46.5
       parent: 1
-  - uid: 1880
+  - uid: 1867
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,47.5
       parent: 1
-  - uid: 1881
+  - uid: 1868
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,45.5
       parent: 1
-  - uid: 1882
+  - uid: 1869
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-56.5
       parent: 1
-  - uid: 1883
+  - uid: 1870
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-56.5
       parent: 1
-  - uid: 1884
+  - uid: 1871
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-56.5
       parent: 1
-  - uid: 1885
+  - uid: 1872
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-56.5
       parent: 1
-  - uid: 1886
+  - uid: 1873
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,39.5
       parent: 1
-  - uid: 1887
+  - uid: 1874
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,44.5
       parent: 1
-  - uid: 1888
+  - uid: 1875
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,44.5
       parent: 1
-  - uid: 1889
+  - uid: 1876
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,44.5
       parent: 1
-  - uid: 1890
+  - uid: 1877
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,37.5
       parent: 1
-  - uid: 1891
+  - uid: 1878
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-56.5
       parent: 1
-  - uid: 1892
+  - uid: 1879
     components:
     - type: Transform
       pos: 16.5,-57.5
       parent: 1
-  - uid: 1893
+  - uid: 1880
     components:
     - type: Transform
       pos: 13.5,-52.5
       parent: 1
-  - uid: 1894
+  - uid: 1881
     components:
     - type: Transform
       pos: 13.5,-51.5
       parent: 1
-  - uid: 1895
+  - uid: 1882
     components:
     - type: Transform
       pos: -22.5,34.5
       parent: 1
-  - uid: 1896
+  - uid: 1883
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,44.5
       parent: 1
-  - uid: 1897
+  - uid: 1884
     components:
     - type: Transform
       pos: 12.5,31.5
       parent: 1
-  - uid: 1898
+  - uid: 1885
     components:
     - type: Transform
       pos: -8.5,-52.5
       parent: 1
-  - uid: 1899
+  - uid: 1886
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-6.5
       parent: 1
-  - uid: 1900
+  - uid: 1887
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-11.5
       parent: 1
-  - uid: 1901
+  - uid: 1888
     components:
     - type: Transform
       pos: 14.5,31.5
       parent: 1
-  - uid: 1902
+  - uid: 1889
     components:
     - type: Transform
       pos: 8.5,31.5
       parent: 1
-  - uid: 1903
+  - uid: 1890
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,43.5
       parent: 1
-  - uid: 1904
+  - uid: 1891
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,41.5
       parent: 1
-  - uid: 1905
+  - uid: 1892
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,42.5
       parent: 1
-  - uid: 1906
+  - uid: 1893
     components:
     - type: Transform
       pos: 14.5,29.5
       parent: 1
-  - uid: 1907
+  - uid: 1894
     components:
     - type: Transform
       pos: -19.5,9.5
       parent: 1
-  - uid: 1908
+  - uid: 1895
     components:
     - type: Transform
       pos: -19.5,14.5
       parent: 1
-  - uid: 1909
+  - uid: 1896
     components:
     - type: Transform
       pos: -19.5,24.5
       parent: 1
-  - uid: 1910
+  - uid: 1897
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,24.5
       parent: 1
-  - uid: 1911
+  - uid: 1898
     components:
     - type: Transform
       pos: 21.5,39.5
       parent: 1
-  - uid: 1912
+  - uid: 1899
     components:
     - type: Transform
       pos: 12.5,49.5
       parent: 1
-  - uid: 1913
+  - uid: 1900
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,9.5
       parent: 1
-  - uid: 1914
+  - uid: 1901
     components:
     - type: Transform
       pos: 17.5,45.5
       parent: 1
-  - uid: 1915
+  - uid: 1902
     components:
     - type: Transform
       pos: 13.5,49.5
       parent: 1
-  - uid: 1916
+  - uid: 1903
     components:
     - type: Transform
       pos: 17.5,48.5
       parent: 1
-  - uid: 1917
+  - uid: 1904
     components:
     - type: Transform
       pos: 18.5,14.5
       parent: 1
-  - uid: 1918
+  - uid: 1905
     components:
     - type: Transform
       pos: 18.5,9.5
       parent: 1
-  - uid: 1919
+  - uid: 1906
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,4.5
       parent: 1
-  - uid: 1920
+  - uid: 1907
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,-6.5
       parent: 1
-  - uid: 1921
+  - uid: 1908
     components:
     - type: Transform
       pos: 17.5,35.5
       parent: 1
-  - uid: 1922
+  - uid: 1909
     components:
     - type: Transform
       pos: -22.5,29.5
       parent: 1
-  - uid: 1923
+  - uid: 1910
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,44.5
       parent: 1
-  - uid: 1924
+  - uid: 1911
     components:
     - type: Transform
       pos: 8.5,49.5
       parent: 1
-  - uid: 1925
+  - uid: 1912
     components:
     - type: Transform
       pos: 3.5,49.5
       parent: 1
-  - uid: 1926
+  - uid: 1913
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-48.5
       parent: 1
-  - uid: 1927
+  - uid: 1914
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-48.5
       parent: 1
-  - uid: 1928
+  - uid: 1915
     components:
     - type: Transform
       pos: 3.5,-52.5
       parent: 1
-  - uid: 1929
+  - uid: 1916
     components:
     - type: Transform
       pos: 1.5,-52.5
       parent: 1
-  - uid: 1930
+  - uid: 1917
     components:
     - type: Transform
       pos: 5.5,-52.5
       parent: 1
-  - uid: 1931
+  - uid: 1918
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,44.5
       parent: 1
-  - uid: 1932
+  - uid: 1919
     components:
     - type: Transform
       pos: 3.5,31.5
       parent: 1
-  - uid: 1933
+  - uid: 1920
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-56.5
       parent: 1
-  - uid: 1934
+  - uid: 1921
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-56.5
       parent: 1
-  - uid: 1935
+  - uid: 1922
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-56.5
       parent: 1
-  - uid: 1936
+  - uid: 1923
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,43.5
       parent: 1
-  - uid: 1937
+  - uid: 1924
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,43.5
       parent: 1
-  - uid: 1938
+  - uid: 1925
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-56.5
       parent: 1
-  - uid: 1939
+  - uid: 1926
     components:
     - type: Transform
       pos: -0.5,-52.5
       parent: 1
-  - uid: 1940
+  - uid: 1927
     components:
     - type: Transform
       pos: 7.5,-49.5
       parent: 1
-  - uid: 1941
+  - uid: 1928
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-56.5
       parent: 1
-  - uid: 1942
+  - uid: 1929
     components:
     - type: Transform
       pos: 0.5,-52.5
       parent: 1
-  - uid: 1943
+  - uid: 1930
     components:
     - type: Transform
       pos: 11.5,-52.5
       parent: 1
-  - uid: 1944
+  - uid: 1931
     components:
     - type: Transform
       pos: 18.5,29.5
       parent: 1
-  - uid: 1945
+  - uid: 1932
     components:
     - type: Transform
       pos: 4.5,-52.5
       parent: 1
-  - uid: 1946
+  - uid: 1933
     components:
     - type: Transform
       pos: 18.5,-16.5
       parent: 1
-  - uid: 1947
+  - uid: 1934
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,37.5
       parent: 1
-  - uid: 1948
+  - uid: 1935
     components:
     - type: Transform
       pos: -4.5,31.5
       parent: 1
-  - uid: 1949
+  - uid: 1936
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,36.5
       parent: 1
-  - uid: 1950
+  - uid: 1937
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,44.5
       parent: 1
-  - uid: 1951
+  - uid: 1938
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,44.5
       parent: 1
-  - uid: 1952
+  - uid: 1939
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,44.5
       parent: 1
-  - uid: 1953
+  - uid: 1940
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,44.5
       parent: 1
-  - uid: 1954
+  - uid: 1941
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,44.5
       parent: 1
-  - uid: 1955
+  - uid: 1942
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,44.5
       parent: 1
-  - uid: 1956
+  - uid: 1943
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,44.5
       parent: 1
-  - uid: 1957
+  - uid: 1944
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,44.5
       parent: 1
-  - uid: 1958
+  - uid: 1945
     components:
     - type: Transform
       pos: 17.5,34.5
       parent: 1
-  - uid: 1959
+  - uid: 1946
     components:
     - type: Transform
       pos: 17.5,47.5
       parent: 1
-  - uid: 1960
+  - uid: 1947
     components:
     - type: Transform
       pos: 14.5,49.5
       parent: 1
-  - uid: 1961
+  - uid: 1948
     components:
     - type: Transform
       pos: 11.5,49.5
       parent: 1
-  - uid: 1962
+  - uid: 1949
     components:
     - type: Transform
       pos: 17.5,46.5
       parent: 1
-  - uid: 1963
+  - uid: 1950
     components:
     - type: Transform
       pos: 10.5,-52.5
       parent: 1
-  - uid: 1964
+  - uid: 1951
     components:
     - type: Transform
       pos: 21.5,49.5
       parent: 1
-  - uid: 1965
+  - uid: 1952
     components:
     - type: Transform
       pos: 21.5,44.5
       parent: 1
-  - uid: 1966
+  - uid: 1953
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,19.5
       parent: 1
-  - uid: 1967
+  - uid: 1954
     components:
     - type: Transform
       pos: 21.5,34.5
       parent: 1
-  - uid: 1968
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 22.5,9.5
-      parent: 1
-  - uid: 1969
+  - uid: 1955
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,14.5
       parent: 1
-  - uid: 1970
+  - uid: 1956
     components:
     - type: Transform
       pos: 18.5,19.5
       parent: 1
-  - uid: 1971
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,4.5
-      parent: 1
-  - uid: 1972
+  - uid: 1957
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,14.5
       parent: 1
-  - uid: 1973
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 22.5,4.5
-      parent: 1
-  - uid: 1974
+  - uid: 1958
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,34.5
       parent: 1
-  - uid: 1975
+  - uid: 1959
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-56.5
       parent: 1
-  - uid: 1976
+  - uid: 1960
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-56.5
       parent: 1
-  - uid: 1977
+  - uid: 1961
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,36.5
       parent: 1
-  - uid: 1978
+  - uid: 1962
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,38.5
       parent: 1
-  - uid: 1979
+  - uid: 1963
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,37.5
       parent: 1
-  - uid: 1980
+  - uid: 1964
     components:
     - type: Transform
       pos: 16.5,-52.5
       parent: 1
-  - uid: 1981
+  - uid: 1965
     components:
     - type: Transform
       pos: -12.5,-60.5
       parent: 1
-  - uid: 1982
+  - uid: 1966
     components:
     - type: Transform
       pos: -13.5,-57.5
       parent: 1
-  - uid: 1983
+  - uid: 1967
     components:
     - type: Transform
       pos: -13.5,-58.5
       parent: 1
-  - uid: 1984
+  - uid: 1968
     components:
     - type: Transform
       pos: -13.5,-60.5
       parent: 1
-  - uid: 1985
+  - uid: 1969
     components:
     - type: Transform
       pos: -13.5,-59.5
       parent: 1
-  - uid: 1986
+  - uid: 1970
     components:
     - type: Transform
       pos: -11.5,-60.5
+      parent: 1
+  - uid: 1971
+    components:
+    - type: Transform
+      pos: 12.5,-60.5
+      parent: 1
+  - uid: 1972
+    components:
+    - type: Transform
+      pos: 12.5,-59.5
+      parent: 1
+  - uid: 1973
+    components:
+    - type: Transform
+      pos: 12.5,-58.5
+      parent: 1
+  - uid: 1974
+    components:
+    - type: Transform
+      pos: 12.5,-57.5
+      parent: 1
+  - uid: 1975
+    components:
+    - type: Transform
+      pos: 5.5,-64.5
+      parent: 1
+  - uid: 1976
+    components:
+    - type: Transform
+      pos: 5.5,-60.5
+      parent: 1
+  - uid: 1977
+    components:
+    - type: Transform
+      pos: 0.5,-66.5
+      parent: 1
+  - uid: 1978
+    components:
+    - type: Transform
+      pos: 5.5,-63.5
+      parent: 1
+  - uid: 1979
+    components:
+    - type: Transform
+      pos: -11.5,-61.5
+      parent: 1
+  - uid: 1980
+    components:
+    - type: Transform
+      pos: -11.5,-62.5
+      parent: 1
+  - uid: 1981
+    components:
+    - type: Transform
+      pos: -11.5,-63.5
+      parent: 1
+  - uid: 1982
+    components:
+    - type: Transform
+      pos: 11.5,-60.5
+      parent: 1
+  - uid: 1983
+    components:
+    - type: Transform
+      pos: 10.5,-60.5
+      parent: 1
+  - uid: 1984
+    components:
+    - type: Transform
+      pos: 10.5,-61.5
+      parent: 1
+  - uid: 1985
+    components:
+    - type: Transform
+      pos: 10.5,-62.5
+      parent: 1
+  - uid: 1986
+    components:
+    - type: Transform
+      pos: 10.5,-63.5
       parent: 1
   - uid: 1987
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -24.5,9.5
-      parent: 1
-  - uid: 1988
-    components:
-    - type: Transform
-      pos: 12.5,-60.5
-      parent: 1
-  - uid: 1989
-    components:
-    - type: Transform
-      pos: 12.5,-59.5
-      parent: 1
-  - uid: 1990
-    components:
-    - type: Transform
-      pos: 12.5,-58.5
-      parent: 1
-  - uid: 1991
-    components:
-    - type: Transform
-      pos: 12.5,-57.5
-      parent: 1
-  - uid: 1992
-    components:
-    - type: Transform
-      pos: 5.5,-64.5
-      parent: 1
-  - uid: 1993
-    components:
-    - type: Transform
-      pos: 5.5,-60.5
-      parent: 1
-  - uid: 1994
-    components:
-    - type: Transform
-      pos: 0.5,-66.5
-      parent: 1
-  - uid: 1995
-    components:
-    - type: Transform
-      pos: 5.5,-63.5
-      parent: 1
-  - uid: 1996
-    components:
-    - type: Transform
-      pos: -11.5,-61.5
-      parent: 1
-  - uid: 1997
-    components:
-    - type: Transform
-      pos: -11.5,-62.5
-      parent: 1
-  - uid: 1998
-    components:
-    - type: Transform
-      pos: -11.5,-63.5
-      parent: 1
-  - uid: 1999
-    components:
-    - type: Transform
-      pos: 11.5,-60.5
-      parent: 1
-  - uid: 2000
-    components:
-    - type: Transform
-      pos: 10.5,-60.5
-      parent: 1
-  - uid: 2001
-    components:
-    - type: Transform
-      pos: 10.5,-61.5
-      parent: 1
-  - uid: 2002
-    components:
-    - type: Transform
-      pos: 10.5,-62.5
-      parent: 1
-  - uid: 2003
-    components:
-    - type: Transform
-      pos: 10.5,-63.5
-      parent: 1
-  - uid: 2004
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,-65.5
       parent: 1
-  - uid: 2005
+  - uid: 1988
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-64.5
       parent: 1
-  - uid: 2006
+  - uid: 1989
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-59.5
       parent: 1
-  - uid: 2007
+  - uid: 1990
     components:
     - type: Transform
       pos: 0.5,-57.5
       parent: 1
-  - uid: 2008
+  - uid: 1991
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-60.5
       parent: 1
-  - uid: 2009
-    components:
-    - type: Transform
-      pos: 28.5,9.5
-      parent: 1
-  - uid: 2010
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.5,25.5
-      parent: 1
-  - uid: 2011
-    components:
-    - type: Transform
-      pos: -30.5,8.5
-      parent: 1
-  - uid: 2012
-    components:
-    - type: Transform
-      pos: -23.5,8.5
-      parent: 1
-  - uid: 2013
-    components:
-    - type: Transform
-      pos: -23.5,7.5
-      parent: 1
-  - uid: 2014
-    components:
-    - type: Transform
-      pos: -23.5,6.5
-      parent: 1
-  - uid: 2015
-    components:
-    - type: Transform
-      pos: -23.5,5.5
-      parent: 1
-  - uid: 2016
+  - uid: 1992
     components:
     - type: Transform
       pos: 22.5,25.5
       parent: 1
-  - uid: 2017
-    components:
-    - type: Transform
-      pos: 26.5,9.5
-      parent: 1
-  - uid: 2018
+  - uid: 1993
     components:
     - type: Transform
       pos: 3.5,38.5
       parent: 1
-  - uid: 2019
+  - uid: 1994
     components:
     - type: Transform
       pos: 8.5,36.5
       parent: 1
-  - uid: 2020
+  - uid: 1995
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,19.5
       parent: 1
-  - uid: 2021
-    components:
-    - type: Transform
-      pos: -31.5,5.5
-      parent: 1
-  - uid: 2022
+  - uid: 1996
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,20.5
       parent: 1
-  - uid: 2023
+  - uid: 1997
     components:
     - type: Transform
       pos: 4.5,49.5
       parent: 1
-  - uid: 2024
+  - uid: 1998
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-67.5
       parent: 1
-  - uid: 2025
+  - uid: 1999
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-68.5
       parent: 1
-  - uid: 2026
-    components:
-    - type: Transform
-      pos: -30.5,9.5
-      parent: 1
-  - uid: 2027
-    components:
-    - type: Transform
-      pos: -29.5,9.5
-      parent: 1
-  - uid: 2028
-    components:
-    - type: Transform
-      pos: -31.5,4.5
-      parent: 1
-  - uid: 2029
-    components:
-    - type: Transform
-      pos: -31.5,7.5
-      parent: 1
-  - uid: 2030
+  - uid: 2000
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,49.5
       parent: 1
-  - uid: 2031
+  - uid: 2001
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,48.5
       parent: 1
-  - uid: 2032
+  - uid: 2002
     components:
     - type: Transform
       pos: 2.5,49.5
       parent: 1
-  - uid: 2033
-    components:
-    - type: Transform
-      pos: 27.5,9.5
-      parent: 1
-  - uid: 2034
-    components:
-    - type: Transform
-      pos: 23.5,9.5
-      parent: 1
-  - uid: 2035
-    components:
-    - type: Transform
-      pos: 24.5,9.5
-      parent: 1
-  - uid: 2036
-    components:
-    - type: Transform
-      pos: 25.5,9.5
-      parent: 1
-  - uid: 2037
-    components:
-    - type: Transform
-      pos: 29.5,9.5
-      parent: 1
-  - uid: 2038
-    components:
-    - type: Transform
-      pos: 29.5,8.5
-      parent: 1
-  - uid: 2039
-    components:
-    - type: Transform
-      pos: 30.5,8.5
-      parent: 1
-  - uid: 2040
-    components:
-    - type: Transform
-      pos: -31.5,6.5
-      parent: 1
-  - uid: 2041
-    components:
-    - type: Transform
-      pos: -31.5,8.5
-      parent: 1
-  - uid: 2042
+  - uid: 2003
     components:
     - type: Transform
       pos: 14.5,-57.5
       parent: 1
-  - uid: 2043
-    components:
-    - type: Transform
-      pos: 22.5,8.5
-      parent: 1
-  - uid: 2044
-    components:
-    - type: Transform
-      pos: 22.5,6.5
-      parent: 1
-  - uid: 2045
-    components:
-    - type: Transform
-      pos: 22.5,7.5
-      parent: 1
-  - uid: 2046
-    components:
-    - type: Transform
-      pos: 22.5,5.5
-      parent: 1
-  - uid: 2047
+  - uid: 2004
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-59.5
       parent: 1
-  - uid: 2048
+  - uid: 2005
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-65.5
       parent: 1
-  - uid: 2049
+  - uid: 2006
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-59.5
       parent: 1
-  - uid: 2050
+  - uid: 2007
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-65.5
       parent: 1
-  - uid: 2051
+  - uid: 2008
     components:
     - type: Transform
       pos: -4.5,-56.5
       parent: 1
-  - uid: 2052
+  - uid: 2009
     components:
     - type: Transform
       pos: -5.5,-56.5
       parent: 1
-  - uid: 2053
+  - uid: 2010
     components:
     - type: Transform
       pos: -13.5,-61.5
       parent: 1
-  - uid: 2054
+  - uid: 2011
     components:
     - type: Transform
       pos: -12.5,-61.5
       parent: 1
-  - uid: 2055
+  - uid: 2012
     components:
     - type: Transform
       pos: 5.5,-59.5
       parent: 1
-  - uid: 2056
+  - uid: 2013
     components:
     - type: Transform
       pos: 11.5,-61.5
       parent: 1
-  - uid: 2057
+  - uid: 2014
     components:
     - type: Transform
       pos: 12.5,-61.5
       parent: 1
-  - uid: 2058
+  - uid: 2015
     components:
     - type: Transform
       pos: 4.5,-64.5
       parent: 1
-  - uid: 2059
+  - uid: 2016
     components:
     - type: Transform
       pos: 3.5,-64.5
       parent: 1
-  - uid: 2060
+  - uid: 2017
     components:
     - type: Transform
       pos: 2.5,-64.5
       parent: 1
-  - uid: 2061
+  - uid: 2018
     components:
     - type: Transform
       pos: 1.5,-64.5
       parent: 1
-  - uid: 2062
+  - uid: 2019
     components:
     - type: Transform
       pos: 5.5,-65.5
       parent: 1
-  - uid: 2063
+  - uid: 2020
     components:
     - type: Transform
       pos: 5.5,-68.5
       parent: 1
-  - uid: 2064
+  - uid: 2021
     components:
     - type: Transform
       pos: -15.5,-57.5
       parent: 1
-  - uid: 2065
+  - uid: 2022
     components:
     - type: Transform
       pos: 3.5,40.5
       parent: 1
-  - uid: 2066
+  - uid: 2023
     components:
     - type: Transform
       pos: 3.5,37.5
       parent: 1
-  - uid: 2067
+  - uid: 2024
     components:
     - type: Transform
       pos: 3.5,39.5
       parent: 1
-  - uid: 2068
+  - uid: 2025
     components:
     - type: Transform
       pos: 3.5,36.5
       parent: 1
-  - uid: 2069
+  - uid: 2026
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,-23.5
       parent: 1
-  - uid: 2070
+  - uid: 2027
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,-21.5
       parent: 1
-  - uid: 2071
+  - uid: 2028
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,-24.5
       parent: 1
-  - uid: 2072
+  - uid: 2029
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-21.5
       parent: 1
-  - uid: 2073
+  - uid: 2030
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-23.5
       parent: 1
-  - uid: 2074
+  - uid: 2031
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-24.5
       parent: 1
-  - uid: 2075
+  - uid: 2032
     components:
     - type: Transform
       pos: 3.5,43.5
       parent: 1
-  - uid: 2076
+  - uid: 2033
     components:
     - type: Transform
       pos: 3.5,42.5
       parent: 1
-  - uid: 2077
+  - uid: 2034
     components:
     - type: Transform
       pos: 3.5,41.5
       parent: 1
-  - uid: 2078
+  - uid: 2035
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,49.5
       parent: 1
-  - uid: 2079
+  - uid: 2036
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,41.5
       parent: 1
-  - uid: 2080
+  - uid: 2037
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,41.5
       parent: 1
-  - uid: 2081
+  - uid: 2038
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,43.5
       parent: 1
-  - uid: 2082
+  - uid: 2039
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,41.5
       parent: 1
-  - uid: 2083
+  - uid: 2040
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,37.5
       parent: 1
-  - uid: 2084
+  - uid: 2041
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,37.5
       parent: 1
-  - uid: 2085
+  - uid: 2042
     components:
     - type: Transform
       pos: -2.5,-36.5
       parent: 1
-  - uid: 2086
+  - uid: 2043
     components:
     - type: Transform
       pos: -6.5,-36.5
       parent: 1
-  - uid: 2087
+  - uid: 2044
     components:
     - type: Transform
       pos: -6.5,-37.5
       parent: 1
-  - uid: 2088
+  - uid: 2045
     components:
     - type: Transform
       pos: -4.5,-36.5
       parent: 1
-  - uid: 2089
+  - uid: 2046
     components:
     - type: Transform
       pos: -11.5,-35.5
       parent: 1
-  - uid: 2090
+  - uid: 2047
     components:
     - type: Transform
       pos: -10.5,-35.5
       parent: 1
-  - uid: 2091
+  - uid: 2048
     components:
     - type: Transform
       pos: -9.5,-35.5
       parent: 1
-  - uid: 2092
+  - uid: 2049
     components:
     - type: Transform
       pos: -8.5,-35.5
       parent: 1
-  - uid: 2093
+  - uid: 2050
     components:
     - type: Transform
       pos: -7.5,-35.5
       parent: 1
-  - uid: 2094
+  - uid: 2051
     components:
     - type: Transform
       pos: -6.5,-35.5
       parent: 1
-  - uid: 2095
+  - uid: 2052
     components:
     - type: Transform
       pos: -4.5,-35.5
       parent: 1
-  - uid: 2096
+  - uid: 2053
     components:
     - type: Transform
       pos: -3.5,-35.5
       parent: 1
-  - uid: 2097
+  - uid: 2054
     components:
     - type: Transform
       pos: -2.5,-35.5
       parent: 1
-  - uid: 2098
+  - uid: 2055
     components:
     - type: Transform
       pos: -1.5,-35.5
       parent: 1
-  - uid: 2099
+  - uid: 2056
     components:
     - type: Transform
       pos: -5.5,-35.5
       parent: 1
-  - uid: 2100
+  - uid: 2057
     components:
     - type: Transform
       pos: -0.5,-35.5
       parent: 1
+  - uid: 2058
+    components:
+    - type: Transform
+      pos: -23.5,25.5
+      parent: 1
 - proto: CMWallReinforcedHeavyAlmayer
   entities:
-  - uid: 2101
+  - uid: 2059
+    components:
+    - type: Transform
+      pos: -22.5,4.5
+      parent: 1
+  - uid: 2060
+    components:
+    - type: Transform
+      pos: 18.5,4.5
+      parent: 1
+  - uid: 2061
+    components:
+    - type: Transform
+      pos: -16.5,4.5
+      parent: 1
+  - uid: 2062
+    components:
+    - type: Transform
+      pos: -23.5,4.5
+      parent: 1
+  - uid: 2063
+    components:
+    - type: Transform
+      pos: -23.5,9.5
+      parent: 1
+  - uid: 2064
+    components:
+    - type: Transform
+      pos: -19.5,4.5
+      parent: 1
+  - uid: 2065
+    components:
+    - type: Transform
+      pos: 22.5,9.5
+      parent: 1
+  - uid: 2066
+    components:
+    - type: Transform
+      pos: 15.5,4.5
+      parent: 1
+  - uid: 2067
+    components:
+    - type: Transform
+      pos: 22.5,4.5
+      parent: 1
+  - uid: 2068
+    components:
+    - type: Transform
+      pos: -24.5,9.5
+      parent: 1
+  - uid: 2069
+    components:
+    - type: Transform
+      pos: 28.5,9.5
+      parent: 1
+  - uid: 2070
+    components:
+    - type: Transform
+      pos: -30.5,8.5
+      parent: 1
+  - uid: 2071
+    components:
+    - type: Transform
+      pos: -23.5,8.5
+      parent: 1
+  - uid: 2072
+    components:
+    - type: Transform
+      pos: -23.5,7.5
+      parent: 1
+  - uid: 2073
+    components:
+    - type: Transform
+      pos: -23.5,6.5
+      parent: 1
+  - uid: 2074
+    components:
+    - type: Transform
+      pos: -23.5,5.5
+      parent: 1
+  - uid: 2075
+    components:
+    - type: Transform
+      pos: 26.5,9.5
+      parent: 1
+  - uid: 2076
+    components:
+    - type: Transform
+      pos: -31.5,5.5
+      parent: 1
+  - uid: 2077
+    components:
+    - type: Transform
+      pos: -30.5,9.5
+      parent: 1
+  - uid: 2078
+    components:
+    - type: Transform
+      pos: -29.5,9.5
+      parent: 1
+  - uid: 2079
+    components:
+    - type: Transform
+      pos: -31.5,4.5
+      parent: 1
+  - uid: 2080
+    components:
+    - type: Transform
+      pos: -31.5,7.5
+      parent: 1
+  - uid: 2081
+    components:
+    - type: Transform
+      pos: 27.5,9.5
+      parent: 1
+  - uid: 2082
+    components:
+    - type: Transform
+      pos: 23.5,9.5
+      parent: 1
+  - uid: 2083
+    components:
+    - type: Transform
+      pos: 24.5,9.5
+      parent: 1
+  - uid: 2084
+    components:
+    - type: Transform
+      pos: 25.5,9.5
+      parent: 1
+  - uid: 2085
+    components:
+    - type: Transform
+      pos: 29.5,9.5
+      parent: 1
+  - uid: 2086
+    components:
+    - type: Transform
+      pos: 29.5,8.5
+      parent: 1
+  - uid: 2087
+    components:
+    - type: Transform
+      pos: 30.5,8.5
+      parent: 1
+  - uid: 2088
+    components:
+    - type: Transform
+      pos: -31.5,6.5
+      parent: 1
+  - uid: 2089
+    components:
+    - type: Transform
+      pos: -31.5,8.5
+      parent: 1
+  - uid: 2090
+    components:
+    - type: Transform
+      pos: 22.5,8.5
+      parent: 1
+  - uid: 2091
+    components:
+    - type: Transform
+      pos: 22.5,6.5
+      parent: 1
+  - uid: 2092
+    components:
+    - type: Transform
+      pos: 22.5,7.5
+      parent: 1
+  - uid: 2093
+    components:
+    - type: Transform
+      pos: 22.5,5.5
+      parent: 1
+  - uid: 2094
     components:
     - type: Transform
       pos: -22.5,-0.5
       parent: 1
-  - uid: 2102
+  - uid: 2095
     components:
     - type: Transform
       pos: 1.5,-69.5
       parent: 1
-  - uid: 2103
+  - uid: 2096
     components:
     - type: Transform
       pos: 3.5,-69.5
       parent: 1
-  - uid: 2104
+  - uid: 2097
     components:
     - type: Transform
       pos: 5.5,-69.5
       parent: 1
-  - uid: 2105
+  - uid: 2098
     components:
     - type: Transform
       pos: 4.5,-69.5
       parent: 1
-  - uid: 2106
+  - uid: 2099
     components:
     - type: Transform
       pos: 2.5,-69.5
       parent: 1
-  - uid: 2107
+  - uid: 2100
     components:
     - type: Transform
       pos: -18.5,-56.5
       parent: 1
-  - uid: 2108
+  - uid: 2101
     components:
     - type: Transform
       pos: 17.5,-56.5
       parent: 1
-  - uid: 2109
+  - uid: 2102
     components:
     - type: Transform
       pos: 17.5,-45.5
       parent: 1
-  - uid: 2110
+  - uid: 2103
     components:
     - type: Transform
       pos: 17.5,-50.5
       parent: 1
-  - uid: 2111
+  - uid: 2104
     components:
     - type: Transform
       pos: 22.5,-16.5
       parent: 1
-  - uid: 2112
+  - uid: 2105
     components:
     - type: Transform
       pos: 4.5,54.5
       parent: 1
-  - uid: 2113
+  - uid: 2106
     components:
     - type: Transform
       pos: 22.5,53.5
       parent: 1
-  - uid: 2114
+  - uid: 2107
     components:
     - type: Transform
       pos: 16.5,-0.5
       parent: 1
-  - uid: 2115
+  - uid: 2108
     components:
     - type: Transform
       pos: 22.5,34.5
       parent: 1
-  - uid: 2116
+  - uid: 2109
     components:
     - type: Transform
       pos: 21.5,-0.5
       parent: 1
-  - uid: 2117
+  - uid: 2110
     components:
     - type: Transform
       pos: -17.5,-0.5
       parent: 1
-  - uid: 2118
+  - uid: 2111
     components:
     - type: Transform
       pos: -19.5,-0.5
       parent: 1
-  - uid: 2119
+  - uid: 2112
     components:
     - type: Transform
       pos: -23.5,34.5
       parent: 1
-  - uid: 2120
+  - uid: 2113
     components:
     - type: Transform
       pos: -23.5,53.5
       parent: 1
-  - uid: 2121
+  - uid: 2114
     components:
     - type: Transform
       pos: -23.5,29.5
       parent: 1
-  - uid: 2122
+  - uid: 2115
     components:
     - type: Transform
       pos: -23.5,39.5
       parent: 1
-  - uid: 2123
+  - uid: 2116
     components:
     - type: Transform
       pos: -23.5,49.5
       parent: 1
-  - uid: 2124
+  - uid: 2117
     components:
     - type: Transform
       pos: -23.5,44.5
       parent: 1
-  - uid: 2125
+  - uid: 2118
     components:
     - type: Transform
       pos: -18.5,-51.5
       parent: 1
-  - uid: 2126
+  - uid: 2119
     components:
     - type: Transform
       pos: 18.5,-19.5
       parent: 1
-  - uid: 2127
+  - uid: 2120
     components:
     - type: Transform
       pos: 19.5,-19.5
       parent: 1
-  - uid: 2128
+  - uid: 2121
     components:
     - type: Transform
       pos: 20.5,-19.5
       parent: 1
-  - uid: 2129
+  - uid: 2122
     components:
     - type: Transform
       pos: 21.5,-18.5
       parent: 1
-  - uid: 2130
+  - uid: 2123
     components:
     - type: Transform
       pos: 14.5,-0.5
       parent: 1
-  - uid: 2131
+  - uid: 2124
     components:
     - type: Transform
       pos: 21.5,-19.5
       parent: 1
-  - uid: 2132
+  - uid: 2125
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 2133
+  - uid: 2126
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 2134
+  - uid: 2127
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 2135
+  - uid: 2128
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 2136
+  - uid: 2129
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
-  - uid: 2137
+  - uid: 2130
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 1
-  - uid: 2138
+  - uid: 2131
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 1
-  - uid: 2139
+  - uid: 2132
     components:
     - type: Transform
       pos: 9.5,-0.5
       parent: 1
-  - uid: 2140
+  - uid: 2133
     components:
     - type: Transform
       pos: 10.5,-0.5
       parent: 1
-  - uid: 2141
+  - uid: 2134
     components:
     - type: Transform
       pos: 11.5,-0.5
       parent: 1
-  - uid: 2142
+  - uid: 2135
     components:
     - type: Transform
       pos: 12.5,-0.5
       parent: 1
-  - uid: 2143
+  - uid: 2136
     components:
     - type: Transform
       pos: 13.5,-0.5
       parent: 1
-  - uid: 2144
+  - uid: 2137
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 2145
+  - uid: 2138
     components:
     - type: Transform
       pos: 15.5,-0.5
       parent: 1
-  - uid: 2146
+  - uid: 2139
     components:
     - type: Transform
       pos: 17.5,-0.5
       parent: 1
-  - uid: 2147
+  - uid: 2140
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 2148
+  - uid: 2141
     components:
     - type: Transform
       pos: -16.5,-0.5
       parent: 1
-  - uid: 2149
+  - uid: 2142
     components:
     - type: Transform
       pos: -15.5,-0.5
       parent: 1
-  - uid: 2150
+  - uid: 2143
     components:
     - type: Transform
       pos: -14.5,-0.5
       parent: 1
-  - uid: 2151
+  - uid: 2144
     components:
     - type: Transform
       pos: -13.5,-0.5
       parent: 1
-  - uid: 2152
+  - uid: 2145
     components:
     - type: Transform
       pos: -12.5,-0.5
       parent: 1
-  - uid: 2153
+  - uid: 2146
     components:
     - type: Transform
       pos: -11.5,-0.5
       parent: 1
-  - uid: 2154
+  - uid: 2147
     components:
     - type: Transform
       pos: -10.5,-0.5
       parent: 1
-  - uid: 2155
+  - uid: 2148
     components:
     - type: Transform
       pos: -9.5,-0.5
       parent: 1
-  - uid: 2156
+  - uid: 2149
     components:
     - type: Transform
       pos: -8.5,-0.5
       parent: 1
-  - uid: 2157
+  - uid: 2150
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 1
-  - uid: 2158
+  - uid: 2151
     components:
     - type: Transform
       pos: -6.5,-0.5
       parent: 1
-  - uid: 2159
+  - uid: 2152
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
-  - uid: 2160
+  - uid: 2153
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-  - uid: 2161
+  - uid: 2154
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 2162
+  - uid: 2155
     components:
     - type: Transform
       pos: -21.5,-19.5
       parent: 1
-  - uid: 2163
+  - uid: 2156
     components:
     - type: Transform
       pos: -23.5,-11.5
       parent: 1
-  - uid: 2164
+  - uid: 2157
     components:
     - type: Transform
       pos: 18.5,-0.5
       parent: 1
-  - uid: 2165
+  - uid: 2158
     components:
     - type: Transform
       pos: -18.5,-0.5
       parent: 1
-  - uid: 2166
+  - uid: 2159
     components:
     - type: Transform
       pos: 17.5,-40.5
       parent: 1
-  - uid: 2167
+  - uid: 2160
     components:
     - type: Transform
       pos: -19.5,-19.5
       parent: 1
-  - uid: 2168
+  - uid: 2161
     components:
     - type: Transform
       pos: -18.5,-19.5
       parent: 1
-  - uid: 2169
+  - uid: 2162
     components:
     - type: Transform
       pos: -18.5,-20.5
       parent: 1
-  - uid: 2170
+  - uid: 2163
     components:
     - type: Transform
       pos: -18.5,-25.5
       parent: 1
-  - uid: 2171
+  - uid: 2164
     components:
     - type: Transform
       pos: -18.5,-30.5
       parent: 1
-  - uid: 2172
+  - uid: 2165
     components:
     - type: Transform
       pos: -18.5,-35.5
       parent: 1
-  - uid: 2173
+  - uid: 2166
     components:
     - type: Transform
       pos: 17.5,-19.5
       parent: 1
-  - uid: 2174
+  - uid: 2167
     components:
     - type: Transform
       pos: 17.5,-20.5
       parent: 1
-  - uid: 2175
+  - uid: 2168
     components:
     - type: Transform
       pos: 17.5,-30.5
       parent: 1
-  - uid: 2176
+  - uid: 2169
     components:
     - type: Transform
       pos: 17.5,-25.5
       parent: 1
-  - uid: 2177
+  - uid: 2170
     components:
     - type: Transform
       pos: 17.5,-35.5
       parent: 1
-  - uid: 2178
+  - uid: 2171
     components:
     - type: Transform
       pos: -18.5,-40.5
       parent: 1
-  - uid: 2179
+  - uid: 2172
     components:
     - type: Transform
       pos: -18.5,-50.5
       parent: 1
-  - uid: 2180
+  - uid: 2173
     components:
     - type: Transform
       pos: -22.5,-19.5
       parent: 1
-  - uid: 2181
+  - uid: 2174
     components:
     - type: Transform
       pos: -23.5,-16.5
       parent: 1
-  - uid: 2182
+  - uid: 2175
     components:
     - type: Transform
       pos: -22.5,-17.5
       parent: 1
-  - uid: 2183
+  - uid: 2176
     components:
     - type: Transform
       pos: -23.5,-6.5
       parent: 1
-  - uid: 2184
+  - uid: 2177
     components:
     - type: Transform
       pos: -22.5,-18.5
       parent: 1
-  - uid: 2185
+  - uid: 2178
     components:
     - type: Transform
       pos: -23.5,-0.5
       parent: 1
-  - uid: 2186
+  - uid: 2179
     components:
     - type: Transform
       pos: -20.5,-19.5
       parent: 1
-  - uid: 2187
+  - uid: 2180
     components:
     - type: Transform
       pos: -23.5,-17.5
       parent: 1
-  - uid: 2188
+  - uid: 2181
     components:
     - type: Transform
       pos: -18.5,53.5
       parent: 1
-  - uid: 2189
+  - uid: 2182
     components:
     - type: Transform
       pos: -17.5,53.5
       parent: 1
-  - uid: 2190
+  - uid: 2183
     components:
     - type: Transform
       pos: -17.5,54.5
       parent: 1
-  - uid: 2191
+  - uid: 2184
     components:
     - type: Transform
       pos: -12.5,54.5
       parent: 1
-  - uid: 2192
+  - uid: 2185
     components:
     - type: Transform
       pos: -5.5,59.5
       parent: 1
-  - uid: 2193
+  - uid: 2186
     components:
     - type: Transform
       pos: 2.5,59.5
       parent: 1
-  - uid: 2194
+  - uid: 2187
     components:
     - type: Transform
       pos: -6.5,59.5
       parent: 1
-  - uid: 2195
+  - uid: 2188
     components:
     - type: Transform
       pos: -6.5,58.5
       parent: 1
-  - uid: 2196
+  - uid: 2189
     components:
     - type: Transform
       pos: -6.5,57.5
       parent: 1
-  - uid: 2197
+  - uid: 2190
     components:
     - type: Transform
       pos: -6.5,56.5
       parent: 1
-  - uid: 2198
+  - uid: 2191
     components:
     - type: Transform
       pos: -6.5,55.5
       parent: 1
-  - uid: 2199
+  - uid: 2192
     components:
     - type: Transform
       pos: 3.5,55.5
       parent: 1
-  - uid: 2200
+  - uid: 2193
     components:
     - type: Transform
       pos: 3.5,56.5
       parent: 1
-  - uid: 2201
+  - uid: 2194
     components:
     - type: Transform
       pos: 3.5,57.5
       parent: 1
-  - uid: 2202
+  - uid: 2195
     components:
     - type: Transform
       pos: 3.5,58.5
       parent: 1
-  - uid: 2203
+  - uid: 2196
     components:
     - type: Transform
       pos: 3.5,59.5
       parent: 1
-  - uid: 2204
+  - uid: 2197
     components:
     - type: Transform
       pos: 2.5,64.5
       parent: 1
-  - uid: 2205
+  - uid: 2198
     components:
     - type: Transform
       pos: -5.5,64.5
       parent: 1
-  - uid: 2206
+  - uid: 2199
     components:
     - type: Transform
       pos: -6.5,64.5
       parent: 1
-  - uid: 2207
+  - uid: 2200
     components:
     - type: Transform
       pos: 3.5,64.5
       parent: 1
-  - uid: 2208
+  - uid: 2201
     components:
     - type: Transform
       pos: -6.5,68.5
       parent: 1
-  - uid: 2209
+  - uid: 2202
     components:
     - type: Transform
       pos: -5.5,68.5
       parent: 1
-  - uid: 2210
+  - uid: 2203
     components:
     - type: Transform
       pos: 3.5,68.5
       parent: 1
-  - uid: 2211
+  - uid: 2204
     components:
     - type: Transform
       pos: 2.5,68.5
       parent: 1
-  - uid: 2212
+  - uid: 2205
     components:
     - type: Transform
       pos: -4.5,70.5
       parent: 1
-  - uid: 2213
+  - uid: 2206
     components:
     - type: Transform
       pos: 2.5,70.5
       parent: 1
-  - uid: 2214
+  - uid: 2207
     components:
     - type: Transform
       pos: -5.5,70.5
       parent: 1
-  - uid: 2215
+  - uid: 2208
     components:
     - type: Transform
       pos: 1.5,70.5
       parent: 1
-  - uid: 2216
+  - uid: 2209
     components:
     - type: Transform
       pos: -4.5,71.5
       parent: 1
-  - uid: 2217
+  - uid: 2210
     components:
     - type: Transform
       pos: 1.5,71.5
       parent: 1
-  - uid: 2218
+  - uid: 2211
     components:
     - type: Transform
       pos: -6.5,54.5
       parent: 1
-  - uid: 2219
+  - uid: 2212
     components:
     - type: Transform
       pos: -7.5,54.5
       parent: 1
-  - uid: 2220
+  - uid: 2213
     components:
     - type: Transform
       pos: 14.5,53.5
       parent: 1
-  - uid: 2221
+  - uid: 2214
     components:
     - type: Transform
       pos: 14.5,54.5
       parent: 1
-  - uid: 2222
+  - uid: 2215
     components:
     - type: Transform
       pos: 3.5,54.5
       parent: 1
-  - uid: 2223
+  - uid: 2216
     components:
     - type: Transform
       pos: 21.5,-17.5
       parent: 1
-  - uid: 2224
+  - uid: 2217
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 2225
+  - uid: 2218
     components:
     - type: Transform
       pos: 22.5,-17.5
       parent: 1
-  - uid: 2226
+  - uid: 2219
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 2227
+  - uid: 2220
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 2228
+  - uid: 2221
     components:
     - type: Transform
       pos: 22.5,-0.5
       parent: 1
-  - uid: 2229
+  - uid: 2222
     components:
     - type: Transform
       pos: 22.5,29.5
       parent: 1
-  - uid: 2230
+  - uid: 2223
     components:
     - type: Transform
       pos: 22.5,-11.5
       parent: 1
-  - uid: 2231
+  - uid: 2224
     components:
     - type: Transform
       pos: 22.5,39.5
       parent: 1
-  - uid: 2232
+  - uid: 2225
     components:
     - type: Transform
       pos: 22.5,49.5
       parent: 1
-  - uid: 2233
+  - uid: 2226
     components:
     - type: Transform
       pos: 22.5,-6.5
       parent: 1
-  - uid: 2234
+  - uid: 2227
     components:
     - type: Transform
       pos: -18.5,-45.5
       parent: 1
-  - uid: 2235
+  - uid: 2228
     components:
     - type: Transform
       pos: -18.5,-52.5
       parent: 1
-  - uid: 2236
+  - uid: 2229
     components:
     - type: Transform
       pos: 21.5,53.5
       parent: 1
-  - uid: 2237
+  - uid: 2230
     components:
     - type: Transform
       pos: 9.5,54.5
       parent: 1
-  - uid: 2238
+  - uid: 2231
     components:
     - type: Transform
       pos: 15.5,53.5
       parent: 1
-  - uid: 2239
+  - uid: 2232
     components:
     - type: Transform
       pos: 22.5,44.5
       parent: 1
-  - uid: 2240
+  - uid: 2233
     components:
     - type: Transform
       pos: 17.5,-51.5
       parent: 1
-  - uid: 2241
+  - uid: 2234
     components:
     - type: Transform
       pos: 17.5,-52.5
       parent: 1
-  - uid: 2242
+  - uid: 2235
     components:
     - type: Transform
       pos: -22.5,53.5
       parent: 1
-  - uid: 2243
+  - uid: 2236
     components:
     - type: Transform
       pos: -11.5,-66.5
       parent: 1
-  - uid: 2244
+  - uid: 2237
     components:
     - type: Transform
       pos: -30.5,3.5
       parent: 1
-  - uid: 2245
+  - uid: 2238
     components:
     - type: Transform
       pos: -11.5,-65.5
       parent: 1
-  - uid: 2246
+  - uid: 2239
     components:
     - type: Transform
       pos: -11.5,-64.5
       parent: 1
-  - uid: 2247
+  - uid: 2240
     components:
     - type: Transform
       pos: 10.5,-64.5
       parent: 1
-  - uid: 2248
+  - uid: 2241
     components:
     - type: Transform
       pos: 22.5,-1.5
       parent: 1
-  - uid: 2249
+  - uid: 2242
     components:
     - type: Transform
       pos: -23.5,-2.5
       parent: 1
-  - uid: 2250
+  - uid: 2243
     components:
     - type: Transform
       pos: -23.5,-3.5
       parent: 1
-  - uid: 2251
+  - uid: 2244
     components:
     - type: Transform
       pos: -23.5,26.5
       parent: 1
-  - uid: 2252
+  - uid: 2245
     components:
     - type: Transform
       pos: -23.5,-1.5
       parent: 1
-  - uid: 2253
+  - uid: 2246
     components:
     - type: Transform
       pos: -34.5,7.5
       parent: 1
-  - uid: 2254
+  - uid: 2247
     components:
     - type: Transform
       pos: 22.5,-2.5
       parent: 1
-  - uid: 2255
+  - uid: 2248
     components:
     - type: Transform
       pos: 22.5,26.5
       parent: 1
-  - uid: 2256
+  - uid: 2249
     components:
     - type: Transform
       pos: 22.5,-3.5
       parent: 1
-  - uid: 2257
+  - uid: 2250
     components:
     - type: Transform
       pos: -34.5,8.5
       parent: 1
-  - uid: 2258
+  - uid: 2251
     components:
     - type: Transform
       pos: -28.5,24.5
       parent: 1
-  - uid: 2259
+  - uid: 2252
     components:
     - type: Transform
       pos: -34.5,6.5
       parent: 1
-  - uid: 2260
+  - uid: 2253
     components:
     - type: Transform
       pos: -34.5,3.5
       parent: 1
-  - uid: 2261
+  - uid: 2254
     components:
     - type: Transform
       pos: -34.5,4.5
       parent: 1
-  - uid: 2262
+  - uid: 2255
     components:
     - type: Transform
       pos: -11.5,-67.5
       parent: 1
-  - uid: 2263
+  - uid: 2256
     components:
     - type: Transform
       pos: -11.5,-68.5
       parent: 1
-  - uid: 2264
+  - uid: 2257
     components:
     - type: Transform
       pos: -11.5,-69.5
       parent: 1
-  - uid: 2265
+  - uid: 2258
     components:
     - type: Transform
       pos: -10.5,-69.5
       parent: 1
-  - uid: 2266
+  - uid: 2259
     components:
     - type: Transform
       pos: -9.5,-69.5
       parent: 1
-  - uid: 2267
+  - uid: 2260
     components:
     - type: Transform
       pos: -8.5,-69.5
       parent: 1
-  - uid: 2268
+  - uid: 2261
     components:
     - type: Transform
       pos: -6.5,-69.5
       parent: 1
-  - uid: 2269
+  - uid: 2262
     components:
     - type: Transform
       pos: -5.5,-69.5
       parent: 1
-  - uid: 2270
+  - uid: 2263
     components:
     - type: Transform
       pos: -4.5,-69.5
       parent: 1
-  - uid: 2271
+  - uid: 2264
     components:
     - type: Transform
       pos: -3.5,-69.5
       parent: 1
-  - uid: 2272
+  - uid: 2265
     components:
     - type: Transform
       pos: -7.5,-69.5
       parent: 1
-  - uid: 2273
+  - uid: 2266
     components:
     - type: Transform
       pos: -1.5,-69.5
       parent: 1
-  - uid: 2274
+  - uid: 2267
     components:
     - type: Transform
       pos: -0.5,-69.5
       parent: 1
-  - uid: 2275
+  - uid: 2268
     components:
     - type: Transform
       pos: -2.5,-69.5
       parent: 1
-  - uid: 2276
+  - uid: 2269
     components:
     - type: Transform
       pos: 0.5,-69.5
       parent: 1
-  - uid: 2277
+  - uid: 2270
     components:
     - type: Transform
       pos: -34.5,16.5
       parent: 1
-  - uid: 2278
+  - uid: 2271
     components:
     - type: Transform
       pos: -32.5,20.5
       parent: 1
-  - uid: 2279
+  - uid: 2272
     components:
     - type: Transform
       pos: -30.5,24.5
       parent: 1
-  - uid: 2280
+  - uid: 2273
     components:
     - type: Transform
       pos: -34.5,5.5
       parent: 1
-  - uid: 2281
+  - uid: 2274
     components:
     - type: Transform
       pos: -30.5,-0.5
       parent: 1
-  - uid: 2282
+  - uid: 2275
     components:
     - type: Transform
       pos: -30.5,20.5
       parent: 1
-  - uid: 2283
+  - uid: 2276
     components:
     - type: Transform
       pos: -33.5,3.5
       parent: 1
-  - uid: 2284
+  - uid: 2277
     components:
     - type: Transform
       pos: -33.5,20.5
       parent: 1
-  - uid: 2285
+  - uid: 2278
     components:
     - type: Transform
       pos: -34.5,20.5
       parent: 1
-  - uid: 2286
+  - uid: 2279
     components:
     - type: Transform
       pos: -34.5,12.5
       parent: 1
-  - uid: 2287
+  - uid: 2280
     components:
     - type: Transform
       pos: -34.5,11.5
       parent: 1
-  - uid: 2288
+  - uid: 2281
     components:
     - type: Transform
       pos: -31.5,20.5
       parent: 1
-  - uid: 2289
+  - uid: 2282
     components:
     - type: Transform
       pos: -34.5,9.5
       parent: 1
-  - uid: 2290
+  - uid: 2283
     components:
     - type: Transform
       pos: -34.5,10.5
       parent: 1
-  - uid: 2291
+  - uid: 2284
     components:
     - type: Transform
       pos: -29.5,-0.5
       parent: 1
-  - uid: 2292
+  - uid: 2285
     components:
     - type: Transform
       pos: -28.5,-0.5
       parent: 1
-  - uid: 2293
+  - uid: 2286
     components:
     - type: Transform
       pos: -27.5,-0.5
       parent: 1
-  - uid: 2294
+  - uid: 2287
     components:
     - type: Transform
       pos: -24.5,-5.5
       parent: 1
-  - uid: 2295
+  - uid: 2288
     components:
     - type: Transform
       pos: -25.5,-0.5
       parent: 1
-  - uid: 2296
+  - uid: 2289
     components:
     - type: Transform
       pos: -24.5,-0.5
       parent: 1
-  - uid: 2297
+  - uid: 2290
     components:
     - type: Transform
       pos: 28.5,24.5
       parent: 1
-  - uid: 2298
+  - uid: 2291
     components:
     - type: Transform
       pos: 29.5,24.5
       parent: 1
-  - uid: 2299
+  - uid: 2292
     components:
     - type: Transform
       pos: 27.5,24.5
       parent: 1
-  - uid: 2300
+  - uid: 2293
     components:
     - type: Transform
       pos: 29.5,23.5
       parent: 1
-  - uid: 2301
+  - uid: 2294
     components:
     - type: Transform
       pos: 29.5,22.5
       parent: 1
-  - uid: 2302
+  - uid: 2295
     components:
     - type: Transform
       pos: 29.5,3.5
       parent: 1
-  - uid: 2303
+  - uid: 2296
     components:
     - type: Transform
       pos: 29.5,-0.5
       parent: 1
-  - uid: 2304
+  - uid: 2297
     components:
     - type: Transform
       pos: 31.5,8.5
       parent: 1
-  - uid: 2305
+  - uid: 2298
     components:
     - type: Transform
       pos: 32.5,8.5
       parent: 1
-  - uid: 2306
+  - uid: 2299
     components:
     - type: Transform
       pos: 33.5,8.5
       parent: 1
-  - uid: 2307
+  - uid: 2300
     components:
     - type: Transform
       pos: 33.5,9.5
       parent: 1
-  - uid: 2308
+  - uid: 2301
     components:
     - type: Transform
       pos: 33.5,10.5
       parent: 1
-  - uid: 2309
+  - uid: 2302
     components:
     - type: Transform
       pos: 33.5,11.5
       parent: 1
-  - uid: 2310
+  - uid: 2303
     components:
     - type: Transform
       pos: 33.5,13.5
       parent: 1
-  - uid: 2311
+  - uid: 2304
     components:
     - type: Transform
       pos: 33.5,14.5
       parent: 1
-  - uid: 2312
+  - uid: 2305
     components:
     - type: Transform
       pos: 33.5,15.5
       parent: 1
-  - uid: 2313
+  - uid: 2306
     components:
     - type: Transform
       pos: 33.5,16.5
       parent: 1
-  - uid: 2314
+  - uid: 2307
     components:
     - type: Transform
       pos: 33.5,17.5
       parent: 1
-  - uid: 2315
+  - uid: 2308
     components:
     - type: Transform
       pos: 33.5,18.5
       parent: 1
-  - uid: 2316
+  - uid: 2309
     components:
     - type: Transform
       pos: 33.5,19.5
       parent: 1
-  - uid: 2317
+  - uid: 2310
     components:
     - type: Transform
       pos: 33.5,12.5
       parent: 1
-  - uid: 2318
+  - uid: 2311
     components:
     - type: Transform
       pos: 30.5,20.5
       parent: 1
-  - uid: 2319
+  - uid: 2312
     components:
     - type: Transform
       pos: 31.5,20.5
       parent: 1
-  - uid: 2320
+  - uid: 2313
     components:
     - type: Transform
       pos: 32.5,20.5
       parent: 1
-  - uid: 2321
+  - uid: 2314
     components:
     - type: Transform
       pos: 33.5,20.5
       parent: 1
-  - uid: 2322
+  - uid: 2315
     components:
     - type: Transform
       pos: 28.5,-0.5
       parent: 1
-  - uid: 2323
+  - uid: 2316
     components:
     - type: Transform
       pos: 27.5,-0.5
       parent: 1
-  - uid: 2324
+  - uid: 2317
     components:
     - type: Transform
       pos: 26.5,-0.5
       parent: 1
-  - uid: 2325
+  - uid: 2318
     components:
     - type: Transform
       pos: 28.5,-1.5
       parent: 1
-  - uid: 2326
+  - uid: 2319
     components:
     - type: Transform
       pos: 24.5,-0.5
       parent: 1
-  - uid: 2327
+  - uid: 2320
     components:
     - type: Transform
       pos: 23.5,-0.5
       parent: 1
-  - uid: 2328
+  - uid: 2321
     components:
     - type: Transform
       pos: 31.5,3.5
       parent: 1
-  - uid: 2329
+  - uid: 2322
     components:
     - type: Transform
       pos: 30.5,3.5
       parent: 1
-  - uid: 2330
+  - uid: 2323
     components:
     - type: Transform
       pos: 23.5,26.5
       parent: 1
-  - uid: 2331
+  - uid: 2324
     components:
     - type: Transform
       pos: 24.5,26.5
       parent: 1
-  - uid: 2332
+  - uid: 2325
     components:
     - type: Transform
       pos: 26.5,25.5
       parent: 1
-  - uid: 2333
+  - uid: 2326
     components:
     - type: Transform
       pos: 25.5,26.5
       parent: 1
-  - uid: 2334
+  - uid: 2327
     components:
     - type: Transform
       pos: 27.5,25.5
       parent: 1
-  - uid: 2335
+  - uid: 2328
     components:
     - type: Transform
       pos: 26.5,26.5
       parent: 1
-  - uid: 2336
+  - uid: 2329
     components:
     - type: Transform
       pos: 30.5,22.5
       parent: 1
-  - uid: 2337
+  - uid: 2330
     components:
     - type: Transform
       pos: 30.5,21.5
       parent: 1
-  - uid: 2338
+  - uid: 2331
     components:
     - type: Transform
       pos: 28.5,-2.5
       parent: 1
-  - uid: 2339
+  - uid: 2332
     components:
     - type: Transform
       pos: 28.5,-4.5
       parent: 1
-  - uid: 2340
+  - uid: 2333
     components:
     - type: Transform
       pos: 28.5,-5.5
       parent: 1
-  - uid: 2341
+  - uid: 2334
     components:
     - type: Transform
       pos: 27.5,-5.5
       parent: 1
-  - uid: 2342
+  - uid: 2335
     components:
     - type: Transform
       pos: 28.5,-3.5
       parent: 1
-  - uid: 2343
+  - uid: 2336
     components:
     - type: Transform
       pos: -32.5,3.5
       parent: 1
-  - uid: 2344
+  - uid: 2337
     components:
     - type: Transform
       pos: -31.5,3.5
       parent: 1
-  - uid: 2345
+  - uid: 2338
     components:
     - type: Transform
       pos: -29.5,-4.5
       parent: 1
-  - uid: 2346
+  - uid: 2339
     components:
     - type: Transform
       pos: -28.5,-5.5
       parent: 1
-  - uid: 2347
+  - uid: 2340
     components:
     - type: Transform
       pos: -26.5,-5.5
       parent: 1
-  - uid: 2348
+  - uid: 2341
     components:
     - type: Transform
       pos: -27.5,-5.5
       parent: 1
-  - uid: 2349
+  - uid: 2342
     components:
     - type: Transform
       pos: -29.5,-5.5
       parent: 1
-  - uid: 2350
+  - uid: 2343
     components:
     - type: Transform
       pos: -27.5,25.5
       parent: 1
-  - uid: 2351
+  - uid: 2344
     components:
     - type: Transform
       pos: -27.5,26.5
       parent: 1
-  - uid: 2352
+  - uid: 2345
     components:
     - type: Transform
       pos: -28.5,25.5
       parent: 1
-  - uid: 2353
+  - uid: 2346
     components:
     - type: Transform
       pos: 22.5,-5.5
       parent: 1
-  - uid: 2354
+  - uid: 2347
     components:
     - type: Transform
       pos: -23.5,-4.5
       parent: 1
-  - uid: 2355
+  - uid: 2348
     components:
     - type: Transform
       pos: -23.5,-5.5
       parent: 1
-  - uid: 2356
+  - uid: 2349
     components:
     - type: Transform
       pos: -29.5,-3.5
       parent: 1
-  - uid: 2357
+  - uid: 2350
     components:
     - type: Transform
       pos: 22.5,-4.5
       parent: 1
-  - uid: 2358
+  - uid: 2351
     components:
     - type: Transform
       pos: -29.5,-2.5
       parent: 1
-  - uid: 2359
+  - uid: 2352
     components:
     - type: Transform
       pos: -25.5,-5.5
       parent: 1
-  - uid: 2360
+  - uid: 2353
     components:
     - type: Transform
       pos: -19.5,-62.5
       parent: 1
-  - uid: 2361
+  - uid: 2354
     components:
     - type: Transform
       pos: -19.5,-61.5
       parent: 1
-  - uid: 2362
+  - uid: 2355
     components:
     - type: Transform
       pos: -19.5,-60.5
       parent: 1
-  - uid: 2363
+  - uid: 2356
     components:
     - type: Transform
       pos: -19.5,-58.5
       parent: 1
-  - uid: 2364
+  - uid: 2357
     components:
     - type: Transform
       pos: -19.5,-59.5
       parent: 1
-  - uid: 2365
+  - uid: 2358
     components:
     - type: Transform
       pos: -19.5,-57.5
       parent: 1
-  - uid: 2366
+  - uid: 2359
     components:
     - type: Transform
       pos: -18.5,-57.5
       parent: 1
-  - uid: 2367
+  - uid: 2360
     components:
     - type: Transform
       pos: -18.5,-62.5
       parent: 1
-  - uid: 2368
+  - uid: 2361
     components:
     - type: Transform
       pos: -17.5,-62.5
       parent: 1
-  - uid: 2369
+  - uid: 2362
     components:
     - type: Transform
       pos: -16.5,-62.5
       parent: 1
-  - uid: 2370
+  - uid: 2363
     components:
     - type: Transform
       pos: -15.5,-62.5
       parent: 1
-  - uid: 2371
+  - uid: 2364
     components:
     - type: Transform
       pos: -14.5,-62.5
       parent: 1
-  - uid: 2372
+  - uid: 2365
     components:
     - type: Transform
       pos: -13.5,-62.5
       parent: 1
-  - uid: 2373
+  - uid: 2366
     components:
     - type: Transform
       pos: -12.5,-62.5
       parent: 1
-  - uid: 2374
+  - uid: 2367
     components:
     - type: Transform
       pos: -12.5,-63.5
       parent: 1
-  - uid: 2375
+  - uid: 2368
     components:
     - type: Transform
       pos: -12.5,-64.5
       parent: 1
-  - uid: 2376
+  - uid: 2369
     components:
     - type: Transform
       pos: 11.5,-62.5
       parent: 1
-  - uid: 2377
+  - uid: 2370
     components:
     - type: Transform
       pos: 11.5,-63.5
       parent: 1
-  - uid: 2378
+  - uid: 2371
     components:
     - type: Transform
       pos: 17.5,-57.5
       parent: 1
-  - uid: 2379
+  - uid: 2372
     components:
     - type: Transform
       pos: 18.5,-57.5
       parent: 1
-  - uid: 2380
+  - uid: 2373
     components:
     - type: Transform
       pos: 18.5,-58.5
       parent: 1
-  - uid: 2381
+  - uid: 2374
     components:
     - type: Transform
       pos: 18.5,-59.5
       parent: 1
-  - uid: 2382
+  - uid: 2375
     components:
     - type: Transform
       pos: 18.5,-60.5
       parent: 1
-  - uid: 2383
+  - uid: 2376
     components:
     - type: Transform
       pos: 18.5,-61.5
       parent: 1
-  - uid: 2384
+  - uid: 2377
     components:
     - type: Transform
       pos: 18.5,-62.5
       parent: 1
-  - uid: 2385
+  - uid: 2378
     components:
     - type: Transform
       pos: 17.5,-62.5
       parent: 1
-  - uid: 2386
+  - uid: 2379
     components:
     - type: Transform
       pos: 16.5,-62.5
       parent: 1
-  - uid: 2387
+  - uid: 2380
     components:
     - type: Transform
       pos: 15.5,-62.5
       parent: 1
-  - uid: 2388
+  - uid: 2381
     components:
     - type: Transform
       pos: 14.5,-62.5
       parent: 1
-  - uid: 2389
+  - uid: 2382
     components:
     - type: Transform
       pos: 13.5,-62.5
       parent: 1
-  - uid: 2390
+  - uid: 2383
     components:
     - type: Transform
       pos: 12.5,-62.5
       parent: 1
-  - uid: 2391
+  - uid: 2384
     components:
     - type: Transform
       pos: 11.5,-64.5
       parent: 1
-  - uid: 2392
+  - uid: 2385
     components:
     - type: Transform
       pos: -29.5,-1.5
       parent: 1
-  - uid: 2393
+  - uid: 2386
     components:
     - type: Transform
       pos: 26.5,-5.5
       parent: 1
-  - uid: 2394
+  - uid: 2387
     components:
     - type: Transform
       pos: 25.5,-5.5
       parent: 1
-  - uid: 2395
+  - uid: 2388
     components:
     - type: Transform
       pos: 23.5,-5.5
       parent: 1
-  - uid: 2396
+  - uid: 2389
     components:
     - type: Transform
       pos: 24.5,-5.5
       parent: 1
-  - uid: 2397
+  - uid: 2390
     components:
     - type: Transform
       pos: 8.5,-69.5
       parent: 1
-  - uid: 2398
+  - uid: 2391
     components:
     - type: Transform
       pos: 9.5,-69.5
       parent: 1
-  - uid: 2399
+  - uid: 2392
     components:
     - type: Transform
       pos: 10.5,-69.5
       parent: 1
-  - uid: 2400
+  - uid: 2393
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,-8.5
       parent: 1
-  - uid: 2401
+  - uid: 2394
     components:
     - type: Transform
       pos: 22.5,-18.5
       parent: 1
-  - uid: 2402
+  - uid: 2395
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-26.5
       parent: 1
-  - uid: 2403
+  - uid: 2396
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-27.5
       parent: 1
-  - uid: 2404
+  - uid: 2397
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-28.5
       parent: 1
-  - uid: 2405
+  - uid: 2398
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-29.5
       parent: 1
-  - uid: 2406
+  - uid: 2399
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,-28.5
       parent: 1
-  - uid: 2407
+  - uid: 2400
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,-29.5
       parent: 1
-  - uid: 2408
+  - uid: 2401
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,-26.5
       parent: 1
-  - uid: 2409
+  - uid: 2402
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,-27.5
       parent: 1
-  - uid: 2410
+  - uid: 2403
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,-8.5
       parent: 1
-  - uid: 2411
+  - uid: 2404
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,-7.5
       parent: 1
-  - uid: 2412
+  - uid: 2405
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,-7.5
       parent: 1
-  - uid: 2413
+  - uid: 2406
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,-6.5
       parent: 1
-  - uid: 2414
+  - uid: 2407
     components:
     - type: Transform
       pos: 22.5,-19.5
       parent: 1
-  - uid: 2415
+  - uid: 2408
     components:
     - type: Transform
       pos: -23.5,-18.5
       parent: 1
-  - uid: 2416
+  - uid: 2409
     components:
     - type: Transform
       pos: -23.5,-20.5
       parent: 1
-  - uid: 2417
+  - uid: 2410
     components:
     - type: Transform
       pos: -23.5,-21.5
       parent: 1
-  - uid: 2418
+  - uid: 2411
     components:
     - type: Transform
       pos: -23.5,-19.5
       parent: 1
-  - uid: 2419
+  - uid: 2412
     components:
     - type: Transform
       pos: -23.5,-22.5
       parent: 1
-  - uid: 2420
+  - uid: 2413
     components:
     - type: Transform
       pos: -23.5,-24.5
       parent: 1
-  - uid: 2421
+  - uid: 2414
     components:
     - type: Transform
       pos: -23.5,-23.5
       parent: 1
-  - uid: 2422
+  - uid: 2415
     components:
     - type: Transform
       pos: -23.5,-25.5
       parent: 1
-  - uid: 2423
+  - uid: 2416
     components:
     - type: Transform
       pos: -22.5,-25.5
       parent: 1
-  - uid: 2424
+  - uid: 2417
     components:
     - type: Transform
       pos: -21.5,-25.5
       parent: 1
-  - uid: 2425
+  - uid: 2418
     components:
     - type: Transform
       pos: -20.5,-25.5
       parent: 1
-  - uid: 2426
+  - uid: 2419
     components:
     - type: Transform
       pos: -19.5,-25.5
       parent: 1
-  - uid: 2427
+  - uid: 2420
     components:
     - type: Transform
       pos: 22.5,-20.5
       parent: 1
-  - uid: 2428
+  - uid: 2421
     components:
     - type: Transform
       pos: 22.5,-21.5
       parent: 1
-  - uid: 2429
+  - uid: 2422
     components:
     - type: Transform
       pos: 22.5,-22.5
       parent: 1
-  - uid: 2430
+  - uid: 2423
     components:
     - type: Transform
       pos: 22.5,-23.5
       parent: 1
-  - uid: 2431
+  - uid: 2424
     components:
     - type: Transform
       pos: 22.5,-25.5
       parent: 1
-  - uid: 2432
+  - uid: 2425
     components:
     - type: Transform
       pos: 22.5,-24.5
       parent: 1
-  - uid: 2433
+  - uid: 2426
     components:
     - type: Transform
       pos: 21.5,-25.5
       parent: 1
-  - uid: 2434
+  - uid: 2427
     components:
     - type: Transform
       pos: 20.5,-25.5
       parent: 1
-  - uid: 2435
+  - uid: 2428
     components:
     - type: Transform
       pos: 19.5,-25.5
       parent: 1
-  - uid: 2436
+  - uid: 2429
     components:
     - type: Transform
       pos: 18.5,-25.5
       parent: 1
-  - uid: 2437
+  - uid: 2430
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-28.5
       parent: 1
-  - uid: 2438
+  - uid: 2431
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-26.5
       parent: 1
-  - uid: 2439
+  - uid: 2432
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-27.5
       parent: 1
-  - uid: 2440
+  - uid: 2433
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 20.5,-26.5
       parent: 1
-  - uid: 2441
+  - uid: 2434
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,-26.5
       parent: 1
-  - uid: 2442
+  - uid: 2435
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,-26.5
       parent: 1
-  - uid: 2443
+  - uid: 2436
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,-26.5
       parent: 1
-  - uid: 2444
+  - uid: 2437
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-26.5
       parent: 1
-  - uid: 2445
+  - uid: 2438
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-27.5
       parent: 1
-  - uid: 2446
+  - uid: 2439
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-28.5
       parent: 1
-  - uid: 2447
+  - uid: 2440
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,-6.5
       parent: 1
-  - uid: 2448
+  - uid: 2441
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,-7.5
       parent: 1
-  - uid: 2449
+  - uid: 2442
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,-8.5
       parent: 1
-  - uid: 2450
+  - uid: 2443
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-6.5
       parent: 1
-  - uid: 2451
+  - uid: 2444
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,-6.5
       parent: 1
-  - uid: 2452
+  - uid: 2445
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,-7.5
       parent: 1
-  - uid: 2453
+  - uid: 2446
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,-8.5
       parent: 1
-  - uid: 2454
+  - uid: 2447
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,-6.5
       parent: 1
-  - uid: 2455
+  - uid: 2448
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,-6.5
       parent: 1
+  - uid: 2449
+    components:
+    - type: Transform
+      pos: -25.5,9.5
+      parent: 1
+  - uid: 2450
+    components:
+    - type: Transform
+      pos: -26.5,9.5
+      parent: 1
+  - uid: 2451
+    components:
+    - type: Transform
+      pos: -28.5,9.5
+      parent: 1
+  - uid: 2452
+    components:
+    - type: Transform
+      pos: -27.5,9.5
+      parent: 1
 - proto: CMWallShuttleOrange
   entities:
-  - uid: 2456
+  - uid: 2453
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,54.5
       parent: 1
-  - uid: 2457
+  - uid: 2454
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,53.5
       parent: 1
-  - uid: 2458
+  - uid: 2455
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,55.5
       parent: 1
-  - uid: 2459
+  - uid: 2456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,56.5
       parent: 1
-  - uid: 2460
+  - uid: 2457
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,57.5
       parent: 1
-  - uid: 2461
+  - uid: 2458
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,58.5
       parent: 1
-  - uid: 2462
+  - uid: 2459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,59.5
       parent: 1
-  - uid: 2463
+  - uid: 2460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,60.5
       parent: 1
-  - uid: 2464
+  - uid: 2461
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,61.5
       parent: 1
-  - uid: 2465
+  - uid: 2462
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,62.5
       parent: 1
-  - uid: 2466
+  - uid: 2463
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,63.5
       parent: 1
-  - uid: 2467
+  - uid: 2464
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,64.5
       parent: 1
-  - uid: 2468
+  - uid: 2465
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,65.5
       parent: 1
-  - uid: 2469
+  - uid: 2466
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,66.5
       parent: 1
-  - uid: 2470
+  - uid: 2467
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,67.5
       parent: 1
-  - uid: 2471
+  - uid: 2468
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,68.5
       parent: 1
-  - uid: 2472
+  - uid: 2469
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,69.5
       parent: 1
-  - uid: 2473
+  - uid: 2470
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,70.5
       parent: 1
-  - uid: 2474
+  - uid: 2471
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,71.5
       parent: 1
-  - uid: 2475
+  - uid: 2472
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,72.5
       parent: 1
-  - uid: 2476
+  - uid: 2473
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,73.5
       parent: 1
-  - uid: 2477
+  - uid: 2474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,74.5
       parent: 1
-  - uid: 2478
+  - uid: 2475
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,75.5
       parent: 1
-  - uid: 2479
+  - uid: 2476
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,76.5
       parent: 1
-  - uid: 2480
+  - uid: 2477
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,77.5
       parent: 1
-  - uid: 2481
+  - uid: 2478
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,78.5
       parent: 1
-  - uid: 2482
+  - uid: 2479
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,79.5
       parent: 1
-  - uid: 2483
+  - uid: 2480
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,80.5
       parent: 1
-  - uid: 2484
+  - uid: 2481
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,81.5
       parent: 1
-  - uid: 2485
+  - uid: 2482
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,82.5
       parent: 1
-  - uid: 2486
+  - uid: 2483
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,83.5
       parent: 1
-  - uid: 2487
+  - uid: 2484
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,84.5
       parent: 1
-  - uid: 2488
+  - uid: 2485
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,85.5
       parent: 1
-  - uid: 2489
+  - uid: 2486
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,86.5
       parent: 1
-  - uid: 2490
+  - uid: 2487
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,87.5
       parent: 1
-  - uid: 2491
+  - uid: 2488
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,88.5
       parent: 1
-  - uid: 2492
+  - uid: 2489
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,89.5
       parent: 1
-  - uid: 2493
+  - uid: 2490
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,90.5
       parent: 1
-  - uid: 2494
+  - uid: 2491
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,91.5
       parent: 1
-  - uid: 2495
+  - uid: 2492
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,92.5
       parent: 1
-  - uid: 2496
+  - uid: 2493
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,93.5
       parent: 1
-  - uid: 2497
+  - uid: 2494
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,94.5
       parent: 1
-  - uid: 2498
+  - uid: 2495
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,95.5
       parent: 1
-  - uid: 2499
+  - uid: 2496
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,96.5
       parent: 1
-  - uid: 2500
+  - uid: 2497
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,97.5
       parent: 1
-  - uid: 2501
+  - uid: 2498
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,98.5
       parent: 1
-  - uid: 2502
+  - uid: 2499
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,99.5
       parent: 1
-  - uid: 2503
+  - uid: 2500
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,100.5
       parent: 1
-  - uid: 2504
+  - uid: 2501
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,101.5
       parent: 1
-  - uid: 2505
+  - uid: 2502
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,102.5
       parent: 1
-  - uid: 2506
+  - uid: 2503
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,103.5
       parent: 1
-  - uid: 2507
+  - uid: 2504
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,104.5
       parent: 1
-  - uid: 2508
+  - uid: 2505
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,105.5
       parent: 1
-  - uid: 2509
+  - uid: 2506
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,106.5
       parent: 1
-  - uid: 2510
+  - uid: 2507
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,107.5
       parent: 1
-  - uid: 2511
+  - uid: 2508
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,108.5
       parent: 1
-  - uid: 2512
+  - uid: 2509
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,109.5
       parent: 1
-  - uid: 2513
+  - uid: 2510
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,110.5
       parent: 1
-  - uid: 2514
+  - uid: 2511
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,111.5
       parent: 1
-  - uid: 2515
+  - uid: 2512
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,111.5
       parent: 1
-  - uid: 2516
+  - uid: 2513
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 44.5,111.5
       parent: 1
-  - uid: 2517
+  - uid: 2514
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 43.5,111.5
       parent: 1
-  - uid: 2518
+  - uid: 2515
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,111.5
       parent: 1
-  - uid: 2519
+  - uid: 2516
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 41.5,111.5
       parent: 1
-  - uid: 2520
+  - uid: 2517
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,111.5
       parent: 1
-  - uid: 2521
+  - uid: 2518
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 39.5,111.5
       parent: 1
-  - uid: 2522
+  - uid: 2519
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 38.5,111.5
       parent: 1
-  - uid: 2523
+  - uid: 2520
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,111.5
       parent: 1
-  - uid: 2524
+  - uid: 2521
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,111.5
       parent: 1
-  - uid: 2525
+  - uid: 2522
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 35.5,111.5
       parent: 1
-  - uid: 2526
+  - uid: 2523
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,111.5
       parent: 1
-  - uid: 2527
+  - uid: 2524
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 33.5,111.5
       parent: 1
-  - uid: 2528
+  - uid: 2525
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.5,111.5
       parent: 1
-  - uid: 2529
+  - uid: 2526
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,111.5
       parent: 1
-  - uid: 2530
+  - uid: 2527
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,111.5
       parent: 1
-  - uid: 2531
+  - uid: 2528
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 29.5,111.5
       parent: 1
-  - uid: 2532
+  - uid: 2529
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,111.5
       parent: 1
-  - uid: 2533
+  - uid: 2530
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 27.5,111.5
       parent: 1
-  - uid: 2534
+  - uid: 2531
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,111.5
       parent: 1
-  - uid: 2535
+  - uid: 2532
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,111.5
       parent: 1
-  - uid: 2536
+  - uid: 2533
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 24.5,111.5
       parent: 1
-  - uid: 2537
+  - uid: 2534
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 23.5,111.5
       parent: 1
-  - uid: 2538
+  - uid: 2535
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,111.5
       parent: 1
-  - uid: 2539
+  - uid: 2536
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,111.5
       parent: 1
-  - uid: 2540
+  - uid: 2537
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,111.5
       parent: 1
-  - uid: 2541
+  - uid: 2538
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,111.5
       parent: 1
-  - uid: 2542
+  - uid: 2539
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,111.5
       parent: 1
-  - uid: 2543
+  - uid: 2540
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,111.5
       parent: 1
-  - uid: 2544
+  - uid: 2541
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,111.5
       parent: 1
-  - uid: 2545
+  - uid: 2542
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,111.5
       parent: 1
-  - uid: 2546
+  - uid: 2543
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,111.5
       parent: 1
-  - uid: 2547
+  - uid: 2544
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,111.5
       parent: 1
-  - uid: 2548
+  - uid: 2545
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,111.5
       parent: 1
-  - uid: 2549
+  - uid: 2546
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,111.5
       parent: 1
-  - uid: 2550
+  - uid: 2547
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,111.5
       parent: 1
-  - uid: 2551
+  - uid: 2548
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,111.5
       parent: 1
-  - uid: 2552
+  - uid: 2549
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,111.5
       parent: 1
-  - uid: 2553
+  - uid: 2550
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,111.5
       parent: 1
-  - uid: 2554
+  - uid: 2551
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,111.5
       parent: 1
-  - uid: 2555
+  - uid: 2552
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,111.5
       parent: 1
-  - uid: 2556
+  - uid: 2553
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,111.5
       parent: 1
-  - uid: 2557
+  - uid: 2554
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,111.5
       parent: 1
-  - uid: 2558
+  - uid: 2555
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,111.5
       parent: 1
-  - uid: 2559
+  - uid: 2556
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,111.5
       parent: 1
-  - uid: 2560
+  - uid: 2557
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,111.5
       parent: 1
-  - uid: 2561
+  - uid: 2558
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,111.5
       parent: 1
-  - uid: 2562
+  - uid: 2559
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,111.5
       parent: 1
-  - uid: 2563
+  - uid: 2560
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,111.5
       parent: 1
-  - uid: 2564
+  - uid: 2561
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,111.5
       parent: 1
-  - uid: 2565
+  - uid: 2562
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,111.5
       parent: 1
-  - uid: 2566
+  - uid: 2563
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,111.5
       parent: 1
-  - uid: 2567
+  - uid: 2564
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,111.5
       parent: 1
-  - uid: 2568
+  - uid: 2565
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,111.5
       parent: 1
-  - uid: 2569
+  - uid: 2566
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,111.5
       parent: 1
-  - uid: 2570
+  - uid: 2567
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,111.5
       parent: 1
-  - uid: 2571
+  - uid: 2568
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,111.5
       parent: 1
-  - uid: 2572
+  - uid: 2569
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,111.5
       parent: 1
-  - uid: 2573
+  - uid: 2570
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,111.5
       parent: 1
-  - uid: 2574
+  - uid: 2571
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,111.5
       parent: 1
-  - uid: 2575
+  - uid: 2572
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,111.5
       parent: 1
-  - uid: 2576
+  - uid: 2573
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,111.5
       parent: 1
-  - uid: 2577
+  - uid: 2574
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,111.5
       parent: 1
-  - uid: 2578
+  - uid: 2575
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,111.5
       parent: 1
-  - uid: 2579
+  - uid: 2576
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,111.5
       parent: 1
-  - uid: 2580
+  - uid: 2577
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,111.5
       parent: 1
-  - uid: 2581
+  - uid: 2578
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,111.5
       parent: 1
-  - uid: 2582
+  - uid: 2579
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,111.5
       parent: 1
-  - uid: 2583
+  - uid: 2580
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,111.5
       parent: 1
-  - uid: 2584
+  - uid: 2581
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,111.5
       parent: 1
-  - uid: 2585
+  - uid: 2582
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,111.5
       parent: 1
-  - uid: 2586
+  - uid: 2583
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -26.5,111.5
       parent: 1
-  - uid: 2587
+  - uid: 2584
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,111.5
       parent: 1
-  - uid: 2588
+  - uid: 2585
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,111.5
       parent: 1
-  - uid: 2589
+  - uid: 2586
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,111.5
       parent: 1
-  - uid: 2590
+  - uid: 2587
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,111.5
       parent: 1
-  - uid: 2591
+  - uid: 2588
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,111.5
       parent: 1
-  - uid: 2592
+  - uid: 2589
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,111.5
       parent: 1
-  - uid: 2593
+  - uid: 2590
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,111.5
       parent: 1
-  - uid: 2594
+  - uid: 2591
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,111.5
       parent: 1
-  - uid: 2595
+  - uid: 2592
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -35.5,111.5
       parent: 1
-  - uid: 2596
+  - uid: 2593
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -36.5,111.5
       parent: 1
-  - uid: 2597
+  - uid: 2594
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,111.5
       parent: 1
-  - uid: 2598
+  - uid: 2595
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,111.5
       parent: 1
-  - uid: 2599
+  - uid: 2596
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -39.5,111.5
       parent: 1
-  - uid: 2600
+  - uid: 2597
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -40.5,111.5
       parent: 1
-  - uid: 2601
+  - uid: 2598
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,111.5
       parent: 1
-  - uid: 2602
+  - uid: 2599
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -42.5,111.5
       parent: 1
-  - uid: 2603
+  - uid: 2600
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -43.5,111.5
       parent: 1
-  - uid: 2604
+  - uid: 2601
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,111.5
       parent: 1
-  - uid: 2605
+  - uid: 2602
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -45.5,111.5
       parent: 1
-  - uid: 2606
+  - uid: 2603
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -46.5,111.5
       parent: 1
-  - uid: 2607
+  - uid: 2604
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -47.5,111.5
       parent: 1
-  - uid: 2608
+  - uid: 2605
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -48.5,111.5
       parent: 1
-  - uid: 2609
+  - uid: 2606
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -49.5,111.5
       parent: 1
-  - uid: 2610
+  - uid: 2607
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,111.5
       parent: 1
-  - uid: 2611
+  - uid: 2608
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 20.5,111.5
       parent: 1
-  - uid: 2612
+  - uid: 2609
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,109.5
       parent: 1
-  - uid: 2613
+  - uid: 2610
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,108.5
       parent: 1
-  - uid: 2614
+  - uid: 2611
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,107.5
       parent: 1
-  - uid: 2615
+  - uid: 2612
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,106.5
       parent: 1
-  - uid: 2616
+  - uid: 2613
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,105.5
       parent: 1
-  - uid: 2617
+  - uid: 2614
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,104.5
       parent: 1
-  - uid: 2618
+  - uid: 2615
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,103.5
       parent: 1
-  - uid: 2619
+  - uid: 2616
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,102.5
       parent: 1
-  - uid: 2620
+  - uid: 2617
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,101.5
       parent: 1
-  - uid: 2621
+  - uid: 2618
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,100.5
       parent: 1
-  - uid: 2622
+  - uid: 2619
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,110.5
       parent: 1
-  - uid: 2623
+  - uid: 2620
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,98.5
       parent: 1
-  - uid: 2624
+  - uid: 2621
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,97.5
       parent: 1
-  - uid: 2625
+  - uid: 2622
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,96.5
       parent: 1
-  - uid: 2626
+  - uid: 2623
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,95.5
       parent: 1
-  - uid: 2627
+  - uid: 2624
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,94.5
       parent: 1
-  - uid: 2628
+  - uid: 2625
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,93.5
       parent: 1
-  - uid: 2629
+  - uid: 2626
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,99.5
       parent: 1
-  - uid: 2630
+  - uid: 2627
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,91.5
       parent: 1
-  - uid: 2631
+  - uid: 2628
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,90.5
       parent: 1
-  - uid: 2632
+  - uid: 2629
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,89.5
       parent: 1
-  - uid: 2633
+  - uid: 2630
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,88.5
       parent: 1
-  - uid: 2634
+  - uid: 2631
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,87.5
       parent: 1
-  - uid: 2635
+  - uid: 2632
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,86.5
       parent: 1
-  - uid: 2636
+  - uid: 2633
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,85.5
       parent: 1
-  - uid: 2637
+  - uid: 2634
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,84.5
       parent: 1
-  - uid: 2638
+  - uid: 2635
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,83.5
       parent: 1
-  - uid: 2639
+  - uid: 2636
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,82.5
       parent: 1
-  - uid: 2640
+  - uid: 2637
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,81.5
       parent: 1
-  - uid: 2641
+  - uid: 2638
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,92.5
       parent: 1
-  - uid: 2642
+  - uid: 2639
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,79.5
       parent: 1
-  - uid: 2643
+  - uid: 2640
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,78.5
       parent: 1
-  - uid: 2644
+  - uid: 2641
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,77.5
       parent: 1
-  - uid: 2645
+  - uid: 2642
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,76.5
       parent: 1
-  - uid: 2646
+  - uid: 2643
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,75.5
       parent: 1
-  - uid: 2647
+  - uid: 2644
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,74.5
       parent: 1
-  - uid: 2648
+  - uid: 2645
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,73.5
       parent: 1
-  - uid: 2649
+  - uid: 2646
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,72.5
       parent: 1
-  - uid: 2650
+  - uid: 2647
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,71.5
       parent: 1
-  - uid: 2651
+  - uid: 2648
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,70.5
       parent: 1
-  - uid: 2652
+  - uid: 2649
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,69.5
       parent: 1
-  - uid: 2653
+  - uid: 2650
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,68.5
       parent: 1
-  - uid: 2654
+  - uid: 2651
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,67.5
       parent: 1
-  - uid: 2655
+  - uid: 2652
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,80.5
       parent: 1
-  - uid: 2656
+  - uid: 2653
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,65.5
       parent: 1
-  - uid: 2657
+  - uid: 2654
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,62.5
       parent: 1
-  - uid: 2658
+  - uid: 2655
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,63.5
       parent: 1
-  - uid: 2659
+  - uid: 2656
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,66.5
       parent: 1
-  - uid: 2660
+  - uid: 2657
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,60.5
       parent: 1
-  - uid: 2661
+  - uid: 2658
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,59.5
       parent: 1
-  - uid: 2662
+  - uid: 2659
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,58.5
       parent: 1
-  - uid: 2663
+  - uid: 2660
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,57.5
       parent: 1
-  - uid: 2664
+  - uid: 2661
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,56.5
       parent: 1
-  - uid: 2665
+  - uid: 2662
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,55.5
       parent: 1
-  - uid: 2666
+  - uid: 2663
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,54.5
       parent: 1
-  - uid: 2667
+  - uid: 2664
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,53.5
       parent: 1
-  - uid: 2668
+  - uid: 2665
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,52.5
       parent: 1
-  - uid: 2669
+  - uid: 2666
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,51.5
       parent: 1
-  - uid: 2670
+  - uid: 2667
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,50.5
       parent: 1
-  - uid: 2671
+  - uid: 2668
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,49.5
       parent: 1
-  - uid: 2672
+  - uid: 2669
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,48.5
       parent: 1
-  - uid: 2673
+  - uid: 2670
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,61.5
       parent: 1
-  - uid: 2674
+  - uid: 2671
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,46.5
       parent: 1
-  - uid: 2675
+  - uid: 2672
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,45.5
       parent: 1
-  - uid: 2676
+  - uid: 2673
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,44.5
       parent: 1
-  - uid: 2677
+  - uid: 2674
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,43.5
       parent: 1
-  - uid: 2678
+  - uid: 2675
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,47.5
       parent: 1
-  - uid: 2679
+  - uid: 2676
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,42.5
       parent: 1
-  - uid: 2680
+  - uid: 2677
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,40.5
       parent: 1
-  - uid: 2681
+  - uid: 2678
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,39.5
       parent: 1
-  - uid: 2682
+  - uid: 2679
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,38.5
       parent: 1
-  - uid: 2683
+  - uid: 2680
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,37.5
       parent: 1
-  - uid: 2684
+  - uid: 2681
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,36.5
       parent: 1
-  - uid: 2685
+  - uid: 2682
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,35.5
       parent: 1
-  - uid: 2686
+  - uid: 2683
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,34.5
       parent: 1
-  - uid: 2687
+  - uid: 2684
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,64.5
       parent: 1
-  - uid: 2688
+  - uid: 2685
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,32.5
       parent: 1
-  - uid: 2689
+  - uid: 2686
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,31.5
       parent: 1
-  - uid: 2690
+  - uid: 2687
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,30.5
       parent: 1
-  - uid: 2691
+  - uid: 2688
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,29.5
       parent: 1
-  - uid: 2692
+  - uid: 2689
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,28.5
       parent: 1
-  - uid: 2693
+  - uid: 2690
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,27.5
       parent: 1
-  - uid: 2694
+  - uid: 2691
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,26.5
       parent: 1
-  - uid: 2695
+  - uid: 2692
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,25.5
       parent: 1
-  - uid: 2696
+  - uid: 2693
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,24.5
       parent: 1
-  - uid: 2697
+  - uid: 2694
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,33.5
       parent: 1
-  - uid: 2698
+  - uid: 2695
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,22.5
       parent: 1
-  - uid: 2699
+  - uid: 2696
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,21.5
       parent: 1
-  - uid: 2700
+  - uid: 2697
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,20.5
       parent: 1
-  - uid: 2701
+  - uid: 2698
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,19.5
       parent: 1
-  - uid: 2702
+  - uid: 2699
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,18.5
       parent: 1
-  - uid: 2703
+  - uid: 2700
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,17.5
       parent: 1
-  - uid: 2704
+  - uid: 2701
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,16.5
       parent: 1
-  - uid: 2705
+  - uid: 2702
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,15.5
       parent: 1
-  - uid: 2706
+  - uid: 2703
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,14.5
       parent: 1
-  - uid: 2707
+  - uid: 2704
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,13.5
       parent: 1
-  - uid: 2708
+  - uid: 2705
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,12.5
       parent: 1
-  - uid: 2709
+  - uid: 2706
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,11.5
       parent: 1
-  - uid: 2710
+  - uid: 2707
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,10.5
       parent: 1
-  - uid: 2711
+  - uid: 2708
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,9.5
       parent: 1
-  - uid: 2712
+  - uid: 2709
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,8.5
       parent: 1
-  - uid: 2713
+  - uid: 2710
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,7.5
       parent: 1
-  - uid: 2714
+  - uid: 2711
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,6.5
       parent: 1
-  - uid: 2715
+  - uid: 2712
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,5.5
       parent: 1
-  - uid: 2716
+  - uid: 2713
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,4.5
       parent: 1
-  - uid: 2717
+  - uid: 2714
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,3.5
       parent: 1
-  - uid: 2718
+  - uid: 2715
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,2.5
       parent: 1
-  - uid: 2719
+  - uid: 2716
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,1.5
       parent: 1
-  - uid: 2720
+  - uid: 2717
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,0.5
       parent: 1
-  - uid: 2721
+  - uid: 2718
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-0.5
       parent: 1
-  - uid: 2722
+  - uid: 2719
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-1.5
       parent: 1
-  - uid: 2723
+  - uid: 2720
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-2.5
       parent: 1
-  - uid: 2724
+  - uid: 2721
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,23.5
       parent: 1
-  - uid: 2725
+  - uid: 2722
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-3.5
       parent: 1
-  - uid: 2726
+  - uid: 2723
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-4.5
       parent: 1
-  - uid: 2727
+  - uid: 2724
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-5.5
       parent: 1
-  - uid: 2728
+  - uid: 2725
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-6.5
       parent: 1
-  - uid: 2729
+  - uid: 2726
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-7.5
       parent: 1
-  - uid: 2730
+  - uid: 2727
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-8.5
       parent: 1
-  - uid: 2731
+  - uid: 2728
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-9.5
       parent: 1
-  - uid: 2732
+  - uid: 2729
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-10.5
       parent: 1
-  - uid: 2733
+  - uid: 2730
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-11.5
       parent: 1
-  - uid: 2734
+  - uid: 2731
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-12.5
       parent: 1
-  - uid: 2735
+  - uid: 2732
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-13.5
       parent: 1
-  - uid: 2736
+  - uid: 2733
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-14.5
       parent: 1
-  - uid: 2737
+  - uid: 2734
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-15.5
       parent: 1
-  - uid: 2738
+  - uid: 2735
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-16.5
       parent: 1
-  - uid: 2739
+  - uid: 2736
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-17.5
       parent: 1
-  - uid: 2740
+  - uid: 2737
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-18.5
       parent: 1
-  - uid: 2741
+  - uid: 2738
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-19.5
       parent: 1
-  - uid: 2742
+  - uid: 2739
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-20.5
       parent: 1
-  - uid: 2743
+  - uid: 2740
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-21.5
       parent: 1
-  - uid: 2744
+  - uid: 2741
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-22.5
       parent: 1
-  - uid: 2745
+  - uid: 2742
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-23.5
       parent: 1
-  - uid: 2746
+  - uid: 2743
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-24.5
       parent: 1
-  - uid: 2747
+  - uid: 2744
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-25.5
       parent: 1
-  - uid: 2748
+  - uid: 2745
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-26.5
       parent: 1
-  - uid: 2749
+  - uid: 2746
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,41.5
       parent: 1
-  - uid: 2750
+  - uid: 2747
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-30.5
       parent: 1
-  - uid: 2751
+  - uid: 2748
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-31.5
       parent: 1
-  - uid: 2752
+  - uid: 2749
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-32.5
       parent: 1
-  - uid: 2753
+  - uid: 2750
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-34.5
       parent: 1
-  - uid: 2754
+  - uid: 2751
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-35.5
       parent: 1
-  - uid: 2755
+  - uid: 2752
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-36.5
       parent: 1
-  - uid: 2756
+  - uid: 2753
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-37.5
       parent: 1
-  - uid: 2757
+  - uid: 2754
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-38.5
       parent: 1
-  - uid: 2758
+  - uid: 2755
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-39.5
       parent: 1
-  - uid: 2759
+  - uid: 2756
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-40.5
       parent: 1
-  - uid: 2760
+  - uid: 2757
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-41.5
       parent: 1
-  - uid: 2761
+  - uid: 2758
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-42.5
       parent: 1
-  - uid: 2762
+  - uid: 2759
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-33.5
       parent: 1
-  - uid: 2763
+  - uid: 2760
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-44.5
       parent: 1
-  - uid: 2764
+  - uid: 2761
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-45.5
       parent: 1
-  - uid: 2765
+  - uid: 2762
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-46.5
       parent: 1
-  - uid: 2766
+  - uid: 2763
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-47.5
       parent: 1
-  - uid: 2767
+  - uid: 2764
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-48.5
       parent: 1
-  - uid: 2768
+  - uid: 2765
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-49.5
       parent: 1
-  - uid: 2769
+  - uid: 2766
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-50.5
       parent: 1
-  - uid: 2770
+  - uid: 2767
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-51.5
       parent: 1
-  - uid: 2771
+  - uid: 2768
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-52.5
       parent: 1
-  - uid: 2772
+  - uid: 2769
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-53.5
       parent: 1
-  - uid: 2773
+  - uid: 2770
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-54.5
       parent: 1
-  - uid: 2774
+  - uid: 2771
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-55.5
       parent: 1
-  - uid: 2775
+  - uid: 2772
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-56.5
       parent: 1
-  - uid: 2776
+  - uid: 2773
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-57.5
       parent: 1
-  - uid: 2777
+  - uid: 2774
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-58.5
       parent: 1
-  - uid: 2778
+  - uid: 2775
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-59.5
       parent: 1
-  - uid: 2779
+  - uid: 2776
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-60.5
       parent: 1
-  - uid: 2780
+  - uid: 2777
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-43.5
       parent: 1
-  - uid: 2781
+  - uid: 2778
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-62.5
       parent: 1
-  - uid: 2782
+  - uid: 2779
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-63.5
       parent: 1
-  - uid: 2783
+  - uid: 2780
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-61.5
       parent: 1
-  - uid: 2784
+  - uid: 2781
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-28.5
       parent: 1
-  - uid: 2785
+  - uid: 2782
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-27.5
       parent: 1
-  - uid: 2786
+  - uid: 2783
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-29.5
       parent: 1
-  - uid: 2787
+  - uid: 2784
     components:
     - type: Transform
       pos: -50.5,-89.5
       parent: 1
-  - uid: 2788
+  - uid: 2785
     components:
     - type: Transform
       pos: -50.5,-87.5
       parent: 1
-  - uid: 2789
+  - uid: 2786
     components:
     - type: Transform
       pos: -50.5,-88.5
       parent: 1
-  - uid: 2790
+  - uid: 2787
     components:
     - type: Transform
       pos: -50.5,-86.5
       parent: 1
-  - uid: 2791
+  - uid: 2788
     components:
     - type: Transform
       pos: -50.5,-83.5
       parent: 1
-  - uid: 2792
+  - uid: 2789
     components:
     - type: Transform
       pos: -50.5,-84.5
       parent: 1
-  - uid: 2793
+  - uid: 2790
     components:
     - type: Transform
       pos: -50.5,-85.5
       parent: 1
-  - uid: 2794
+  - uid: 2791
     components:
     - type: Transform
       pos: -50.5,-79.5
       parent: 1
-  - uid: 2795
+  - uid: 2792
     components:
     - type: Transform
       pos: -50.5,-81.5
       parent: 1
-  - uid: 2796
+  - uid: 2793
     components:
     - type: Transform
       pos: -50.5,-75.5
       parent: 1
-  - uid: 2797
+  - uid: 2794
     components:
     - type: Transform
       pos: -50.5,-66.5
       parent: 1
-  - uid: 2798
+  - uid: 2795
     components:
     - type: Transform
       pos: -50.5,-67.5
       parent: 1
-  - uid: 2799
+  - uid: 2796
     components:
     - type: Transform
       pos: -50.5,-82.5
       parent: 1
-  - uid: 2800
+  - uid: 2797
     components:
     - type: Transform
       pos: -50.5,-74.5
       parent: 1
-  - uid: 2801
+  - uid: 2798
     components:
     - type: Transform
       pos: -50.5,-77.5
       parent: 1
-  - uid: 2802
+  - uid: 2799
     components:
     - type: Transform
       pos: -50.5,-72.5
       parent: 1
-  - uid: 2803
+  - uid: 2800
     components:
     - type: Transform
       pos: -50.5,-69.5
       parent: 1
-  - uid: 2804
+  - uid: 2801
     components:
     - type: Transform
       pos: -50.5,-70.5
       parent: 1
-  - uid: 2805
+  - uid: 2802
     components:
     - type: Transform
       pos: -50.5,-71.5
       parent: 1
-  - uid: 2806
+  - uid: 2803
     components:
     - type: Transform
       pos: -50.5,-80.5
       parent: 1
-  - uid: 2807
+  - uid: 2804
     components:
     - type: Transform
       pos: -50.5,-68.5
       parent: 1
-  - uid: 2808
+  - uid: 2805
     components:
     - type: Transform
       pos: -50.5,-73.5
       parent: 1
-  - uid: 2809
+  - uid: 2806
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-63.5
       parent: 1
-  - uid: 2810
+  - uid: 2807
     components:
     - type: Transform
       pos: -50.5,-76.5
       parent: 1
-  - uid: 2811
+  - uid: 2808
     components:
     - type: Transform
       pos: -50.5,-64.5
       parent: 1
-  - uid: 2812
+  - uid: 2809
     components:
     - type: Transform
       pos: -50.5,-65.5
       parent: 1
-  - uid: 2813
+  - uid: 2810
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-62.5
       parent: 1
-  - uid: 2814
+  - uid: 2811
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-61.5
       parent: 1
-  - uid: 2815
+  - uid: 2812
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-60.5
       parent: 1
-  - uid: 2816
+  - uid: 2813
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-59.5
       parent: 1
-  - uid: 2817
+  - uid: 2814
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-58.5
       parent: 1
-  - uid: 2818
+  - uid: 2815
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-57.5
       parent: 1
-  - uid: 2819
+  - uid: 2816
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-56.5
       parent: 1
-  - uid: 2820
+  - uid: 2817
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-55.5
       parent: 1
-  - uid: 2821
+  - uid: 2818
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-54.5
       parent: 1
-  - uid: 2822
+  - uid: 2819
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-53.5
       parent: 1
-  - uid: 2823
+  - uid: 2820
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-52.5
       parent: 1
-  - uid: 2824
+  - uid: 2821
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-51.5
       parent: 1
-  - uid: 2825
+  - uid: 2822
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-50.5
       parent: 1
-  - uid: 2826
+  - uid: 2823
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-49.5
       parent: 1
-  - uid: 2827
+  - uid: 2824
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-48.5
       parent: 1
-  - uid: 2828
+  - uid: 2825
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-47.5
       parent: 1
-  - uid: 2829
+  - uid: 2826
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-46.5
       parent: 1
-  - uid: 2830
+  - uid: 2827
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-45.5
       parent: 1
-  - uid: 2831
+  - uid: 2828
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-44.5
       parent: 1
-  - uid: 2832
+  - uid: 2829
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-43.5
       parent: 1
-  - uid: 2833
+  - uid: 2830
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-41.5
       parent: 1
-  - uid: 2834
+  - uid: 2831
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-40.5
       parent: 1
-  - uid: 2835
+  - uid: 2832
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-39.5
       parent: 1
-  - uid: 2836
+  - uid: 2833
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-42.5
       parent: 1
-  - uid: 2837
+  - uid: 2834
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-38.5
       parent: 1
-  - uid: 2838
+  - uid: 2835
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-37.5
       parent: 1
-  - uid: 2839
+  - uid: 2836
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-36.5
       parent: 1
-  - uid: 2840
+  - uid: 2837
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-35.5
       parent: 1
-  - uid: 2841
+  - uid: 2838
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-34.5
       parent: 1
-  - uid: 2842
+  - uid: 2839
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-33.5
       parent: 1
-  - uid: 2843
+  - uid: 2840
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-32.5
       parent: 1
-  - uid: 2844
+  - uid: 2841
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-31.5
       parent: 1
-  - uid: 2845
+  - uid: 2842
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-30.5
       parent: 1
-  - uid: 2846
+  - uid: 2843
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-29.5
       parent: 1
-  - uid: 2847
+  - uid: 2844
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-28.5
       parent: 1
-  - uid: 2848
+  - uid: 2845
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-27.5
       parent: 1
-  - uid: 2849
+  - uid: 2846
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-26.5
       parent: 1
-  - uid: 2850
+  - uid: 2847
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-25.5
       parent: 1
-  - uid: 2851
+  - uid: 2848
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-24.5
       parent: 1
-  - uid: 2852
+  - uid: 2849
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-23.5
       parent: 1
-  - uid: 2853
+  - uid: 2850
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-22.5
       parent: 1
-  - uid: 2854
+  - uid: 2851
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-21.5
       parent: 1
-  - uid: 2855
+  - uid: 2852
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-20.5
       parent: 1
-  - uid: 2856
+  - uid: 2853
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-19.5
       parent: 1
-  - uid: 2857
+  - uid: 2854
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-18.5
       parent: 1
-  - uid: 2858
+  - uid: 2855
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-17.5
       parent: 1
-  - uid: 2859
+  - uid: 2856
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-16.5
       parent: 1
-  - uid: 2860
+  - uid: 2857
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-15.5
       parent: 1
-  - uid: 2861
+  - uid: 2858
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-14.5
       parent: 1
-  - uid: 2862
+  - uid: 2859
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-13.5
       parent: 1
-  - uid: 2863
+  - uid: 2860
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-12.5
       parent: 1
-  - uid: 2864
+  - uid: 2861
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-11.5
       parent: 1
-  - uid: 2865
+  - uid: 2862
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-10.5
       parent: 1
-  - uid: 2866
+  - uid: 2863
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-9.5
       parent: 1
-  - uid: 2867
+  - uid: 2864
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-8.5
       parent: 1
-  - uid: 2868
+  - uid: 2865
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-7.5
       parent: 1
-  - uid: 2869
+  - uid: 2866
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-6.5
       parent: 1
-  - uid: 2870
+  - uid: 2867
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-5.5
       parent: 1
-  - uid: 2871
+  - uid: 2868
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-4.5
       parent: 1
-  - uid: 2872
+  - uid: 2869
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-3.5
       parent: 1
-  - uid: 2873
+  - uid: 2870
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-2.5
       parent: 1
-  - uid: 2874
+  - uid: 2871
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-1.5
       parent: 1
-  - uid: 2875
+  - uid: 2872
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-0.5
       parent: 1
-  - uid: 2876
+  - uid: 2873
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,0.5
       parent: 1
-  - uid: 2877
+  - uid: 2874
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,1.5
       parent: 1
-  - uid: 2878
+  - uid: 2875
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,2.5
       parent: 1
-  - uid: 2879
+  - uid: 2876
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,3.5
       parent: 1
-  - uid: 2880
+  - uid: 2877
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,4.5
       parent: 1
-  - uid: 2881
+  - uid: 2878
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,5.5
       parent: 1
-  - uid: 2882
+  - uid: 2879
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,6.5
       parent: 1
-  - uid: 2883
+  - uid: 2880
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,7.5
       parent: 1
-  - uid: 2884
+  - uid: 2881
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,8.5
       parent: 1
-  - uid: 2885
+  - uid: 2882
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,9.5
       parent: 1
-  - uid: 2886
+  - uid: 2883
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,10.5
       parent: 1
-  - uid: 2887
+  - uid: 2884
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,11.5
       parent: 1
-  - uid: 2888
+  - uid: 2885
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,12.5
       parent: 1
-  - uid: 2889
+  - uid: 2886
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,13.5
       parent: 1
-  - uid: 2890
+  - uid: 2887
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,14.5
       parent: 1
-  - uid: 2891
+  - uid: 2888
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,15.5
       parent: 1
-  - uid: 2892
+  - uid: 2889
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,16.5
       parent: 1
-  - uid: 2893
+  - uid: 2890
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,17.5
       parent: 1
-  - uid: 2894
+  - uid: 2891
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,18.5
       parent: 1
-  - uid: 2895
+  - uid: 2892
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,19.5
       parent: 1
-  - uid: 2896
+  - uid: 2893
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,20.5
       parent: 1
-  - uid: 2897
+  - uid: 2894
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,21.5
       parent: 1
-  - uid: 2898
+  - uid: 2895
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,22.5
       parent: 1
-  - uid: 2899
+  - uid: 2896
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,23.5
       parent: 1
-  - uid: 2900
+  - uid: 2897
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,24.5
       parent: 1
-  - uid: 2901
+  - uid: 2898
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,25.5
       parent: 1
-  - uid: 2902
+  - uid: 2899
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,26.5
       parent: 1
-  - uid: 2903
+  - uid: 2900
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,27.5
       parent: 1
-  - uid: 2904
+  - uid: 2901
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,28.5
       parent: 1
-  - uid: 2905
+  - uid: 2902
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,29.5
       parent: 1
-  - uid: 2906
+  - uid: 2903
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,30.5
       parent: 1
-  - uid: 2907
+  - uid: 2904
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,31.5
       parent: 1
-  - uid: 2908
+  - uid: 2905
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,32.5
       parent: 1
-  - uid: 2909
+  - uid: 2906
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,33.5
       parent: 1
-  - uid: 2910
+  - uid: 2907
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,34.5
       parent: 1
-  - uid: 2911
+  - uid: 2908
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,35.5
       parent: 1
-  - uid: 2912
+  - uid: 2909
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,36.5
       parent: 1
-  - uid: 2913
+  - uid: 2910
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,37.5
       parent: 1
-  - uid: 2914
+  - uid: 2911
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,38.5
       parent: 1
-  - uid: 2915
+  - uid: 2912
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,39.5
       parent: 1
-  - uid: 2916
+  - uid: 2913
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,40.5
       parent: 1
-  - uid: 2917
+  - uid: 2914
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,41.5
       parent: 1
-  - uid: 2918
+  - uid: 2915
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,42.5
       parent: 1
-  - uid: 2919
+  - uid: 2916
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,43.5
       parent: 1
-  - uid: 2920
+  - uid: 2917
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,44.5
       parent: 1
-  - uid: 2921
+  - uid: 2918
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,45.5
       parent: 1
-  - uid: 2922
+  - uid: 2919
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,46.5
       parent: 1
-  - uid: 2923
+  - uid: 2920
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,47.5
       parent: 1
-  - uid: 2924
+  - uid: 2921
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,48.5
       parent: 1
-  - uid: 2925
+  - uid: 2922
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,49.5
       parent: 1
-  - uid: 2926
+  - uid: 2923
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,50.5
       parent: 1
-  - uid: 2927
+  - uid: 2924
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,51.5
       parent: 1
-  - uid: 2928
+  - uid: 2925
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,52.5
       parent: 1
-  - uid: 2929
+  - uid: 2926
     components:
     - type: Transform
       pos: -50.5,-90.5
       parent: 1
-  - uid: 2930
+  - uid: 2927
     components:
     - type: Transform
       pos: -50.5,-91.5
       parent: 1
-  - uid: 2931
+  - uid: 2928
     components:
     - type: Transform
       pos: -50.5,-92.5
       parent: 1
-  - uid: 2932
+  - uid: 2929
     components:
     - type: Transform
       pos: -50.5,-93.5
       parent: 1
-  - uid: 2933
+  - uid: 2930
     components:
     - type: Transform
       pos: -50.5,-94.5
       parent: 1
-  - uid: 2934
+  - uid: 2931
     components:
     - type: Transform
       pos: -50.5,-95.5
       parent: 1
-  - uid: 2935
+  - uid: 2932
     components:
     - type: Transform
       pos: -50.5,-78.5
       parent: 1
-  - uid: 2936
+  - uid: 2933
     components:
     - type: Transform
       pos: -50.5,-97.5
       parent: 1
-  - uid: 2937
+  - uid: 2934
     components:
     - type: Transform
       pos: -50.5,-96.5
       parent: 1
-  - uid: 2938
+  - uid: 2935
     components:
     - type: Transform
       pos: -50.5,-100.5
       parent: 1
-  - uid: 2939
+  - uid: 2936
     components:
     - type: Transform
       pos: -50.5,-101.5
       parent: 1
-  - uid: 2940
+  - uid: 2937
     components:
     - type: Transform
       pos: -50.5,-98.5
       parent: 1
-  - uid: 2941
+  - uid: 2938
     components:
     - type: Transform
       pos: -50.5,-102.5
       parent: 1
-  - uid: 2942
+  - uid: 2939
     components:
     - type: Transform
       pos: -50.5,-103.5
       parent: 1
-  - uid: 2943
+  - uid: 2940
     components:
     - type: Transform
       pos: -50.5,-104.5
       parent: 1
-  - uid: 2944
+  - uid: 2941
     components:
     - type: Transform
       pos: -50.5,-105.5
       parent: 1
-  - uid: 2945
+  - uid: 2942
     components:
     - type: Transform
       pos: -50.5,-99.5
       parent: 1
-  - uid: 2946
+  - uid: 2943
     components:
     - type: Transform
       pos: -49.5,-105.5
       parent: 1
-  - uid: 2947
+  - uid: 2944
     components:
     - type: Transform
       pos: -48.5,-105.5
       parent: 1
-  - uid: 2948
+  - uid: 2945
     components:
     - type: Transform
       pos: -47.5,-105.5
       parent: 1
-  - uid: 2949
+  - uid: 2946
     components:
     - type: Transform
       pos: -46.5,-105.5
       parent: 1
-  - uid: 2950
+  - uid: 2947
     components:
     - type: Transform
       pos: -45.5,-105.5
       parent: 1
-  - uid: 2951
+  - uid: 2948
     components:
     - type: Transform
       pos: -43.5,-105.5
       parent: 1
-  - uid: 2952
+  - uid: 2949
     components:
     - type: Transform
       pos: -42.5,-105.5
       parent: 1
-  - uid: 2953
+  - uid: 2950
     components:
     - type: Transform
       pos: -41.5,-105.5
       parent: 1
-  - uid: 2954
+  - uid: 2951
     components:
     - type: Transform
       pos: -40.5,-105.5
       parent: 1
-  - uid: 2955
+  - uid: 2952
     components:
     - type: Transform
       pos: -39.5,-105.5
       parent: 1
-  - uid: 2956
+  - uid: 2953
     components:
     - type: Transform
       pos: -38.5,-105.5
       parent: 1
-  - uid: 2957
+  - uid: 2954
     components:
     - type: Transform
       pos: -37.5,-105.5
       parent: 1
-  - uid: 2958
+  - uid: 2955
     components:
     - type: Transform
       pos: -36.5,-105.5
       parent: 1
-  - uid: 2959
+  - uid: 2956
     components:
     - type: Transform
       pos: -35.5,-105.5
       parent: 1
-  - uid: 2960
+  - uid: 2957
     components:
     - type: Transform
       pos: -44.5,-105.5
       parent: 1
-  - uid: 2961
+  - uid: 2958
     components:
     - type: Transform
       pos: -33.5,-105.5
       parent: 1
-  - uid: 2962
+  - uid: 2959
     components:
     - type: Transform
       pos: -34.5,-105.5
       parent: 1
-  - uid: 2963
+  - uid: 2960
     components:
     - type: Transform
       pos: -31.5,-105.5
       parent: 1
-  - uid: 2964
+  - uid: 2961
     components:
     - type: Transform
       pos: -29.5,-105.5
       parent: 1
-  - uid: 2965
+  - uid: 2962
     components:
     - type: Transform
       pos: -32.5,-105.5
       parent: 1
-  - uid: 2966
+  - uid: 2963
     components:
     - type: Transform
       pos: -28.5,-105.5
       parent: 1
-  - uid: 2967
+  - uid: 2964
     components:
     - type: Transform
       pos: -26.5,-105.5
       parent: 1
-  - uid: 2968
+  - uid: 2965
     components:
     - type: Transform
       pos: -27.5,-105.5
       parent: 1
-  - uid: 2969
+  - uid: 2966
     components:
     - type: Transform
       pos: -25.5,-105.5
       parent: 1
-  - uid: 2970
+  - uid: 2967
     components:
     - type: Transform
       pos: -24.5,-105.5
       parent: 1
-  - uid: 2971
+  - uid: 2968
     components:
     - type: Transform
       pos: -23.5,-105.5
       parent: 1
-  - uid: 2972
+  - uid: 2969
     components:
     - type: Transform
       pos: -22.5,-105.5
       parent: 1
-  - uid: 2973
+  - uid: 2970
     components:
     - type: Transform
       pos: -21.5,-105.5
       parent: 1
-  - uid: 2974
+  - uid: 2971
     components:
     - type: Transform
       pos: -19.5,-105.5
       parent: 1
-  - uid: 2975
+  - uid: 2972
     components:
     - type: Transform
       pos: -20.5,-105.5
       parent: 1
-  - uid: 2976
+  - uid: 2973
     components:
     - type: Transform
       pos: -18.5,-105.5
       parent: 1
-  - uid: 2977
+  - uid: 2974
     components:
     - type: Transform
       pos: -30.5,-105.5
       parent: 1
-  - uid: 2978
+  - uid: 2975
     components:
     - type: Transform
       pos: -17.5,-105.5
       parent: 1
-  - uid: 2979
+  - uid: 2976
     components:
     - type: Transform
       pos: -16.5,-105.5
       parent: 1
-  - uid: 2980
+  - uid: 2977
     components:
     - type: Transform
       pos: -15.5,-105.5
       parent: 1
-  - uid: 2981
+  - uid: 2978
     components:
     - type: Transform
       pos: -14.5,-105.5
       parent: 1
-  - uid: 2982
+  - uid: 2979
     components:
     - type: Transform
       pos: -13.5,-105.5
       parent: 1
-  - uid: 2983
+  - uid: 2980
     components:
     - type: Transform
       pos: -11.5,-105.5
       parent: 1
-  - uid: 2984
+  - uid: 2981
     components:
     - type: Transform
       pos: -10.5,-105.5
       parent: 1
-  - uid: 2985
+  - uid: 2982
     components:
     - type: Transform
       pos: -9.5,-105.5
       parent: 1
-  - uid: 2986
+  - uid: 2983
     components:
     - type: Transform
       pos: -7.5,-105.5
       parent: 1
-  - uid: 2987
+  - uid: 2984
     components:
     - type: Transform
       pos: -8.5,-105.5
       parent: 1
-  - uid: 2988
+  - uid: 2985
     components:
     - type: Transform
       pos: -6.5,-105.5
       parent: 1
-  - uid: 2989
+  - uid: 2986
     components:
     - type: Transform
       pos: -5.5,-105.5
       parent: 1
-  - uid: 2990
+  - uid: 2987
     components:
     - type: Transform
       pos: -4.5,-105.5
       parent: 1
-  - uid: 2991
+  - uid: 2988
     components:
     - type: Transform
       pos: -3.5,-105.5
       parent: 1
-  - uid: 2992
+  - uid: 2989
     components:
     - type: Transform
       pos: -2.5,-105.5
       parent: 1
-  - uid: 2993
+  - uid: 2990
     components:
     - type: Transform
       pos: -0.5,-105.5
       parent: 1
-  - uid: 2994
+  - uid: 2991
     components:
     - type: Transform
       pos: -1.5,-105.5
       parent: 1
-  - uid: 2995
+  - uid: 2992
     components:
     - type: Transform
       pos: 0.5,-105.5
       parent: 1
-  - uid: 2996
+  - uid: 2993
     components:
     - type: Transform
       pos: 1.5,-105.5
       parent: 1
-  - uid: 2997
+  - uid: 2994
     components:
     - type: Transform
       pos: 2.5,-105.5
       parent: 1
-  - uid: 2998
+  - uid: 2995
     components:
     - type: Transform
       pos: 3.5,-105.5
       parent: 1
-  - uid: 2999
+  - uid: 2996
     components:
     - type: Transform
       pos: 4.5,-105.5
       parent: 1
-  - uid: 3000
+  - uid: 2997
     components:
     - type: Transform
       pos: 5.5,-105.5
       parent: 1
-  - uid: 3001
+  - uid: 2998
     components:
     - type: Transform
       pos: 7.5,-105.5
       parent: 1
-  - uid: 3002
+  - uid: 2999
     components:
     - type: Transform
       pos: -12.5,-105.5
       parent: 1
-  - uid: 3003
+  - uid: 3000
     components:
     - type: Transform
       pos: 8.5,-105.5
       parent: 1
-  - uid: 3004
+  - uid: 3001
     components:
     - type: Transform
       pos: 6.5,-105.5
       parent: 1
-  - uid: 3005
+  - uid: 3002
     components:
     - type: Transform
       pos: 9.5,-105.5
       parent: 1
-  - uid: 3006
+  - uid: 3003
     components:
     - type: Transform
       pos: 10.5,-105.5
       parent: 1
-  - uid: 3007
+  - uid: 3004
     components:
     - type: Transform
       pos: 12.5,-105.5
       parent: 1
-  - uid: 3008
+  - uid: 3005
     components:
     - type: Transform
       pos: 13.5,-105.5
       parent: 1
-  - uid: 3009
+  - uid: 3006
     components:
     - type: Transform
       pos: 11.5,-105.5
       parent: 1
-  - uid: 3010
+  - uid: 3007
     components:
     - type: Transform
       pos: 14.5,-105.5
       parent: 1
-  - uid: 3011
+  - uid: 3008
     components:
     - type: Transform
       pos: 15.5,-105.5
       parent: 1
-  - uid: 3012
+  - uid: 3009
     components:
     - type: Transform
       pos: 16.5,-105.5
       parent: 1
-  - uid: 3013
+  - uid: 3010
     components:
     - type: Transform
       pos: 17.5,-105.5
       parent: 1
-  - uid: 3014
+  - uid: 3011
     components:
     - type: Transform
       pos: 19.5,-105.5
       parent: 1
-  - uid: 3015
+  - uid: 3012
     components:
     - type: Transform
       pos: 18.5,-105.5
       parent: 1
-  - uid: 3016
+  - uid: 3013
     components:
     - type: Transform
       pos: 21.5,-105.5
       parent: 1
-  - uid: 3017
+  - uid: 3014
     components:
     - type: Transform
       pos: 22.5,-105.5
       parent: 1
-  - uid: 3018
+  - uid: 3015
     components:
     - type: Transform
       pos: 20.5,-105.5
       parent: 1
-  - uid: 3019
+  - uid: 3016
     components:
     - type: Transform
       pos: 23.5,-105.5
       parent: 1
-  - uid: 3020
+  - uid: 3017
     components:
     - type: Transform
       pos: 24.5,-105.5
       parent: 1
-  - uid: 3021
+  - uid: 3018
     components:
     - type: Transform
       pos: 25.5,-105.5
       parent: 1
-  - uid: 3022
+  - uid: 3019
     components:
     - type: Transform
       pos: 27.5,-105.5
       parent: 1
-  - uid: 3023
+  - uid: 3020
     components:
     - type: Transform
       pos: 26.5,-105.5
       parent: 1
-  - uid: 3024
+  - uid: 3021
     components:
     - type: Transform
       pos: 28.5,-105.5
       parent: 1
-  - uid: 3025
+  - uid: 3022
     components:
     - type: Transform
       pos: 29.5,-105.5
       parent: 1
-  - uid: 3026
+  - uid: 3023
     components:
     - type: Transform
       pos: 30.5,-105.5
       parent: 1
-  - uid: 3027
+  - uid: 3024
     components:
     - type: Transform
       pos: 31.5,-105.5
       parent: 1
-  - uid: 3028
+  - uid: 3025
     components:
     - type: Transform
       pos: 32.5,-105.5
       parent: 1
-  - uid: 3029
+  - uid: 3026
     components:
     - type: Transform
       pos: 33.5,-105.5
       parent: 1
-  - uid: 3030
+  - uid: 3027
     components:
     - type: Transform
       pos: 34.5,-105.5
       parent: 1
-  - uid: 3031
+  - uid: 3028
     components:
     - type: Transform
       pos: 35.5,-105.5
       parent: 1
-  - uid: 3032
+  - uid: 3029
     components:
     - type: Transform
       pos: 36.5,-105.5
       parent: 1
-  - uid: 3033
+  - uid: 3030
     components:
     - type: Transform
       pos: 37.5,-105.5
       parent: 1
-  - uid: 3034
+  - uid: 3031
     components:
     - type: Transform
       pos: 38.5,-105.5
       parent: 1
-  - uid: 3035
+  - uid: 3032
     components:
     - type: Transform
       pos: 39.5,-105.5
       parent: 1
-  - uid: 3036
+  - uid: 3033
     components:
     - type: Transform
       pos: 40.5,-105.5
       parent: 1
-  - uid: 3037
+  - uid: 3034
     components:
     - type: Transform
       pos: 41.5,-105.5
       parent: 1
-  - uid: 3038
+  - uid: 3035
     components:
     - type: Transform
       pos: 42.5,-105.5
       parent: 1
-  - uid: 3039
+  - uid: 3036
     components:
     - type: Transform
       pos: 44.5,-105.5
       parent: 1
-  - uid: 3040
+  - uid: 3037
     components:
     - type: Transform
       pos: 43.5,-105.5
       parent: 1
-  - uid: 3041
+  - uid: 3038
     components:
     - type: Transform
       pos: 45.5,-105.5
       parent: 1
-  - uid: 3042
+  - uid: 3039
     components:
     - type: Transform
       pos: 46.5,-105.5
       parent: 1
-  - uid: 3043
+  - uid: 3040
     components:
     - type: Transform
       pos: 46.5,-104.5
       parent: 1
-  - uid: 3044
+  - uid: 3041
     components:
     - type: Transform
       pos: 46.5,-103.5
       parent: 1
-  - uid: 3045
+  - uid: 3042
     components:
     - type: Transform
       pos: 46.5,-102.5
       parent: 1
-  - uid: 3046
+  - uid: 3043
     components:
     - type: Transform
       pos: 46.5,-101.5
       parent: 1
-  - uid: 3047
+  - uid: 3044
     components:
     - type: Transform
       pos: 46.5,-100.5
       parent: 1
-  - uid: 3048
+  - uid: 3045
     components:
     - type: Transform
       pos: 46.5,-99.5
       parent: 1
-  - uid: 3049
+  - uid: 3046
     components:
     - type: Transform
       pos: 46.5,-97.5
       parent: 1
-  - uid: 3050
+  - uid: 3047
     components:
     - type: Transform
       pos: 46.5,-96.5
       parent: 1
-  - uid: 3051
+  - uid: 3048
     components:
     - type: Transform
       pos: 46.5,-95.5
       parent: 1
-  - uid: 3052
+  - uid: 3049
     components:
     - type: Transform
       pos: 46.5,-94.5
       parent: 1
-  - uid: 3053
+  - uid: 3050
     components:
     - type: Transform
       pos: 46.5,-93.5
       parent: 1
-  - uid: 3054
+  - uid: 3051
     components:
     - type: Transform
       pos: 46.5,-92.5
       parent: 1
-  - uid: 3055
+  - uid: 3052
     components:
     - type: Transform
       pos: 46.5,-98.5
       parent: 1
-  - uid: 3056
+  - uid: 3053
     components:
     - type: Transform
       pos: 46.5,-91.5
       parent: 1
-  - uid: 3057
+  - uid: 3054
     components:
     - type: Transform
       pos: 46.5,-90.5
       parent: 1
-  - uid: 3058
+  - uid: 3055
     components:
     - type: Transform
       pos: 46.5,-89.5
       parent: 1
-  - uid: 3059
+  - uid: 3056
     components:
     - type: Transform
       pos: 46.5,-88.5
       parent: 1
-  - uid: 3060
+  - uid: 3057
     components:
     - type: Transform
       pos: 46.5,-87.5
       parent: 1
-  - uid: 3061
+  - uid: 3058
     components:
     - type: Transform
       pos: 46.5,-86.5
       parent: 1
-  - uid: 3062
+  - uid: 3059
     components:
     - type: Transform
       pos: 46.5,-85.5
       parent: 1
-  - uid: 3063
+  - uid: 3060
     components:
     - type: Transform
       pos: 46.5,-84.5
       parent: 1
-  - uid: 3064
+  - uid: 3061
     components:
     - type: Transform
       pos: 46.5,-82.5
       parent: 1
-  - uid: 3065
+  - uid: 3062
     components:
     - type: Transform
       pos: 46.5,-81.5
       parent: 1
-  - uid: 3066
+  - uid: 3063
     components:
     - type: Transform
       pos: 46.5,-80.5
       parent: 1
-  - uid: 3067
+  - uid: 3064
     components:
     - type: Transform
       pos: 46.5,-79.5
       parent: 1
-  - uid: 3068
+  - uid: 3065
     components:
     - type: Transform
       pos: 46.5,-78.5
       parent: 1
-  - uid: 3069
+  - uid: 3066
     components:
     - type: Transform
       pos: 46.5,-77.5
       parent: 1
-  - uid: 3070
+  - uid: 3067
     components:
     - type: Transform
       pos: 46.5,-76.5
       parent: 1
-  - uid: 3071
+  - uid: 3068
     components:
     - type: Transform
       pos: 46.5,-75.5
       parent: 1
-  - uid: 3072
+  - uid: 3069
     components:
     - type: Transform
       pos: 46.5,-74.5
       parent: 1
-  - uid: 3073
+  - uid: 3070
     components:
     - type: Transform
       pos: 46.5,-73.5
       parent: 1
-  - uid: 3074
+  - uid: 3071
     components:
     - type: Transform
       pos: 46.5,-72.5
       parent: 1
-  - uid: 3075
+  - uid: 3072
     components:
     - type: Transform
       pos: 46.5,-71.5
       parent: 1
-  - uid: 3076
+  - uid: 3073
     components:
     - type: Transform
       pos: 46.5,-70.5
       parent: 1
-  - uid: 3077
+  - uid: 3074
     components:
     - type: Transform
       pos: 46.5,-69.5
       parent: 1
-  - uid: 3078
+  - uid: 3075
     components:
     - type: Transform
       pos: 46.5,-68.5
       parent: 1
-  - uid: 3079
+  - uid: 3076
     components:
     - type: Transform
       pos: 46.5,-67.5
       parent: 1
-  - uid: 3080
+  - uid: 3077
     components:
     - type: Transform
       pos: 46.5,-66.5
       parent: 1
-  - uid: 3081
+  - uid: 3078
     components:
     - type: Transform
       pos: 46.5,-83.5
       parent: 1
-  - uid: 3082
+  - uid: 3079
     components:
     - type: Transform
       pos: 46.5,-64.5
       parent: 1
-  - uid: 3083
+  - uid: 3080
     components:
     - type: Transform
       pos: 46.5,-65.5
       parent: 1
 - proto: CMWindoor
   entities:
-  - uid: 3084
+  - uid: 3081
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,22.5
       parent: 1
-  - uid: 3085
+  - uid: 3082
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -24167,1410 +24138,1390 @@ entities:
       parent: 1
 - proto: CMWindowReinforcedAlmayer
   entities:
-  - uid: 3086
+  - uid: 3083
     components:
     - type: Transform
       pos: 22.5,21.5
       parent: 1
-  - uid: 3087
+  - uid: 3084
     components:
     - type: Transform
       pos: 22.5,23.5
       parent: 1
-  - uid: 3088
+  - uid: 3085
     components:
     - type: Transform
       pos: 22.5,13.5
       parent: 1
-  - uid: 3089
+  - uid: 3086
     components:
     - type: Transform
       pos: 22.5,10.5
       parent: 1
-  - uid: 3090
+  - uid: 3087
     components:
     - type: Transform
       pos: 5.5,-62.5
       parent: 1
-  - uid: 3091
+  - uid: 3088
     components:
     - type: Transform
       pos: 5.5,-61.5
       parent: 1
-  - uid: 3092
+  - uid: 3089
     components:
     - type: Transform
       pos: 0.5,-63.5
       parent: 1
-  - uid: 3093
+  - uid: 3090
     components:
     - type: Transform
       pos: 0.5,-61.5
       parent: 1
-  - uid: 3094
+  - uid: 3091
     components:
     - type: Transform
       pos: 0.5,-62.5
       parent: 1
-  - uid: 3095
-    components:
-    - type: Transform
-      pos: -27.5,9.5
-      parent: 1
-  - uid: 3096
-    components:
-    - type: Transform
-      pos: -26.5,9.5
-      parent: 1
-  - uid: 3097
-    components:
-    - type: Transform
-      pos: -28.5,9.5
-      parent: 1
-  - uid: 3098
-    components:
-    - type: Transform
-      pos: -25.5,9.5
-      parent: 1
-  - uid: 3099
+  - uid: 3092
     components:
     - type: Transform
       pos: -1.5,54.5
       parent: 1
-  - uid: 3100
+  - uid: 3093
     components:
     - type: Transform
       pos: -16.5,3.5
       parent: 1
-  - uid: 3101
+  - uid: 3094
     components:
     - type: Transform
       pos: 15.5,0.5
       parent: 1
-  - uid: 3102
+  - uid: 3095
     components:
     - type: Transform
       pos: -17.5,4.5
       parent: 1
-  - uid: 3103
+  - uid: 3096
     components:
     - type: Transform
       pos: -16.5,0.5
       parent: 1
-  - uid: 3104
+  - uid: 3097
     components:
     - type: Transform
       pos: 15.5,1.5
       parent: 1
-  - uid: 3105
+  - uid: 3098
     components:
     - type: Transform
       pos: 4.5,-43.5
       parent: 1
-  - uid: 3106
+  - uid: 3099
     components:
     - type: Transform
       pos: 4.5,-33.5
       parent: 1
-  - uid: 3107
+  - uid: 3100
     components:
     - type: Transform
       pos: 3.5,-33.5
       parent: 1
-  - uid: 3108
+  - uid: 3101
     components:
     - type: Transform
       pos: 5.5,-31.5
       parent: 1
-  - uid: 3109
+  - uid: 3102
     components:
     - type: Transform
       pos: 5.5,-30.5
       parent: 1
-  - uid: 3110
+  - uid: 3103
     components:
     - type: Transform
       pos: 17.5,4.5
       parent: 1
-  - uid: 3111
+  - uid: 3104
     components:
     - type: Transform
       pos: 16.5,4.5
       parent: 1
-  - uid: 3112
+  - uid: 3105
     components:
     - type: Transform
       pos: 15.5,3.5
       parent: 1
-  - uid: 3113
+  - uid: 3106
     components:
     - type: Transform
       pos: 7.5,-33.5
       parent: 1
-  - uid: 3114
+  - uid: 3107
     components:
     - type: Transform
       pos: 7.5,-50.5
       parent: 1
-  - uid: 3115
+  - uid: 3108
     components:
     - type: Transform
       pos: 5.5,-32.5
       parent: 1
-  - uid: 3116
+  - uid: 3109
     components:
     - type: Transform
       pos: 1.5,-33.5
       parent: 1
-  - uid: 3117
+  - uid: 3110
     components:
     - type: Transform
       pos: 5.5,-29.5
       parent: 1
-  - uid: 3118
+  - uid: 3111
     components:
     - type: Transform
       pos: 7.5,-43.5
       parent: 1
-  - uid: 3119
+  - uid: 3112
     components:
     - type: Transform
       pos: 8.5,-49.5
       parent: 1
-  - uid: 3120
+  - uid: 3113
     components:
     - type: Transform
       pos: 14.5,-15.5
       parent: 1
-  - uid: 3121
+  - uid: 3114
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 1
-  - uid: 3122
+  - uid: 3115
     components:
     - type: Transform
       pos: 2.5,-15.5
       parent: 1
-  - uid: 3123
+  - uid: 3116
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 1
-  - uid: 3124
+  - uid: 3117
     components:
     - type: Transform
       pos: -1.5,-15.5
       parent: 1
-  - uid: 3125
+  - uid: 3118
     components:
     - type: Transform
       pos: 6.5,-33.5
       parent: 1
-  - uid: 3126
+  - uid: 3119
     components:
     - type: Transform
       pos: -8.5,-20.5
       parent: 1
-  - uid: 3127
+  - uid: 3120
     components:
     - type: Transform
       pos: -9.5,-20.5
       parent: 1
-  - uid: 3128
+  - uid: 3121
     components:
     - type: Transform
       pos: -7.5,-20.5
       parent: 1
-  - uid: 3129
+  - uid: 3122
     components:
     - type: Transform
       pos: 11.5,-33.5
       parent: 1
-  - uid: 3130
+  - uid: 3123
     components:
     - type: Transform
       pos: 7.5,-51.5
       parent: 1
-  - uid: 3131
+  - uid: 3124
     components:
     - type: Transform
       pos: 9.5,-49.5
       parent: 1
-  - uid: 3132
+  - uid: 3125
     components:
     - type: Transform
       pos: -16.5,1.5
       parent: 1
-  - uid: 3133
+  - uid: 3126
     components:
     - type: Transform
       pos: -18.5,4.5
       parent: 1
-  - uid: 3134
+  - uid: 3127
     components:
     - type: Transform
       pos: 11.5,-49.5
       parent: 1
-  - uid: 3135
+  - uid: 3128
     components:
     - type: Transform
       pos: 18.5,3.5
       parent: 1
-  - uid: 3136
+  - uid: 3129
     components:
     - type: Transform
       pos: 10.5,-49.5
       parent: 1
-  - uid: 3137
+  - uid: 3130
     components:
     - type: Transform
       pos: 1.5,-43.5
       parent: 1
-  - uid: 3138
+  - uid: 3131
     components:
     - type: Transform
       pos: 15.5,-15.5
       parent: 1
-  - uid: 3139
+  - uid: 3132
     components:
     - type: Transform
       pos: 11.5,-15.5
       parent: 1
-  - uid: 3140
+  - uid: 3133
     components:
     - type: Transform
       pos: 4.5,-15.5
       parent: 1
-  - uid: 3141
+  - uid: 3134
     components:
     - type: Transform
       pos: 12.5,-15.5
       parent: 1
-  - uid: 3142
+  - uid: 3135
     components:
     - type: Transform
       pos: 10.5,-43.5
       parent: 1
-  - uid: 3143
+  - uid: 3136
     components:
     - type: Transform
       pos: 16.5,-15.5
       parent: 1
-  - uid: 3144
+  - uid: 3137
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 1
-  - uid: 3145
+  - uid: 3138
     components:
     - type: Transform
       pos: 10.5,-15.5
       parent: 1
-  - uid: 3146
+  - uid: 3139
     components:
     - type: Transform
       pos: 18.5,1.5
       parent: 1
-  - uid: 3147
+  - uid: 3140
     components:
     - type: Transform
       pos: -19.5,3.5
       parent: 1
-  - uid: 3148
+  - uid: 3141
     components:
     - type: Transform
       pos: -19.5,1.5
       parent: 1
-  - uid: 3149
+  - uid: 3142
     components:
     - type: Transform
       pos: -23.5,20.5
       parent: 1
-  - uid: 3150
+  - uid: 3143
     components:
     - type: Transform
       pos: -23.5,21.5
       parent: 1
-  - uid: 3151
+  - uid: 3144
     components:
     - type: Transform
       pos: -23.5,23.5
       parent: 1
-  - uid: 3152
+  - uid: 3145
     components:
     - type: Transform
       pos: -23.5,17.5
       parent: 1
-  - uid: 3153
+  - uid: 3146
     components:
     - type: Transform
       pos: -23.5,16.5
       parent: 1
-  - uid: 3154
+  - uid: 3147
     components:
     - type: Transform
       pos: -23.5,18.5
       parent: 1
-  - uid: 3155
+  - uid: 3148
     components:
     - type: Transform
       pos: -23.5,15.5
       parent: 1
-  - uid: 3156
+  - uid: 3149
     components:
     - type: Transform
       pos: -26.5,19.5
       parent: 1
-  - uid: 3157
+  - uid: 3150
     components:
     - type: Transform
       pos: -30.5,15.5
       parent: 1
-  - uid: 3158
+  - uid: 3151
     components:
     - type: Transform
       pos: -30.5,13.5
       parent: 1
-  - uid: 3159
+  - uid: 3152
     components:
     - type: Transform
       pos: -30.5,17.5
       parent: 1
-  - uid: 3160
+  - uid: 3153
     components:
     - type: Transform
       pos: -30.5,19.5
       parent: 1
-  - uid: 3161
+  - uid: 3154
     components:
     - type: Transform
       pos: -24.5,19.5
       parent: 1
-  - uid: 3162
+  - uid: 3155
     components:
     - type: Transform
       pos: -23.5,13.5
       parent: 1
-  - uid: 3163
+  - uid: 3156
     components:
     - type: Transform
       pos: -23.5,10.5
       parent: 1
-  - uid: 3164
+  - uid: 3157
     components:
     - type: Transform
       pos: 2.5,-59.5
       parent: 1
-  - uid: 3165
+  - uid: 3158
     components:
     - type: Transform
       pos: 1.5,-59.5
       parent: 1
-  - uid: 3166
+  - uid: 3159
     components:
     - type: Transform
       pos: 4.5,-59.5
       parent: 1
-  - uid: 3167
+  - uid: 3160
     components:
     - type: Transform
       pos: 22.5,20.5
       parent: 1
-  - uid: 3168
+  - uid: 3161
     components:
     - type: Transform
       pos: 22.5,15.5
       parent: 1
-  - uid: 3169
+  - uid: 3162
     components:
     - type: Transform
       pos: 22.5,18.5
       parent: 1
-  - uid: 3170
+  - uid: 3163
     components:
     - type: Transform
       pos: 2.5,37.5
       parent: 1
-  - uid: 3171
+  - uid: 3164
     components:
     - type: Transform
       pos: 22.5,16.5
       parent: 1
-  - uid: 3172
+  - uid: 3165
     components:
     - type: Transform
       pos: 1.5,37.5
       parent: 1
-  - uid: 3173
+  - uid: 3166
     components:
     - type: Transform
       pos: 22.5,17.5
       parent: 1
 - proto: CMWindowReinforcedAlmayerHull
   entities:
-  - uid: 3174
-    components:
-    - type: Transform
-      pos: 6.5,-69.5
-      parent: 1
-  - uid: 3175
-    components:
-    - type: Transform
-      pos: 7.5,-69.5
-      parent: 1
-  - uid: 3176
-    components:
-    - type: Transform
-      pos: 10.5,-57.5
-      parent: 1
-  - uid: 3177
-    components:
-    - type: Transform
-      pos: 10.5,-59.5
-      parent: 1
-  - uid: 3178
-    components:
-    - type: Transform
-      pos: 10.5,-68.5
-      parent: 1
-  - uid: 3179
-    components:
-    - type: Transform
-      pos: 8.5,-65.5
-      parent: 1
-  - uid: 3180
-    components:
-    - type: Transform
-      pos: 9.5,-64.5
-      parent: 1
-  - uid: 3181
-    components:
-    - type: Transform
-      pos: 10.5,-67.5
-      parent: 1
-  - uid: 3182
-    components:
-    - type: Transform
-      pos: 10.5,-58.5
-      parent: 1
-  - uid: 3183
-    components:
-    - type: Transform
-      pos: 31.5,7.5
-      parent: 1
-  - uid: 3184
-    components:
-    - type: Transform
-      pos: 31.5,5.5
-      parent: 1
-  - uid: 3185
-    components:
-    - type: Transform
-      pos: 31.5,6.5
-      parent: 1
-  - uid: 3186
-    components:
-    - type: Transform
-      pos: 29.5,1.5
-      parent: 1
-  - uid: 3187
-    components:
-    - type: Transform
-      pos: 31.5,4.5
-      parent: 1
-  - uid: 3188
-    components:
-    - type: Transform
-      pos: 29.5,2.5
-      parent: 1
-  - uid: 3189
-    components:
-    - type: Transform
-      pos: 29.5,0.5
-      parent: 1
-  - uid: 3190
-    components:
-    - type: Transform
-      pos: 17.5,-55.5
-      parent: 1
-  - uid: 3191
-    components:
-    - type: Transform
-      pos: -18.5,-53.5
-      parent: 1
-  - uid: 3192
-    components:
-    - type: Transform
-      pos: -18.5,-54.5
-      parent: 1
-  - uid: 3193
-    components:
-    - type: Transform
-      pos: 12.5,54.5
-      parent: 1
-  - uid: 3194
-    components:
-    - type: Transform
-      pos: 13.5,54.5
-      parent: 1
-  - uid: 3195
-    components:
-    - type: Transform
-      pos: 10.5,54.5
-      parent: 1
-  - uid: 3196
-    components:
-    - type: Transform
-      pos: 22.5,47.5
-      parent: 1
-  - uid: 3197
-    components:
-    - type: Transform
-      pos: 22.5,45.5
-      parent: 1
-  - uid: 3198
-    components:
-    - type: Transform
-      pos: 22.5,51.5
-      parent: 1
-  - uid: 3199
-    components:
-    - type: Transform
-      pos: 17.5,53.5
-      parent: 1
-  - uid: 3200
-    components:
-    - type: Transform
-      pos: 22.5,-13.5
-      parent: 1
-  - uid: 3201
-    components:
-    - type: Transform
-      pos: 22.5,-10.5
-      parent: 1
-  - uid: 3202
-    components:
-    - type: Transform
-      pos: -30.5,2.5
-      parent: 1
-  - uid: 3203
-    components:
-    - type: Transform
-      pos: 22.5,35.5
-      parent: 1
-  - uid: 3204
-    components:
-    - type: Transform
-      pos: -23.5,45.5
-      parent: 1
-  - uid: 3205
-    components:
-    - type: Transform
-      pos: -23.5,42.5
-      parent: 1
-  - uid: 3206
-    components:
-    - type: Transform
-      pos: -23.5,43.5
-      parent: 1
-  - uid: 3207
-    components:
-    - type: Transform
-      pos: -23.5,41.5
-      parent: 1
-  - uid: 3208
-    components:
-    - type: Transform
-      pos: -23.5,51.5
-      parent: 1
-  - uid: 3209
-    components:
-    - type: Transform
-      pos: -23.5,47.5
-      parent: 1
-  - uid: 3210
-    components:
-    - type: Transform
-      pos: -23.5,48.5
-      parent: 1
-  - uid: 3211
-    components:
-    - type: Transform
-      pos: 17.5,-53.5
-      parent: 1
-  - uid: 3212
-    components:
-    - type: Transform
-      pos: -18.5,-49.5
-      parent: 1
-  - uid: 3213
-    components:
-    - type: Transform
-      pos: -23.5,36.5
-      parent: 1
-  - uid: 3214
-    components:
-    - type: Transform
-      pos: -23.5,32.5
-      parent: 1
-  - uid: 3215
-    components:
-    - type: Transform
-      pos: -23.5,35.5
-      parent: 1
-  - uid: 3216
-    components:
-    - type: Transform
-      pos: -23.5,28.5
-      parent: 1
-  - uid: 3217
-    components:
-    - type: Transform
-      pos: -18.5,-43.5
-      parent: 1
-  - uid: 3218
-    components:
-    - type: Transform
-      pos: -18.5,-46.5
-      parent: 1
-  - uid: 3219
-    components:
-    - type: Transform
-      pos: -23.5,-15.5
-      parent: 1
-  - uid: 3220
-    components:
-    - type: Transform
-      pos: -23.5,-14.5
-      parent: 1
-  - uid: 3221
-    components:
-    - type: Transform
-      pos: -23.5,-13.5
-      parent: 1
-  - uid: 3222
-    components:
-    - type: Transform
-      pos: 16.5,53.5
-      parent: 1
-  - uid: 3223
-    components:
-    - type: Transform
-      pos: 20.5,53.5
-      parent: 1
-  - uid: 3224
-    components:
-    - type: Transform
-      pos: -18.5,-31.5
-      parent: 1
-  - uid: 3225
-    components:
-    - type: Transform
-      pos: -18.5,-32.5
-      parent: 1
-  - uid: 3226
-    components:
-    - type: Transform
-      pos: -18.5,-33.5
-      parent: 1
-  - uid: 3227
-    components:
-    - type: Transform
-      pos: -18.5,-34.5
-      parent: 1
-  - uid: 3228
-    components:
-    - type: Transform
-      pos: 17.5,-31.5
-      parent: 1
-  - uid: 3229
-    components:
-    - type: Transform
-      pos: 17.5,-32.5
-      parent: 1
-  - uid: 3230
-    components:
-    - type: Transform
-      pos: 17.5,-33.5
-      parent: 1
-  - uid: 3231
-    components:
-    - type: Transform
-      pos: 17.5,-34.5
-      parent: 1
-  - uid: 3232
-    components:
-    - type: Transform
-      pos: 17.5,-39.5
-      parent: 1
-  - uid: 3233
-    components:
-    - type: Transform
-      pos: 17.5,-38.5
-      parent: 1
-  - uid: 3234
-    components:
-    - type: Transform
-      pos: 17.5,-37.5
-      parent: 1
-  - uid: 3235
-    components:
-    - type: Transform
-      pos: 17.5,-36.5
-      parent: 1
-  - uid: 3236
-    components:
-    - type: Transform
-      pos: -18.5,-36.5
-      parent: 1
-  - uid: 3237
-    components:
-    - type: Transform
-      pos: -18.5,-37.5
-      parent: 1
-  - uid: 3238
-    components:
-    - type: Transform
-      pos: -18.5,-38.5
-      parent: 1
-  - uid: 3239
-    components:
-    - type: Transform
-      pos: -18.5,-39.5
-      parent: 1
-  - uid: 3240
-    components:
-    - type: Transform
-      pos: -14.5,54.5
-      parent: 1
-  - uid: 3241
-    components:
-    - type: Transform
-      pos: -13.5,54.5
-      parent: 1
-  - uid: 3242
-    components:
-    - type: Transform
-      pos: -11.5,54.5
-      parent: 1
-  - uid: 3243
-    components:
-    - type: Transform
-      pos: -10.5,54.5
-      parent: 1
-  - uid: 3244
-    components:
-    - type: Transform
-      pos: -9.5,54.5
-      parent: 1
-  - uid: 3245
-    components:
-    - type: Transform
-      pos: -8.5,54.5
-      parent: 1
-  - uid: 3246
-    components:
-    - type: Transform
-      pos: -23.5,-10.5
-      parent: 1
-  - uid: 3247
-    components:
-    - type: Transform
-      pos: -23.5,-9.5
-      parent: 1
-  - uid: 3248
-    components:
-    - type: Transform
-      pos: -23.5,-12.5
-      parent: 1
-  - uid: 3249
-    components:
-    - type: Transform
-      pos: 2.5,62.5
-      parent: 1
-  - uid: 3250
-    components:
-    - type: Transform
-      pos: 2.5,60.5
-      parent: 1
-  - uid: 3251
-    components:
-    - type: Transform
-      pos: -5.5,62.5
-      parent: 1
-  - uid: 3252
-    components:
-    - type: Transform
-      pos: 2.5,61.5
-      parent: 1
-  - uid: 3253
-    components:
-    - type: Transform
-      pos: -5.5,63.5
-      parent: 1
-  - uid: 3254
-    components:
-    - type: Transform
-      pos: 2.5,63.5
-      parent: 1
-  - uid: 3255
-    components:
-    - type: Transform
-      pos: 3.5,65.5
-      parent: 1
-  - uid: 3256
-    components:
-    - type: Transform
-      pos: -6.5,65.5
-      parent: 1
-  - uid: 3257
-    components:
-    - type: Transform
-      pos: -6.5,67.5
-      parent: 1
-  - uid: 3258
-    components:
-    - type: Transform
-      pos: -6.5,66.5
-      parent: 1
-  - uid: 3259
-    components:
-    - type: Transform
-      pos: 3.5,66.5
-      parent: 1
-  - uid: 3260
-    components:
-    - type: Transform
-      pos: 3.5,67.5
-      parent: 1
-  - uid: 3261
-    components:
-    - type: Transform
-      pos: -5.5,69.5
-      parent: 1
-  - uid: 3262
-    components:
-    - type: Transform
-      pos: 2.5,69.5
-      parent: 1
-  - uid: 3263
-    components:
-    - type: Transform
-      pos: 0.5,71.5
-      parent: 1
-  - uid: 3264
-    components:
-    - type: Transform
-      pos: -0.5,71.5
-      parent: 1
-  - uid: 3265
-    components:
-    - type: Transform
-      pos: -1.5,71.5
-      parent: 1
-  - uid: 3266
-    components:
-    - type: Transform
-      pos: -2.5,71.5
-      parent: 1
-  - uid: 3267
-    components:
-    - type: Transform
-      pos: -3.5,71.5
-      parent: 1
-  - uid: 3268
-    components:
-    - type: Transform
-      pos: -15.5,54.5
-      parent: 1
-  - uid: 3269
-    components:
-    - type: Transform
-      pos: -16.5,54.5
-      parent: 1
-  - uid: 3270
-    components:
-    - type: Transform
-      pos: -5.5,60.5
-      parent: 1
-  - uid: 3271
-    components:
-    - type: Transform
-      pos: -5.5,61.5
-      parent: 1
-  - uid: 3272
-    components:
-    - type: Transform
-      pos: 17.5,-54.5
-      parent: 1
-  - uid: 3273
-    components:
-    - type: Transform
-      pos: 18.5,53.5
-      parent: 1
-  - uid: 3274
-    components:
-    - type: Transform
-      pos: 17.5,-42.5
-      parent: 1
-  - uid: 3275
-    components:
-    - type: Transform
-      pos: 17.5,-41.5
-      parent: 1
-  - uid: 3276
-    components:
-    - type: Transform
-      pos: 17.5,-43.5
-      parent: 1
-  - uid: 3277
-    components:
-    - type: Transform
-      pos: 17.5,-44.5
-      parent: 1
-  - uid: 3278
-    components:
-    - type: Transform
-      pos: 17.5,-49.5
-      parent: 1
-  - uid: 3279
-    components:
-    - type: Transform
-      pos: 17.5,-47.5
-      parent: 1
-  - uid: 3280
-    components:
-    - type: Transform
-      pos: 17.5,-48.5
-      parent: 1
-  - uid: 3281
-    components:
-    - type: Transform
-      pos: -18.5,-55.5
-      parent: 1
-  - uid: 3282
-    components:
-    - type: Transform
-      pos: -19.5,53.5
-      parent: 1
-  - uid: 3283
-    components:
-    - type: Transform
-      pos: 19.5,53.5
-      parent: 1
-  - uid: 3284
-    components:
-    - type: Transform
-      pos: -18.5,-42.5
-      parent: 1
-  - uid: 3285
-    components:
-    - type: Transform
-      pos: 22.5,30.5
-      parent: 1
-  - uid: 3286
-    components:
-    - type: Transform
-      pos: 22.5,37.5
-      parent: 1
-  - uid: 3287
-    components:
-    - type: Transform
-      pos: 17.5,-46.5
-      parent: 1
-  - uid: 3288
-    components:
-    - type: Transform
-      pos: -23.5,31.5
-      parent: 1
-  - uid: 3289
-    components:
-    - type: Transform
-      pos: -23.5,52.5
-      parent: 1
-  - uid: 3290
-    components:
-    - type: Transform
-      pos: -18.5,-41.5
-      parent: 1
-  - uid: 3291
-    components:
-    - type: Transform
-      pos: -21.5,53.5
-      parent: 1
-  - uid: 3292
-    components:
-    - type: Transform
-      pos: 5.5,54.5
-      parent: 1
-  - uid: 3293
-    components:
-    - type: Transform
-      pos: 6.5,54.5
-      parent: 1
-  - uid: 3294
-    components:
-    - type: Transform
-      pos: 22.5,32.5
-      parent: 1
-  - uid: 3295
-    components:
-    - type: Transform
-      pos: 22.5,38.5
-      parent: 1
-  - uid: 3296
-    components:
-    - type: Transform
-      pos: 22.5,-14.5
-      parent: 1
-  - uid: 3297
-    components:
-    - type: Transform
-      pos: 22.5,43.5
-      parent: 1
-  - uid: 3298
-    components:
-    - type: Transform
-      pos: 22.5,50.5
-      parent: 1
-  - uid: 3299
-    components:
-    - type: Transform
-      pos: 22.5,52.5
-      parent: 1
-  - uid: 3300
-    components:
-    - type: Transform
-      pos: 22.5,46.5
-      parent: 1
-  - uid: 3301
-    components:
-    - type: Transform
-      pos: 22.5,48.5
-      parent: 1
-  - uid: 3302
-    components:
-    - type: Transform
-      pos: 8.5,54.5
-      parent: 1
-  - uid: 3303
-    components:
-    - type: Transform
-      pos: 11.5,54.5
-      parent: 1
-  - uid: 3304
-    components:
-    - type: Transform
-      pos: 7.5,54.5
-      parent: 1
-  - uid: 3305
-    components:
-    - type: Transform
-      pos: 22.5,28.5
-      parent: 1
-  - uid: 3306
-    components:
-    - type: Transform
-      pos: 22.5,27.5
-      parent: 1
-  - uid: 3307
-    components:
-    - type: Transform
-      pos: 22.5,31.5
-      parent: 1
-  - uid: 3308
-    components:
-    - type: Transform
-      pos: 22.5,33.5
-      parent: 1
-  - uid: 3309
-    components:
-    - type: Transform
-      pos: 22.5,36.5
-      parent: 1
-  - uid: 3310
-    components:
-    - type: Transform
-      pos: 22.5,42.5
-      parent: 1
-  - uid: 3311
-    components:
-    - type: Transform
-      pos: 22.5,41.5
-      parent: 1
-  - uid: 3312
-    components:
-    - type: Transform
-      pos: 22.5,40.5
-      parent: 1
-  - uid: 3313
-    components:
-    - type: Transform
-      pos: 22.5,-9.5
-      parent: 1
-  - uid: 3314
-    components:
-    - type: Transform
-      pos: 22.5,-15.5
-      parent: 1
-  - uid: 3315
-    components:
-    - type: Transform
-      pos: 22.5,-12.5
-      parent: 1
-  - uid: 3316
-    components:
-    - type: Transform
-      pos: -23.5,50.5
-      parent: 1
-  - uid: 3317
-    components:
-    - type: Transform
-      pos: -23.5,46.5
-      parent: 1
-  - uid: 3318
-    components:
-    - type: Transform
-      pos: -18.5,-48.5
-      parent: 1
-  - uid: 3319
-    components:
-    - type: Transform
-      pos: -18.5,-44.5
-      parent: 1
-  - uid: 3320
-    components:
-    - type: Transform
-      pos: -18.5,-47.5
-      parent: 1
-  - uid: 3321
-    components:
-    - type: Transform
-      pos: -23.5,30.5
-      parent: 1
-  - uid: 3322
-    components:
-    - type: Transform
-      pos: -23.5,33.5
-      parent: 1
-  - uid: 3323
-    components:
-    - type: Transform
-      pos: -20.5,53.5
-      parent: 1
-  - uid: 3324
-    components:
-    - type: Transform
-      pos: -23.5,37.5
-      parent: 1
-  - uid: 3325
-    components:
-    - type: Transform
-      pos: -23.5,40.5
-      parent: 1
-  - uid: 3326
-    components:
-    - type: Transform
-      pos: -23.5,38.5
-      parent: 1
-  - uid: 3327
-    components:
-    - type: Transform
-      pos: -23.5,27.5
-      parent: 1
-  - uid: 3328
-    components:
-    - type: Transform
-      pos: -29.5,20.5
-      parent: 1
-  - uid: 3329
-    components:
-    - type: Transform
-      pos: -29.5,24.5
-      parent: 1
-  - uid: 3330
-    components:
-    - type: Transform
-      pos: -30.5,21.5
-      parent: 1
-  - uid: 3331
-    components:
-    - type: Transform
-      pos: -30.5,0.5
-      parent: 1
-  - uid: 3332
-    components:
-    - type: Transform
-      pos: -34.5,13.5
-      parent: 1
-  - uid: 3333
-    components:
-    - type: Transform
-      pos: -34.5,19.5
-      parent: 1
-  - uid: 3334
-    components:
-    - type: Transform
-      pos: -34.5,17.5
-      parent: 1
-  - uid: 3335
-    components:
-    - type: Transform
-      pos: -34.5,14.5
-      parent: 1
-  - uid: 3336
-    components:
-    - type: Transform
-      pos: -34.5,15.5
-      parent: 1
-  - uid: 3337
-    components:
-    - type: Transform
-      pos: -30.5,1.5
-      parent: 1
-  - uid: 3338
-    components:
-    - type: Transform
-      pos: -30.5,23.5
-      parent: 1
-  - uid: 3339
-    components:
-    - type: Transform
-      pos: -30.5,22.5
-      parent: 1
-  - uid: 3340
-    components:
-    - type: Transform
-      pos: -34.5,18.5
-      parent: 1
-  - uid: 3341
+  - uid: 3167
     components:
     - type: Transform
       pos: -24.5,26.5
       parent: 1
-  - uid: 3342
+  - uid: 3168
+    components:
+    - type: Transform
+      pos: 6.5,-69.5
+      parent: 1
+  - uid: 3169
+    components:
+    - type: Transform
+      pos: 7.5,-69.5
+      parent: 1
+  - uid: 3170
+    components:
+    - type: Transform
+      pos: 10.5,-57.5
+      parent: 1
+  - uid: 3171
+    components:
+    - type: Transform
+      pos: 10.5,-59.5
+      parent: 1
+  - uid: 3172
+    components:
+    - type: Transform
+      pos: 10.5,-68.5
+      parent: 1
+  - uid: 3173
+    components:
+    - type: Transform
+      pos: 8.5,-65.5
+      parent: 1
+  - uid: 3174
+    components:
+    - type: Transform
+      pos: 9.5,-64.5
+      parent: 1
+  - uid: 3175
+    components:
+    - type: Transform
+      pos: 10.5,-67.5
+      parent: 1
+  - uid: 3176
+    components:
+    - type: Transform
+      pos: 10.5,-58.5
+      parent: 1
+  - uid: 3177
+    components:
+    - type: Transform
+      pos: 31.5,7.5
+      parent: 1
+  - uid: 3178
+    components:
+    - type: Transform
+      pos: 31.5,5.5
+      parent: 1
+  - uid: 3179
+    components:
+    - type: Transform
+      pos: 31.5,6.5
+      parent: 1
+  - uid: 3180
+    components:
+    - type: Transform
+      pos: 29.5,1.5
+      parent: 1
+  - uid: 3181
+    components:
+    - type: Transform
+      pos: 31.5,4.5
+      parent: 1
+  - uid: 3182
+    components:
+    - type: Transform
+      pos: 29.5,2.5
+      parent: 1
+  - uid: 3183
+    components:
+    - type: Transform
+      pos: 29.5,0.5
+      parent: 1
+  - uid: 3184
+    components:
+    - type: Transform
+      pos: 17.5,-55.5
+      parent: 1
+  - uid: 3185
+    components:
+    - type: Transform
+      pos: -18.5,-53.5
+      parent: 1
+  - uid: 3186
+    components:
+    - type: Transform
+      pos: -18.5,-54.5
+      parent: 1
+  - uid: 3187
+    components:
+    - type: Transform
+      pos: 12.5,54.5
+      parent: 1
+  - uid: 3188
+    components:
+    - type: Transform
+      pos: 13.5,54.5
+      parent: 1
+  - uid: 3189
+    components:
+    - type: Transform
+      pos: 10.5,54.5
+      parent: 1
+  - uid: 3190
+    components:
+    - type: Transform
+      pos: 22.5,47.5
+      parent: 1
+  - uid: 3191
+    components:
+    - type: Transform
+      pos: 22.5,45.5
+      parent: 1
+  - uid: 3192
+    components:
+    - type: Transform
+      pos: 22.5,51.5
+      parent: 1
+  - uid: 3193
+    components:
+    - type: Transform
+      pos: 17.5,53.5
+      parent: 1
+  - uid: 3194
+    components:
+    - type: Transform
+      pos: 22.5,-13.5
+      parent: 1
+  - uid: 3195
+    components:
+    - type: Transform
+      pos: 22.5,-10.5
+      parent: 1
+  - uid: 3196
+    components:
+    - type: Transform
+      pos: -30.5,2.5
+      parent: 1
+  - uid: 3197
+    components:
+    - type: Transform
+      pos: 22.5,35.5
+      parent: 1
+  - uid: 3198
+    components:
+    - type: Transform
+      pos: -23.5,45.5
+      parent: 1
+  - uid: 3199
+    components:
+    - type: Transform
+      pos: -23.5,42.5
+      parent: 1
+  - uid: 3200
+    components:
+    - type: Transform
+      pos: -23.5,43.5
+      parent: 1
+  - uid: 3201
+    components:
+    - type: Transform
+      pos: -23.5,41.5
+      parent: 1
+  - uid: 3202
+    components:
+    - type: Transform
+      pos: -23.5,51.5
+      parent: 1
+  - uid: 3203
+    components:
+    - type: Transform
+      pos: -23.5,47.5
+      parent: 1
+  - uid: 3204
+    components:
+    - type: Transform
+      pos: -23.5,48.5
+      parent: 1
+  - uid: 3205
+    components:
+    - type: Transform
+      pos: 17.5,-53.5
+      parent: 1
+  - uid: 3206
+    components:
+    - type: Transform
+      pos: -18.5,-49.5
+      parent: 1
+  - uid: 3207
+    components:
+    - type: Transform
+      pos: -23.5,36.5
+      parent: 1
+  - uid: 3208
+    components:
+    - type: Transform
+      pos: -23.5,32.5
+      parent: 1
+  - uid: 3209
+    components:
+    - type: Transform
+      pos: -23.5,35.5
+      parent: 1
+  - uid: 3210
+    components:
+    - type: Transform
+      pos: -23.5,28.5
+      parent: 1
+  - uid: 3211
+    components:
+    - type: Transform
+      pos: -18.5,-43.5
+      parent: 1
+  - uid: 3212
+    components:
+    - type: Transform
+      pos: -18.5,-46.5
+      parent: 1
+  - uid: 3213
+    components:
+    - type: Transform
+      pos: -23.5,-15.5
+      parent: 1
+  - uid: 3214
+    components:
+    - type: Transform
+      pos: -23.5,-14.5
+      parent: 1
+  - uid: 3215
+    components:
+    - type: Transform
+      pos: -23.5,-13.5
+      parent: 1
+  - uid: 3216
+    components:
+    - type: Transform
+      pos: 16.5,53.5
+      parent: 1
+  - uid: 3217
+    components:
+    - type: Transform
+      pos: 20.5,53.5
+      parent: 1
+  - uid: 3218
+    components:
+    - type: Transform
+      pos: -18.5,-31.5
+      parent: 1
+  - uid: 3219
+    components:
+    - type: Transform
+      pos: -18.5,-32.5
+      parent: 1
+  - uid: 3220
+    components:
+    - type: Transform
+      pos: -18.5,-33.5
+      parent: 1
+  - uid: 3221
+    components:
+    - type: Transform
+      pos: -18.5,-34.5
+      parent: 1
+  - uid: 3222
+    components:
+    - type: Transform
+      pos: 17.5,-31.5
+      parent: 1
+  - uid: 3223
+    components:
+    - type: Transform
+      pos: 17.5,-32.5
+      parent: 1
+  - uid: 3224
+    components:
+    - type: Transform
+      pos: 17.5,-33.5
+      parent: 1
+  - uid: 3225
+    components:
+    - type: Transform
+      pos: 17.5,-34.5
+      parent: 1
+  - uid: 3226
+    components:
+    - type: Transform
+      pos: 17.5,-39.5
+      parent: 1
+  - uid: 3227
+    components:
+    - type: Transform
+      pos: 17.5,-38.5
+      parent: 1
+  - uid: 3228
+    components:
+    - type: Transform
+      pos: 17.5,-37.5
+      parent: 1
+  - uid: 3229
+    components:
+    - type: Transform
+      pos: 17.5,-36.5
+      parent: 1
+  - uid: 3230
+    components:
+    - type: Transform
+      pos: -18.5,-36.5
+      parent: 1
+  - uid: 3231
+    components:
+    - type: Transform
+      pos: -18.5,-37.5
+      parent: 1
+  - uid: 3232
+    components:
+    - type: Transform
+      pos: -18.5,-38.5
+      parent: 1
+  - uid: 3233
+    components:
+    - type: Transform
+      pos: -18.5,-39.5
+      parent: 1
+  - uid: 3234
+    components:
+    - type: Transform
+      pos: -14.5,54.5
+      parent: 1
+  - uid: 3235
+    components:
+    - type: Transform
+      pos: -13.5,54.5
+      parent: 1
+  - uid: 3236
+    components:
+    - type: Transform
+      pos: -11.5,54.5
+      parent: 1
+  - uid: 3237
+    components:
+    - type: Transform
+      pos: -10.5,54.5
+      parent: 1
+  - uid: 3238
+    components:
+    - type: Transform
+      pos: -9.5,54.5
+      parent: 1
+  - uid: 3239
+    components:
+    - type: Transform
+      pos: -8.5,54.5
+      parent: 1
+  - uid: 3240
+    components:
+    - type: Transform
+      pos: -23.5,-10.5
+      parent: 1
+  - uid: 3241
+    components:
+    - type: Transform
+      pos: -23.5,-9.5
+      parent: 1
+  - uid: 3242
+    components:
+    - type: Transform
+      pos: -23.5,-12.5
+      parent: 1
+  - uid: 3243
+    components:
+    - type: Transform
+      pos: 2.5,62.5
+      parent: 1
+  - uid: 3244
+    components:
+    - type: Transform
+      pos: 2.5,60.5
+      parent: 1
+  - uid: 3245
+    components:
+    - type: Transform
+      pos: -5.5,62.5
+      parent: 1
+  - uid: 3246
+    components:
+    - type: Transform
+      pos: 2.5,61.5
+      parent: 1
+  - uid: 3247
+    components:
+    - type: Transform
+      pos: -5.5,63.5
+      parent: 1
+  - uid: 3248
+    components:
+    - type: Transform
+      pos: 2.5,63.5
+      parent: 1
+  - uid: 3249
+    components:
+    - type: Transform
+      pos: 3.5,65.5
+      parent: 1
+  - uid: 3250
+    components:
+    - type: Transform
+      pos: -6.5,65.5
+      parent: 1
+  - uid: 3251
+    components:
+    - type: Transform
+      pos: -6.5,67.5
+      parent: 1
+  - uid: 3252
+    components:
+    - type: Transform
+      pos: -6.5,66.5
+      parent: 1
+  - uid: 3253
+    components:
+    - type: Transform
+      pos: 3.5,66.5
+      parent: 1
+  - uid: 3254
+    components:
+    - type: Transform
+      pos: 3.5,67.5
+      parent: 1
+  - uid: 3255
+    components:
+    - type: Transform
+      pos: -5.5,69.5
+      parent: 1
+  - uid: 3256
+    components:
+    - type: Transform
+      pos: 2.5,69.5
+      parent: 1
+  - uid: 3257
+    components:
+    - type: Transform
+      pos: 0.5,71.5
+      parent: 1
+  - uid: 3258
+    components:
+    - type: Transform
+      pos: -0.5,71.5
+      parent: 1
+  - uid: 3259
+    components:
+    - type: Transform
+      pos: -1.5,71.5
+      parent: 1
+  - uid: 3260
+    components:
+    - type: Transform
+      pos: -2.5,71.5
+      parent: 1
+  - uid: 3261
+    components:
+    - type: Transform
+      pos: -3.5,71.5
+      parent: 1
+  - uid: 3262
+    components:
+    - type: Transform
+      pos: -15.5,54.5
+      parent: 1
+  - uid: 3263
+    components:
+    - type: Transform
+      pos: -16.5,54.5
+      parent: 1
+  - uid: 3264
+    components:
+    - type: Transform
+      pos: -5.5,60.5
+      parent: 1
+  - uid: 3265
+    components:
+    - type: Transform
+      pos: -5.5,61.5
+      parent: 1
+  - uid: 3266
+    components:
+    - type: Transform
+      pos: 17.5,-54.5
+      parent: 1
+  - uid: 3267
+    components:
+    - type: Transform
+      pos: 18.5,53.5
+      parent: 1
+  - uid: 3268
+    components:
+    - type: Transform
+      pos: 17.5,-42.5
+      parent: 1
+  - uid: 3269
+    components:
+    - type: Transform
+      pos: 17.5,-41.5
+      parent: 1
+  - uid: 3270
+    components:
+    - type: Transform
+      pos: 17.5,-43.5
+      parent: 1
+  - uid: 3271
+    components:
+    - type: Transform
+      pos: 17.5,-44.5
+      parent: 1
+  - uid: 3272
+    components:
+    - type: Transform
+      pos: 17.5,-49.5
+      parent: 1
+  - uid: 3273
+    components:
+    - type: Transform
+      pos: 17.5,-47.5
+      parent: 1
+  - uid: 3274
+    components:
+    - type: Transform
+      pos: 17.5,-48.5
+      parent: 1
+  - uid: 3275
+    components:
+    - type: Transform
+      pos: -18.5,-55.5
+      parent: 1
+  - uid: 3276
+    components:
+    - type: Transform
+      pos: -19.5,53.5
+      parent: 1
+  - uid: 3277
+    components:
+    - type: Transform
+      pos: 19.5,53.5
+      parent: 1
+  - uid: 3278
+    components:
+    - type: Transform
+      pos: -18.5,-42.5
+      parent: 1
+  - uid: 3279
+    components:
+    - type: Transform
+      pos: 22.5,30.5
+      parent: 1
+  - uid: 3280
+    components:
+    - type: Transform
+      pos: 22.5,37.5
+      parent: 1
+  - uid: 3281
+    components:
+    - type: Transform
+      pos: 17.5,-46.5
+      parent: 1
+  - uid: 3282
+    components:
+    - type: Transform
+      pos: -23.5,31.5
+      parent: 1
+  - uid: 3283
+    components:
+    - type: Transform
+      pos: -23.5,52.5
+      parent: 1
+  - uid: 3284
+    components:
+    - type: Transform
+      pos: -18.5,-41.5
+      parent: 1
+  - uid: 3285
+    components:
+    - type: Transform
+      pos: -21.5,53.5
+      parent: 1
+  - uid: 3286
+    components:
+    - type: Transform
+      pos: 5.5,54.5
+      parent: 1
+  - uid: 3287
+    components:
+    - type: Transform
+      pos: 6.5,54.5
+      parent: 1
+  - uid: 3288
+    components:
+    - type: Transform
+      pos: 22.5,32.5
+      parent: 1
+  - uid: 3289
+    components:
+    - type: Transform
+      pos: 22.5,38.5
+      parent: 1
+  - uid: 3290
+    components:
+    - type: Transform
+      pos: 22.5,-14.5
+      parent: 1
+  - uid: 3291
+    components:
+    - type: Transform
+      pos: 22.5,43.5
+      parent: 1
+  - uid: 3292
+    components:
+    - type: Transform
+      pos: 22.5,50.5
+      parent: 1
+  - uid: 3293
+    components:
+    - type: Transform
+      pos: 22.5,52.5
+      parent: 1
+  - uid: 3294
+    components:
+    - type: Transform
+      pos: 22.5,46.5
+      parent: 1
+  - uid: 3295
+    components:
+    - type: Transform
+      pos: 22.5,48.5
+      parent: 1
+  - uid: 3296
+    components:
+    - type: Transform
+      pos: 8.5,54.5
+      parent: 1
+  - uid: 3297
+    components:
+    - type: Transform
+      pos: 11.5,54.5
+      parent: 1
+  - uid: 3298
+    components:
+    - type: Transform
+      pos: 7.5,54.5
+      parent: 1
+  - uid: 3299
+    components:
+    - type: Transform
+      pos: 22.5,28.5
+      parent: 1
+  - uid: 3300
+    components:
+    - type: Transform
+      pos: 22.5,27.5
+      parent: 1
+  - uid: 3301
+    components:
+    - type: Transform
+      pos: 22.5,31.5
+      parent: 1
+  - uid: 3302
+    components:
+    - type: Transform
+      pos: 22.5,33.5
+      parent: 1
+  - uid: 3303
+    components:
+    - type: Transform
+      pos: 22.5,36.5
+      parent: 1
+  - uid: 3304
+    components:
+    - type: Transform
+      pos: 22.5,42.5
+      parent: 1
+  - uid: 3305
+    components:
+    - type: Transform
+      pos: 22.5,41.5
+      parent: 1
+  - uid: 3306
+    components:
+    - type: Transform
+      pos: 22.5,40.5
+      parent: 1
+  - uid: 3307
+    components:
+    - type: Transform
+      pos: 22.5,-9.5
+      parent: 1
+  - uid: 3308
+    components:
+    - type: Transform
+      pos: 22.5,-15.5
+      parent: 1
+  - uid: 3309
+    components:
+    - type: Transform
+      pos: 22.5,-12.5
+      parent: 1
+  - uid: 3310
+    components:
+    - type: Transform
+      pos: -23.5,50.5
+      parent: 1
+  - uid: 3311
+    components:
+    - type: Transform
+      pos: -23.5,46.5
+      parent: 1
+  - uid: 3312
+    components:
+    - type: Transform
+      pos: -18.5,-48.5
+      parent: 1
+  - uid: 3313
+    components:
+    - type: Transform
+      pos: -18.5,-44.5
+      parent: 1
+  - uid: 3314
+    components:
+    - type: Transform
+      pos: -18.5,-47.5
+      parent: 1
+  - uid: 3315
+    components:
+    - type: Transform
+      pos: -23.5,30.5
+      parent: 1
+  - uid: 3316
+    components:
+    - type: Transform
+      pos: -23.5,33.5
+      parent: 1
+  - uid: 3317
+    components:
+    - type: Transform
+      pos: -20.5,53.5
+      parent: 1
+  - uid: 3318
+    components:
+    - type: Transform
+      pos: -23.5,37.5
+      parent: 1
+  - uid: 3319
+    components:
+    - type: Transform
+      pos: -23.5,40.5
+      parent: 1
+  - uid: 3320
+    components:
+    - type: Transform
+      pos: -23.5,38.5
+      parent: 1
+  - uid: 3321
+    components:
+    - type: Transform
+      pos: -23.5,27.5
+      parent: 1
+  - uid: 3322
+    components:
+    - type: Transform
+      pos: -29.5,20.5
+      parent: 1
+  - uid: 3323
+    components:
+    - type: Transform
+      pos: -29.5,24.5
+      parent: 1
+  - uid: 3324
+    components:
+    - type: Transform
+      pos: -30.5,21.5
+      parent: 1
+  - uid: 3325
+    components:
+    - type: Transform
+      pos: -30.5,0.5
+      parent: 1
+  - uid: 3326
+    components:
+    - type: Transform
+      pos: -34.5,13.5
+      parent: 1
+  - uid: 3327
+    components:
+    - type: Transform
+      pos: -34.5,19.5
+      parent: 1
+  - uid: 3328
+    components:
+    - type: Transform
+      pos: -34.5,17.5
+      parent: 1
+  - uid: 3329
+    components:
+    - type: Transform
+      pos: -34.5,14.5
+      parent: 1
+  - uid: 3330
+    components:
+    - type: Transform
+      pos: -34.5,15.5
+      parent: 1
+  - uid: 3331
+    components:
+    - type: Transform
+      pos: -30.5,1.5
+      parent: 1
+  - uid: 3332
+    components:
+    - type: Transform
+      pos: -30.5,23.5
+      parent: 1
+  - uid: 3333
+    components:
+    - type: Transform
+      pos: -30.5,22.5
+      parent: 1
+  - uid: 3334
+    components:
+    - type: Transform
+      pos: -34.5,18.5
+      parent: 1
+  - uid: 3335
     components:
     - type: Transform
       pos: -26.5,26.5
       parent: 1
-  - uid: 3343
+  - uid: 3336
     components:
     - type: Transform
       pos: -25.5,26.5
       parent: 1
-  - uid: 3344
+  - uid: 3337
     components:
     - type: Transform
       pos: 8.5,-66.5
       parent: 1
-  - uid: 3345
+  - uid: 3338
     components:
     - type: Transform
       pos: 8.5,-67.5
       parent: 1
-  - uid: 3346
+  - uid: 3339
     components:
     - type: Transform
       pos: 8.5,-68.5
       parent: 1
-  - uid: 3347
+  - uid: 3340
     components:
     - type: Transform
       pos: 10.5,-65.5
       parent: 1
-  - uid: 3348
+  - uid: 3341
     components:
     - type: Transform
       pos: 10.5,-66.5
       parent: 1
 - proto: CMWindowUltraDirectional
   entities:
-  - uid: 3349
+  - uid: 3342
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-3.5
       parent: 1
-  - uid: 3350
+  - uid: 3343
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-7.5
       parent: 1
-  - uid: 3351
+  - uid: 3344
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-11.5
       parent: 1
-  - uid: 3352
+  - uid: 3345
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-5.5
       parent: 1
-  - uid: 3353
+  - uid: 3346
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-1.5
       parent: 1
-  - uid: 3354
+  - uid: 3347
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-9.5
       parent: 1
-  - uid: 3355
+  - uid: 3348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-9.5
       parent: 1
-  - uid: 3356
+  - uid: 3349
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-5.5
       parent: 1
-  - uid: 3357
+  - uid: 3350
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-1.5
       parent: 1
-  - uid: 3358
+  - uid: 3351
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,-14.5
       parent: 1
-  - uid: 3359
+  - uid: 3352
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-14.5
       parent: 1
-  - uid: 3360
+  - uid: 3353
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-14.5
       parent: 1
-  - uid: 3361
+  - uid: 3354
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-14.5
       parent: 1
-  - uid: 3362
+  - uid: 3355
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-14.5
       parent: 1
-  - uid: 3363
+  - uid: 3356
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -25578,15 +25529,16 @@ entities:
       parent: 1
 - proto: d12Dice
   entities:
-  - uid: 3364
+  - uid: 3357
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.076985,-46.298435
+      pos: 3.1959014,-46.299377
       parent: 1
+    - type: Dice
+      currentValue: 8
 - proto: d6Dice
   entities:
-  - uid: 3365
+  - uid: 3358
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -25594,7 +25546,15 @@ entities:
       parent: 1
 - proto: DecorFloorPallet
   entities:
-  - uid: 3366
+  - uid: 3359
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,40.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 3360
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -25602,26 +25562,59 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 3367
+  - uid: 3361
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,38.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 3362
     components:
     - type: Transform
       pos: 14.5,38.5
       parent: 1
     - type: Fixtures
       fixtures: {}
+  - uid: 3363
+    components:
+    - type: Transform
+      pos: -7.5,42.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 3364
+    components:
+    - type: Transform
+      pos: -8.5,42.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: DecorFloorPalletStack
   entities:
-  - uid: 3369
+  - uid: 3365
     components:
     - type: Transform
       pos: -10.5,41.5
       parent: 1
-  - uid: 3370
+  - uid: 3366
+    components:
+    - type: Transform
+      pos: -6.5,41.5
+      parent: 1
+  - uid: 3367
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,42.5
+      parent: 1
+  - uid: 3368
     components:
     - type: Transform
       pos: 14.5,39.5
       parent: 1
-  - uid: 3371
+  - uid: 3369
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -25629,22 +25622,14 @@ entities:
       parent: 1
 - proto: DecorFloorPaper
   entities:
-  - uid: 3372
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,39.5
-      parent: 1
-    - type: Fixtures
-      fixtures: {}
-  - uid: 3373
+  - uid: 3370
     components:
     - type: Transform
       pos: -12.5,39.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 3374
+  - uid: 3371
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -25652,7 +25637,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 3375
+  - uid: 3372
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -25660,7 +25645,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 3376
+  - uid: 3373
     components:
     - type: Transform
       pos: -10.5,40.5
@@ -25669,7 +25654,7 @@ entities:
       fixtures: {}
 - proto: DecorFloorPaper2
   entities:
-  - uid: 3377
+  - uid: 3374
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -25677,7 +25662,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 3378
+  - uid: 3375
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -25687,31 +25672,31 @@ entities:
       fixtures: {}
 - proto: DisposalBend
   entities:
-  - uid: 3379
+  - uid: 3376
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-41.5
       parent: 1
-  - uid: 3380
+  - uid: 3377
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,28.5
       parent: 1
-  - uid: 3381
+  - uid: 3378
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-27.5
       parent: 1
-  - uid: 3382
+  - uid: 3379
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,15.5
       parent: 1
-  - uid: 3383
+  - uid: 3380
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -25719,730 +25704,730 @@ entities:
       parent: 1
 - proto: DisposalJunction
   entities:
-  - uid: 3384
+  - uid: 3381
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-37.5
       parent: 1
-  - uid: 3385
+  - uid: 3382
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-27.5
       parent: 1
-  - uid: 3386
+  - uid: 3383
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-27.5
       parent: 1
-  - uid: 3387
+  - uid: 3384
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-37.5
       parent: 1
-- proto: DisposalPipe
-  entities:
-  - uid: 3388
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,-47.5
-      parent: 1
-  - uid: 3389
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,-47.5
-      parent: 1
-  - uid: 3390
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,-47.5
-      parent: 1
-  - uid: 3391
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-47.5
-      parent: 1
-  - uid: 3392
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,-43.5
-      parent: 1
-  - uid: 3393
-    components:
-    - type: Transform
-      pos: -4.5,-42.5
-      parent: 1
-  - uid: 3394
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-51.5
-      parent: 1
-  - uid: 3395
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,1.5
-      parent: 1
-  - uid: 3396
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,1.5
-      parent: 1
-  - uid: 3397
+  - uid: 3385
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,1.5
       parent: 1
-  - uid: 3398
+- proto: DisposalPipe
+  entities:
+  - uid: 3386
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-47.5
+      parent: 1
+  - uid: 3387
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-47.5
+      parent: 1
+  - uid: 3388
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-47.5
+      parent: 1
+  - uid: 3389
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-47.5
+      parent: 1
+  - uid: 3390
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-43.5
+      parent: 1
+  - uid: 3391
+    components:
+    - type: Transform
+      pos: -4.5,-42.5
+      parent: 1
+  - uid: 3392
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-51.5
+      parent: 1
+  - uid: 3393
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 3394
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 3395
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 3399
+  - uid: 3396
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,28.5
       parent: 1
-  - uid: 3400
+  - uid: 3397
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,28.5
       parent: 1
-  - uid: 3401
+  - uid: 3398
     components:
     - type: Transform
       pos: -0.5,22.5
       parent: 1
-  - uid: 3402
+  - uid: 3399
     components:
     - type: Transform
       pos: -0.5,23.5
       parent: 1
-  - uid: 3403
+  - uid: 3400
     components:
     - type: Transform
       pos: -0.5,24.5
       parent: 1
-  - uid: 3404
+  - uid: 3401
     components:
     - type: Transform
       pos: -16.5,24.5
       parent: 1
-  - uid: 3405
+  - uid: 3402
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
-  - uid: 3406
+  - uid: 3403
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,8.5
       parent: 1
-  - uid: 3407
+  - uid: 3404
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,28.5
       parent: 1
-  - uid: 3408
+  - uid: 3405
     components:
     - type: Transform
       pos: 5.5,-41.5
       parent: 1
-  - uid: 3409
+  - uid: 3406
     components:
     - type: Transform
       pos: -16.5,23.5
       parent: 1
-  - uid: 3410
+  - uid: 3407
     components:
     - type: Transform
       pos: 11.5,-42.5
       parent: 1
-  - uid: 3411
+  - uid: 3408
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,9.5
       parent: 1
-  - uid: 3412
+  - uid: 3409
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,28.5
       parent: 1
-  - uid: 3413
+  - uid: 3410
     components:
     - type: Transform
       pos: -16.5,21.5
       parent: 1
-  - uid: 3414
+  - uid: 3411
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 1
-  - uid: 3415
+  - uid: 3412
     components:
     - type: Transform
       pos: 2.5,-42.5
       parent: 1
-  - uid: 3416
+  - uid: 3413
     components:
     - type: Transform
       pos: 5.5,-41.5
       parent: 1
-  - uid: 3417
+  - uid: 3414
     components:
     - type: Transform
       pos: -0.5,19.5
       parent: 1
-  - uid: 3418
+  - uid: 3415
     components:
     - type: Transform
       pos: -0.5,27.5
       parent: 1
-  - uid: 3419
+  - uid: 3416
     components:
     - type: Transform
       pos: -0.5,25.5
       parent: 1
-  - uid: 3420
+  - uid: 3417
     components:
     - type: Transform
       pos: -0.5,26.5
       parent: 1
-  - uid: 3421
+  - uid: 3418
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,28.5
       parent: 1
-  - uid: 3422
+  - uid: 3419
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,28.5
       parent: 1
-  - uid: 3423
+  - uid: 3420
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,28.5
       parent: 1
-  - uid: 3424
+  - uid: 3421
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,2.5
       parent: 1
-  - uid: 3425
+  - uid: 3422
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,6.5
       parent: 1
-  - uid: 3426
+  - uid: 3423
     components:
     - type: Transform
       pos: -0.5,20.5
       parent: 1
-  - uid: 3427
+  - uid: 3424
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,28.5
       parent: 1
-  - uid: 3428
+  - uid: 3425
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 3429
+  - uid: 3426
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 3430
+  - uid: 3427
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 3431
+  - uid: 3428
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 3432
+  - uid: 3429
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-  - uid: 3433
+  - uid: 3430
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
-  - uid: 3434
+  - uid: 3431
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 3435
+  - uid: 3432
     components:
     - type: Transform
       pos: -8.5,-5.5
       parent: 1
-  - uid: 3436
+  - uid: 3433
     components:
     - type: Transform
       pos: -8.5,-6.5
       parent: 1
-  - uid: 3437
+  - uid: 3434
     components:
     - type: Transform
       pos: -8.5,-7.5
       parent: 1
-  - uid: 3438
+  - uid: 3435
     components:
     - type: Transform
       pos: -8.5,-8.5
       parent: 1
-  - uid: 3439
+  - uid: 3436
     components:
     - type: Transform
       pos: -8.5,-9.5
       parent: 1
-  - uid: 3440
+  - uid: 3437
     components:
     - type: Transform
       pos: -8.5,-10.5
       parent: 1
-  - uid: 3441
+  - uid: 3438
     components:
     - type: Transform
       pos: -8.5,-11.5
       parent: 1
-  - uid: 3442
+  - uid: 3439
     components:
     - type: Transform
       pos: -8.5,-12.5
       parent: 1
-  - uid: 3443
+  - uid: 3440
     components:
     - type: Transform
       pos: -8.5,-13.5
       parent: 1
-  - uid: 3444
+  - uid: 3441
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-27.5
       parent: 1
-  - uid: 3445
+  - uid: 3442
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-27.5
       parent: 1
-  - uid: 3446
+  - uid: 3443
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-27.5
       parent: 1
-  - uid: 3447
+  - uid: 3444
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-27.5
       parent: 1
-  - uid: 3448
+  - uid: 3445
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-27.5
       parent: 1
-  - uid: 3449
+  - uid: 3446
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-27.5
       parent: 1
-  - uid: 3450
+  - uid: 3447
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-27.5
       parent: 1
-  - uid: 3451
+  - uid: 3448
     components:
     - type: Transform
       pos: -4.5,-28.5
       parent: 1
-  - uid: 3452
+  - uid: 3449
     components:
     - type: Transform
       pos: -4.5,-28.5
       parent: 1
-  - uid: 3453
+  - uid: 3450
     components:
     - type: Transform
       pos: -4.5,-29.5
       parent: 1
-  - uid: 3454
+  - uid: 3451
     components:
     - type: Transform
       pos: -4.5,-30.5
       parent: 1
-  - uid: 3455
+  - uid: 3452
     components:
     - type: Transform
       pos: -4.5,-31.5
       parent: 1
-  - uid: 3456
+  - uid: 3453
     components:
     - type: Transform
       pos: -4.5,-32.5
       parent: 1
-  - uid: 3457
+  - uid: 3454
     components:
     - type: Transform
       pos: -8.5,-32.5
       parent: 1
-  - uid: 3458
+  - uid: 3455
     components:
     - type: Transform
       pos: -8.5,-31.5
       parent: 1
-  - uid: 3459
+  - uid: 3456
     components:
     - type: Transform
       pos: -8.5,-30.5
       parent: 1
-  - uid: 3460
+  - uid: 3457
     components:
     - type: Transform
       pos: -8.5,-29.5
       parent: 1
-  - uid: 3461
+  - uid: 3458
     components:
     - type: Transform
       pos: -8.5,-28.5
       parent: 1
-  - uid: 3462
+  - uid: 3459
     components:
     - type: Transform
       pos: -12.5,-28.5
       parent: 1
-  - uid: 3463
+  - uid: 3460
     components:
     - type: Transform
       pos: -12.5,-29.5
       parent: 1
-  - uid: 3464
+  - uid: 3461
     components:
     - type: Transform
       pos: -12.5,-30.5
       parent: 1
-  - uid: 3465
+  - uid: 3462
     components:
     - type: Transform
       pos: -12.5,-31.5
       parent: 1
-  - uid: 3466
+  - uid: 3463
     components:
     - type: Transform
       pos: -12.5,-32.5
       parent: 1
-  - uid: 3467
+  - uid: 3464
     components:
     - type: Transform
       pos: 8.5,-42.5
       parent: 1
-  - uid: 3468
+  - uid: 3465
     components:
     - type: Transform
       pos: 2.5,-41.5
       parent: 1
-  - uid: 3469
+  - uid: 3466
     components:
     - type: Transform
       pos: 11.5,-42.5
       parent: 1
-  - uid: 3470
+  - uid: 3467
     components:
     - type: Transform
       pos: 8.5,-41.5
       parent: 1
-  - uid: 3471
+  - uid: 3468
     components:
     - type: Transform
       pos: 5.5,-42.5
       parent: 1
-  - uid: 3472
+  - uid: 3469
     components:
     - type: Transform
       pos: 11.5,-41.5
       parent: 1
-  - uid: 3473
+  - uid: 3470
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
-  - uid: 3474
+  - uid: 3471
     components:
     - type: Transform
       pos: -16.5,22.5
       parent: 1
-  - uid: 3475
+  - uid: 3472
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,7.5
       parent: 1
-  - uid: 3476
+  - uid: 3473
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,28.5
       parent: 1
-  - uid: 3477
+  - uid: 3474
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 1
-  - uid: 3478
+  - uid: 3475
     components:
     - type: Transform
       pos: -0.5,21.5
       parent: 1
-  - uid: 3479
+  - uid: 3476
     components:
     - type: Transform
       pos: -16.5,13.5
       parent: 1
-  - uid: 3480
+  - uid: 3477
     components:
     - type: Transform
       pos: -16.5,14.5
       parent: 1
-  - uid: 3481
+  - uid: 3478
     components:
     - type: Transform
       pos: -0.5,18.5
       parent: 1
-  - uid: 3482
+  - uid: 3479
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,28.5
       parent: 1
-  - uid: 3483
+  - uid: 3480
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 1
-  - uid: 3484
+  - uid: 3481
     components:
     - type: Transform
       pos: -0.5,15.5
       parent: 1
-  - uid: 3485
+  - uid: 3482
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 1
-  - uid: 3486
+  - uid: 3483
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,2.5
       parent: 1
-  - uid: 3487
+  - uid: 3484
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,28.5
       parent: 1
-  - uid: 3488
+  - uid: 3485
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,1.5
       parent: 1
-  - uid: 3489
+  - uid: 3486
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,1.5
       parent: 1
-  - uid: 3490
+  - uid: 3487
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,2.5
       parent: 1
-  - uid: 3491
+  - uid: 3488
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-37.5
       parent: 1
-  - uid: 3492
+  - uid: 3489
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-37.5
       parent: 1
-  - uid: 3493
+  - uid: 3490
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-37.5
       parent: 1
-  - uid: 3494
+  - uid: 3491
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-37.5
       parent: 1
-  - uid: 3495
+  - uid: 3492
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-51.5
       parent: 1
-  - uid: 3496
+  - uid: 3493
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-51.5
       parent: 1
-  - uid: 3497
+  - uid: 3494
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-51.5
       parent: 1
-  - uid: 3498
+  - uid: 3495
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,7.5
       parent: 1
-  - uid: 3499
+  - uid: 3496
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,7.5
       parent: 1
-  - uid: 3500
+  - uid: 3497
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,7.5
       parent: 1
-  - uid: 3501
+  - uid: 3498
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,7.5
       parent: 1
-  - uid: 3502
+  - uid: 3499
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-60.5
       parent: 1
-  - uid: 3503
+  - uid: 3500
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,4.5
       parent: 1
-  - uid: 3504
+  - uid: 3501
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,5.5
       parent: 1
-  - uid: 3505
+  - uid: 3502
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,7.5
       parent: 1
-  - uid: 3506
+  - uid: 3503
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,6.5
       parent: 1
-  - uid: 3507
+  - uid: 3504
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-61.5
       parent: 1
-  - uid: 3508
+  - uid: 3505
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-62.5
       parent: 1
-  - uid: 3509
+  - uid: 3506
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-63.5
       parent: 1
-  - uid: 3510
+  - uid: 3507
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-44.5
       parent: 1
-  - uid: 3511
+  - uid: 3508
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-43.5
       parent: 1
-  - uid: 3512
+  - uid: 3509
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-43.5
       parent: 1
-  - uid: 3513
+  - uid: 3510
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-45.5
       parent: 1
-  - uid: 3514
+  - uid: 3511
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-46.5
       parent: 1
-  - uid: 3515
+  - uid: 3512
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -26450,13 +26435,13 @@ entities:
       parent: 1
 - proto: DisposalRouterFlipped
   entities:
-  - uid: 3516
+  - uid: 3513
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,28.5
       parent: 1
-  - uid: 3517
+  - uid: 3514
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -26464,180 +26449,180 @@ entities:
       parent: 1
 - proto: DrinkBeerCan
   entities:
-  - uid: 3518
+  - uid: 3515
     components:
     - type: Transform
       pos: 6.6121044,-27.207598
       parent: 1
-  - uid: 3519
+  - uid: 3516
     components:
     - type: Transform
       pos: 6.341271,-27.218016
       parent: 1
-  - uid: 3520
+  - uid: 3517
     components:
     - type: Transform
       pos: 6.028771,-27.218016
       parent: 1
-  - uid: 3521
+  - uid: 3518
     components:
     - type: Transform
       pos: 6.0391874,-27.561766
       parent: 1
-  - uid: 3522
+  - uid: 3519
     components:
     - type: Transform
       pos: 6.278771,-27.561766
       parent: 1
-  - uid: 3523
+  - uid: 3520
     components:
     - type: Transform
       pos: 6.591271,-27.572182
       parent: 1
 - proto: DrinkBottleWhiskey
   entities:
-  - uid: 3524
+  - uid: 3521
     components:
     - type: Transform
       pos: 25.459276,3.903802
       parent: 1
 - proto: DrinkGlass
   entities:
-  - uid: 3525
+  - uid: 3522
     components:
     - type: Transform
       pos: -6.7725763,-30.32932
       parent: 1
-  - uid: 3526
+  - uid: 3523
     components:
     - type: Transform
       pos: -16.06838,46.64263
       parent: 1
-  - uid: 3527
+  - uid: 3524
     components:
     - type: Transform
       pos: -2.5538263,-32.329323
       parent: 1
-  - uid: 3528
+  - uid: 3525
     components:
     - type: Transform
       pos: -2.2413263,-31.376196
       parent: 1
-  - uid: 3529
+  - uid: 3526
     components:
     - type: Transform
       pos: -6.4600763,-31.126196
       parent: 1
-  - uid: 3530
+  - uid: 3527
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.696705,48.304783
       parent: 1
-  - uid: 3531
+  - uid: 3528
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.476553,48.286438
       parent: 1
-  - uid: 3532
+  - uid: 3529
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.256403,48.286438
       parent: 1
-  - uid: 3533
+  - uid: 3530
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.274748,48.726738
       parent: 1
-  - uid: 3534
+  - uid: 3531
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.476553,48.726738
       parent: 1
-  - uid: 3535
+  - uid: 3532
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.696705,48.726738
       parent: 1
-  - uid: 3536
+  - uid: 3533
     components:
     - type: Transform
       pos: -10.835076,-31.32932
       parent: 1
-  - uid: 3537
+  - uid: 3534
     components:
     - type: Transform
       pos: -10.256951,-32.688698
       parent: 1
-  - uid: 3538
+  - uid: 3535
     components:
     - type: Transform
       pos: -12.739072,46.396214
       parent: 1
-  - uid: 3539
+  - uid: 3536
     components:
     - type: Transform
       pos: -10.725701,-33.407448
       parent: 1
-  - uid: 3540
+  - uid: 3537
     components:
     - type: Transform
       pos: -6.6007013,-33.438698
       parent: 1
 - proto: DrinkGrapeCan
   entities:
-  - uid: 3541
+  - uid: 3538
     components:
     - type: Transform
       pos: 6.301942,-24.349457
       parent: 1
-  - uid: 3542
+  - uid: 3539
     components:
     - type: Transform
       pos: 6.5311084,-24.359873
       parent: 1
-  - uid: 3543
+  - uid: 3540
     components:
     - type: Transform
       pos: 6.791525,-24.37029
       parent: 1
-  - uid: 3544
+  - uid: 3541
     components:
     - type: Transform
       pos: 6.770692,-24.630707
       parent: 1
-  - uid: 3545
+  - uid: 3542
     components:
     - type: Transform
       pos: 6.572775,-24.630707
       parent: 1
-  - uid: 3546
+  - uid: 3543
     components:
     - type: Transform
       pos: 6.301942,-24.641123
       parent: 1
 - proto: DrinkWhiskeyGlass
   entities:
-  - uid: 3548
+  - uid: 3544
     components:
     - type: Transform
       pos: 26.681938,3.82862
       parent: 1
 - proto: dropshipdestshipmarker
   entities:
-  - uid: 3549
+  - uid: 3545
     components:
     - type: MetaData
       name: USS Bush Hangar Bay 2
     - type: Transform
       pos: 7.5,15.5
       parent: 1
-  - uid: 5472
+  - uid: 3546
     components:
     - type: MetaData
       name: USS Bush Hangar Bay 1
@@ -26646,281 +26631,276 @@ entities:
       parent: 1
 - proto: filingCabinet
   entities:
-  - uid: 3551
+  - uid: 3547
     components:
     - type: Transform
       pos: -2.1903598,-51.5
       parent: 1
-  - uid: 3552
+  - uid: 3548
     components:
     - type: Transform
       pos: -2.8141203,-51.5
       parent: 1
-  - uid: 3553
+  - uid: 3549
     components:
     - type: Transform
       pos: -2.483894,-51.5
       parent: 1
-  - uid: 3554
+  - uid: 3550
     components:
     - type: Transform
       pos: 1.7388451,-29.566553
       parent: 1
 - proto: filingCabinetRandom
   entities:
-  - uid: 3555
+  - uid: 3551
     components:
     - type: Transform
       pos: -0.6984911,59.5
       parent: 1
-  - uid: 3556
+  - uid: 3552
     components:
     - type: Transform
       pos: -0.3130746,59.5
       parent: 1
 - proto: FoodBakedGrilledCheeseSandwich
   entities:
-  - uid: 754
+  - uid: 745
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 755
+  - uid: 746
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 756
+  - uid: 747
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 757
+  - uid: 748
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 758
+  - uid: 749
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: FoodBurgerCheese
   entities:
-  - uid: 759
+  - uid: 750
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 760
+  - uid: 751
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 761
+  - uid: 752
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 762
+  - uid: 753
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 763
+  - uid: 754
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: FoodPlate
   entities:
-  - uid: 3557
+  - uid: 3553
     components:
     - type: Transform
       pos: -6.4444513,-32.719948
       parent: 1
-  - uid: 3558
+  - uid: 3554
     components:
     - type: Transform
       pos: -2.687333,-31.709373
       parent: 1
-  - uid: 3559
+  - uid: 3555
     components:
     - type: Transform
       pos: -10.631951,-31.719946
       parent: 1
 - proto: FoodSnackChips
   entities:
-  - uid: 3560
+  - uid: 3556
     components:
     - type: Transform
       pos: 5.301425,-24.688683
       parent: 1
-  - uid: 3561
+  - uid: 3557
     components:
     - type: Transform
       pos: 5.640609,-24.411957
       parent: 1
-  - uid: 3562
+  - uid: 3558
     components:
     - type: Transform
       pos: 5.3282347,-24.432842
       parent: 1
-  - uid: 3563
+  - uid: 3559
     components:
     - type: Transform
       pos: 5.647814,-24.675816
       parent: 1
+- proto: FoodSoupChiliHot
+  entities:
+  - uid: 3560
+    components:
+    - type: Transform
+      pos: 10.258638,-48.35646
+      parent: 1
 - proto: FoodSoupTomato
   entities:
-  - uid: 764
+  - uid: 755
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 765
+  - uid: 756
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 766
+  - uid: 757
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 767
+  - uid: 758
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 768
+  - uid: 759
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 769
+  - uid: 760
     components:
     - type: Transform
-      parent: 753
+      parent: 744
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: KnifePlastic
   entities:
-  - uid: 3564
+  - uid: 3561
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.43668,-31.681765
       parent: 1
-  - uid: 3565
+  - uid: 3562
     components:
     - type: Transform
       pos: -10.685181,-32.556763
       parent: 1
-- proto: MaintenanceJack
-  entities:
-  - uid: 529
-    components:
-    - type: Transform
-      pos: -10.454451,43.399567
-      parent: 1
-  - uid: 3368
-    components:
-    - type: Transform
-      pos: -10.579451,43.691235
-      parent: 1
-  - uid: 5643
-    components:
-    - type: Transform
-      pos: 11.387506,43.69677
-      parent: 1
-  - uid: 5644
-    components:
-    - type: Transform
-      pos: 11.595839,43.41899
-      parent: 1
 - proto: PosterLegitCleanliness
   entities:
-  - uid: 3566
+  - uid: 3563
     components:
     - type: Transform
       pos: -31.5,16.5
       parent: 1
-  - uid: 3567
+  - uid: 3564
     components:
     - type: Transform
       pos: -31.5,20.5
       parent: 1
-- proto: RMCAirlockEvacuationBlack
+- proto: ReagentContainerFlour
   entities:
+  - uid: 3565
+    components:
+    - type: Transform
+      pos: 11.184144,-48.268295
+      parent: 1
+  - uid: 3566
+    components:
+    - type: Transform
+      pos: 11.277894,-48.330795
+      parent: 1
+- proto: RMCAirlockHybrisaPersonal
+  entities:
+  - uid: 3567
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-22.5
+      parent: 1
   - uid: 3568
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 17.5,-22.5
+      rot: 3.141592653589793 rad
+      pos: -26.5,-0.5
       parent: 1
   - uid: 3569
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,-22.5
+      pos: 15.5,-57.5
       parent: 1
   - uid: 3570
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,-57.5
+      pos: -16.5,-57.5
       parent: 1
   - uid: 3571
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -16.5,-57.5
+      rot: 1.5707963267948966 rad
+      pos: -18.5,-22.5
       parent: 1
   - uid: 3572
     components:
     - type: Transform
-      pos: -26.5,-0.5
-      parent: 1
-  - uid: 3573
-    components:
-    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 25.5,-0.5
       parent: 1
-- proto: RMCAirlockHybrisaPersonal
-  entities:
-  - uid: 3574
+  - uid: 3573
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -26930,65 +26910,71 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -59055.156
+      secondsUntilStateChange: -59678.715
       state: Opening
-  - uid: 3575
+  - uid: 3574
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-10.5
       parent: 1
-  - uid: 3576
+  - uid: 3575
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-6.5
       parent: 1
-  - uid: 3577
+  - uid: 3576
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 1
-  - uid: 3578
+  - uid: 3577
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-48.5
       parent: 1
-  - uid: 3579
+  - uid: 3578
     components:
     - type: Transform
       pos: -16.5,49.5
       parent: 1
-  - uid: 3580
+  - uid: 3579
     components:
     - type: Transform
       pos: -11.5,49.5
       parent: 1
 - proto: RMCAshtray
   entities:
-  - uid: 3581
+  - uid: 3580
     components:
     - type: Transform
       pos: -3.394186,-3.5214117
       parent: 1
-  - uid: 3582
+  - uid: 3581
     components:
     - type: Transform
       pos: -2.5061302,-67.73013
       parent: 1
-  - uid: 3583
+  - uid: 3582
     components:
     - type: Transform
       pos: 25.907297,3.3547244
       parent: 1
 - proto: RMCBarrelBlue
   entities:
-  - uid: 3584
+  - uid: 3583
     components:
     - type: Transform
       pos: -11.5,41.5
+      parent: 1
+  - uid: 3584
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,40.5
       parent: 1
   - uid: 3585
     components:
@@ -26996,132 +26982,151 @@ entities:
       rot: 3.141592653589793 rad
       pos: 13.5,40.5
       parent: 1
-- proto: RMCBarricadeHandrail
+  - uid: 3586
+    components:
+    - type: Transform
+      pos: -5.5,37.5
+      parent: 1
+- proto: RMCBarrelGreen
   entities:
   - uid: 3587
+    components:
+    - type: Transform
+      pos: -7.5,41.5
+      parent: 1
+- proto: RMCBarrelYellow
+  entities:
+  - uid: 3588
+    components:
+    - type: Transform
+      pos: -8.5,38.5
+      parent: 1
+- proto: RMCBarricadeHandrail
+  entities:
+  - uid: 3589
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-4.5
       parent: 1
-  - uid: 3588
+  - uid: 3590
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-3.5
       parent: 1
-  - uid: 3589
+  - uid: 3591
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-5.5
       parent: 1
-  - uid: 3590
+  - uid: 3592
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-4.5
       parent: 1
-  - uid: 3591
+  - uid: 3593
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-5.5
       parent: 1
-  - uid: 3592
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,-6.5
-      parent: 1
-  - uid: 3593
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,-6.5
-      parent: 1
   - uid: 3594
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.5,-6.5
+      parent: 1
+  - uid: 3595
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.5,-6.5
+      parent: 1
+  - uid: 3596
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-3.5
       parent: 1
-  - uid: 3595
+  - uid: 3597
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-6.5
       parent: 1
-  - uid: 3596
+  - uid: 3598
     components:
     - type: Transform
       pos: -6.5,-58.5
       parent: 1
-  - uid: 3597
+  - uid: 3599
     components:
     - type: Transform
       pos: -5.5,-58.5
       parent: 1
-  - uid: 3598
-    components:
-    - type: Transform
-      pos: -4.5,-58.5
-      parent: 1
-  - uid: 3599
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-61.5
-      parent: 1
   - uid: 3600
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-62.5
+      pos: -4.5,-58.5
       parent: 1
   - uid: 3601
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,-63.5
+      pos: -1.5,-61.5
       parent: 1
   - uid: 3602
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-66.5
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-62.5
       parent: 1
   - uid: 3603
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-66.5
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-63.5
       parent: 1
   - uid: 3604
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -6.5,-66.5
+      pos: -4.5,-66.5
       parent: 1
   - uid: 3605
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,-63.5
+      rot: 3.141592653589793 rad
+      pos: -5.5,-66.5
       parent: 1
   - uid: 3606
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,-62.5
+      rot: 3.141592653589793 rad
+      pos: -6.5,-66.5
       parent: 1
   - uid: 3607
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -9.5,-61.5
+      pos: -9.5,-63.5
       parent: 1
   - uid: 3608
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-62.5
+      parent: 1
+  - uid: 3609
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-61.5
+      parent: 1
+  - uid: 3610
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27129,119 +27134,119 @@ entities:
       parent: 1
 - proto: RMCBarricadeHandrailAlt
   entities:
-  - uid: 3609
+  - uid: 3611
     components:
     - type: Transform
       pos: 7.5,-22.5
       parent: 1
-  - uid: 3610
+  - uid: 3612
     components:
     - type: Transform
       pos: 8.5,-22.5
       parent: 1
-  - uid: 3611
+  - uid: 3613
     components:
     - type: Transform
       pos: 7.5,-25.5
       parent: 1
-  - uid: 3612
+  - uid: 3614
     components:
     - type: Transform
       pos: 8.5,-25.5
       parent: 1
 - proto: RMCBarricadeHybrisa
   entities:
-  - uid: 3613
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-49.5
-      parent: 1
-  - uid: 3614
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-49.5
-      parent: 1
   - uid: 3615
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,-49.5
+      pos: 5.5,-49.5
       parent: 1
   - uid: 3616
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,-49.5
+      pos: 5.5,-49.5
       parent: 1
   - uid: 3617
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-49.5
+      parent: 1
+  - uid: 3618
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-49.5
+      parent: 1
+  - uid: 3619
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-49.5
       parent: 1
-  - uid: 3618
+  - uid: 3620
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-49.5
       parent: 1
-  - uid: 3619
+  - uid: 3621
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-49.5
       parent: 1
-  - uid: 3620
+  - uid: 3622
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-51.5
       parent: 1
-  - uid: 3621
+  - uid: 3623
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-51.5
       parent: 1
-  - uid: 3622
+  - uid: 3624
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-51.5
       parent: 1
-  - uid: 3623
+  - uid: 3625
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-51.5
       parent: 1
-  - uid: 3624
+  - uid: 3626
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-51.5
       parent: 1
-  - uid: 3625
+  - uid: 3627
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-49.5
       parent: 1
-  - uid: 3626
+  - uid: 3628
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-49.5
       parent: 1
-  - uid: 3627
+  - uid: 3629
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-49.5
       parent: 1
-  - uid: 3628
+  - uid: 3630
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27249,449 +27254,449 @@ entities:
       parent: 1
 - proto: RMCBarricadeWireRailAltDrawdepth
   entities:
-  - uid: 3629
+  - uid: 3631
     components:
     - type: Transform
       pos: 26.5,24.5
       parent: 1
-  - uid: 3630
+  - uid: 3632
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,16.5
       parent: 1
-  - uid: 3631
+  - uid: 3633
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,19.5
       parent: 1
-  - uid: 3632
+  - uid: 3634
     components:
     - type: Transform
       pos: -14.5,31.5
       parent: 1
-  - uid: 3633
+  - uid: 3635
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,28.5
       parent: 1
-  - uid: 3634
+  - uid: 3636
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,15.5
       parent: 1
-  - uid: 3635
+  - uid: 3637
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,28.5
       parent: 1
-  - uid: 3636
+  - uid: 3638
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,27.5
       parent: 1
-  - uid: 3637
+  - uid: 3639
     components:
     - type: Transform
       pos: 6.5,31.5
       parent: 1
-  - uid: 3638
+  - uid: 3640
     components:
     - type: Transform
       pos: 4.5,31.5
       parent: 1
-  - uid: 3639
+  - uid: 3641
     components:
     - type: Transform
       pos: 5.5,31.5
       parent: 1
-  - uid: 3640
+  - uid: 3642
     components:
     - type: Transform
       pos: 10.5,31.5
       parent: 1
-  - uid: 3641
+  - uid: 3643
     components:
     - type: Transform
       pos: 7.5,31.5
       parent: 1
-  - uid: 3642
+  - uid: 3644
     components:
     - type: Transform
       pos: 9.5,31.5
       parent: 1
-  - uid: 3643
+  - uid: 3645
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,25.5
       parent: 1
-  - uid: 3644
+  - uid: 3646
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,26.5
       parent: 1
-  - uid: 3645
-    components:
-    - type: Transform
-      pos: -17.5,29.5
-      parent: 1
-  - uid: 3646
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,17.5
-      parent: 1
   - uid: 3647
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,16.5
+      pos: -17.5,29.5
       parent: 1
   - uid: 3648
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 18.5,15.5
+      pos: 18.5,17.5
       parent: 1
   - uid: 3649
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 18.5,5.5
+      pos: 18.5,16.5
       parent: 1
   - uid: 3650
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 18.5,6.5
+      pos: 18.5,15.5
       parent: 1
   - uid: 3651
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 18.5,8.5
+      pos: 18.5,5.5
       parent: 1
   - uid: 3652
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 18.5,7.5
+      pos: 18.5,6.5
       parent: 1
   - uid: 3653
     components:
     - type: Transform
-      pos: 17.5,29.5
+      rot: -1.5707963267948966 rad
+      pos: 18.5,8.5
       parent: 1
   - uid: 3654
     components:
     - type: Transform
-      pos: 15.5,29.5
+      rot: -1.5707963267948966 rad
+      pos: 18.5,7.5
       parent: 1
   - uid: 3655
     components:
     - type: Transform
-      pos: 16.5,29.5
+      pos: 17.5,29.5
       parent: 1
   - uid: 3656
+    components:
+    - type: Transform
+      pos: 15.5,29.5
+      parent: 1
+  - uid: 3657
+    components:
+    - type: Transform
+      pos: 16.5,29.5
+      parent: 1
+  - uid: 3658
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,30.5
       parent: 1
-  - uid: 3657
+  - uid: 3659
     components:
     - type: Transform
       pos: 11.5,31.5
       parent: 1
-  - uid: 3658
+  - uid: 3660
     components:
     - type: Transform
       pos: 13.5,31.5
       parent: 1
-  - uid: 3659
+  - uid: 3661
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,18.5
       parent: 1
-  - uid: 3660
-    components:
-    - type: Transform
-      pos: -16.5,29.5
-      parent: 1
-  - uid: 3661
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,18.5
-      parent: 1
   - uid: 3662
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,16.5
+      pos: -16.5,29.5
       parent: 1
   - uid: 3663
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -19.5,5.5
+      pos: -19.5,18.5
       parent: 1
   - uid: 3664
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -19.5,8.5
+      pos: -19.5,16.5
       parent: 1
   - uid: 3665
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -19.5,6.5
+      pos: -19.5,5.5
       parent: 1
   - uid: 3666
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -19.5,7.5
+      pos: -19.5,8.5
       parent: 1
   - uid: 3667
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -19.5,25.5
+      pos: -19.5,6.5
       parent: 1
   - uid: 3668
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -19.5,26.5
+      pos: -19.5,7.5
       parent: 1
   - uid: 3669
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -19.5,17.5
+      pos: -19.5,25.5
       parent: 1
   - uid: 3670
     components:
     - type: Transform
-      pos: -18.5,29.5
+      rot: 1.5707963267948966 rad
+      pos: -19.5,26.5
       parent: 1
   - uid: 3671
     components:
     - type: Transform
-      pos: -6.5,31.5
+      rot: 1.5707963267948966 rad
+      pos: -19.5,17.5
       parent: 1
   - uid: 3672
+    components:
+    - type: Transform
+      pos: -18.5,29.5
+      parent: 1
+  - uid: 3673
+    components:
+    - type: Transform
+      pos: -6.5,31.5
+      parent: 1
+  - uid: 3674
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,30.5
       parent: 1
-  - uid: 3673
+  - uid: 3675
     components:
     - type: Transform
       pos: -10.5,31.5
       parent: 1
-  - uid: 3674
+  - uid: 3676
     components:
     - type: Transform
       pos: -12.5,31.5
       parent: 1
-  - uid: 3675
+  - uid: 3677
     components:
     - type: Transform
       pos: -11.5,31.5
       parent: 1
-  - uid: 3676
+  - uid: 3678
     components:
     - type: Transform
       pos: -5.5,31.5
       parent: 1
-  - uid: 3677
+  - uid: 3679
     components:
     - type: Transform
       pos: -7.5,31.5
       parent: 1
-  - uid: 3678
-    components:
-    - type: Transform
-      pos: -8.5,31.5
-      parent: 1
-  - uid: 3679
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,27.5
-      parent: 1
   - uid: 3680
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,22.5
+      pos: -8.5,31.5
       parent: 1
   - uid: 3681
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,21.5
+      pos: -19.5,27.5
       parent: 1
   - uid: 3682
     components:
     - type: Transform
-      pos: -25.5,18.5
+      rot: 1.5707963267948966 rad
+      pos: -22.5,22.5
       parent: 1
   - uid: 3683
     components:
     - type: Transform
-      pos: -26.5,18.5
+      rot: 1.5707963267948966 rad
+      pos: -22.5,21.5
       parent: 1
   - uid: 3684
     components:
     - type: Transform
-      pos: -27.5,18.5
+      pos: -25.5,18.5
       parent: 1
   - uid: 3685
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,17.5
+      pos: -26.5,18.5
       parent: 1
   - uid: 3686
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,21.5
+      pos: -27.5,18.5
       parent: 1
   - uid: 3687
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,18.5
+      pos: 21.5,17.5
       parent: 1
   - uid: 3688
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,20.5
+      pos: 21.5,21.5
       parent: 1
   - uid: 3689
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,22.5
+      pos: 21.5,18.5
       parent: 1
   - uid: 3690
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,20.5
+      parent: 1
+  - uid: 3691
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,22.5
+      parent: 1
+  - uid: 3692
     components:
     - type: Transform
       pos: 23.5,24.5
       parent: 1
 - proto: RMCBedBunkBlue
   entities:
-  - uid: 3691
+  - uid: 3693
     components:
     - type: Transform
       pos: -3.5,40.5
       parent: 1
-  - uid: 3692
+  - uid: 3694
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 3693
+  - uid: 3695
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-  - uid: 3694
+  - uid: 3696
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
-  - uid: 3695
+  - uid: 3697
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 3696
+  - uid: 3698
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 1
-  - uid: 3697
+  - uid: 3699
     components:
     - type: Transform
       pos: -5.5,-9.5
       parent: 1
-  - uid: 3698
+  - uid: 3700
     components:
     - type: Transform
       pos: -3.5,38.5
       parent: 1
 - proto: RMCBedBunkRed
   entities:
-  - uid: 3699
+  - uid: 3701
     components:
     - type: Transform
       pos: 4.5,-42.5
       parent: 1
-  - uid: 3700
+  - uid: 3702
     components:
     - type: Transform
       pos: 1.5,-42.5
       parent: 1
-  - uid: 3701
+  - uid: 3703
     components:
     - type: Transform
       pos: 10.5,-42.5
       parent: 1
-  - uid: 3702
+  - uid: 3704
     components:
     - type: Transform
       pos: 7.5,-42.5
       parent: 1
 - proto: RMCBlackSensorComputer
   entities:
-  - uid: 3703
+  - uid: 3705
     components:
     - type: Transform
       pos: 0.5,70.5
       parent: 1
 - proto: RMCBlackSensorComputer3
   entities:
-  - uid: 3704
+  - uid: 3706
     components:
     - type: Transform
       pos: -3.5,70.5
       parent: 1
 - proto: RMCBookcase
   entities:
-  - uid: 3705
+  - uid: 3707
     components:
     - type: Transform
       pos: 12.5,48.5
       parent: 1
     - type: Storage
       storedItems:
+        3711:
+          position: 6,0
+          _rotation: South
         3709:
           position: 0,0
           _rotation: South
-        3707:
+        3710:
           position: 2,0
           _rotation: South
         3708:
           position: 4,0
-          _rotation: South
-        3706:
-          position: 6,0
           _rotation: South
     - type: ContainerContainer
       containers:
@@ -27700,32 +27705,32 @@ entities:
           occludes: True
           ents:
           - 3709
-          - 3707
+          - 3710
           - 3708
-          - 3706
-  - uid: 3710
+          - 3711
+  - uid: 3712
     components:
     - type: Transform
       pos: -5.5,58.5
       parent: 1
     - type: Storage
       storedItems:
-        3711:
+        3713:
           position: 2,0
           _rotation: South
-        3714:
+        3716:
           position: 0,0
           _rotation: South
-        3715:
+        3717:
           position: 4,0
           _rotation: South
-        3712:
+        3714:
           position: 6,0
           _rotation: South
-        3716:
+        3718:
           position: 8,0
           _rotation: South
-        3713:
+        3715:
           position: 10,0
           _rotation: South
     - type: ContainerContainer
@@ -27734,888 +27739,878 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 3714
-          - 3711
-          - 3715
-          - 3712
           - 3716
           - 3713
+          - 3717
+          - 3714
+          - 3718
+          - 3715
 - proto: RMCBoxBodyBag
   entities:
-  - uid: 3717
+  - uid: 3719
     components:
     - type: Transform
       pos: -14.488371,30.70294
       parent: 1
-  - uid: 3718
+  - uid: 3720
     components:
     - type: Transform
       pos: -31.342436,10.47432
       parent: 1
 - proto: RMCBoxDonut
   entities:
-  - uid: 3719
+  - uid: 3721
     components:
     - type: Transform
-      pos: 10.162235,-27.280321
+      pos: 10.228921,-27.27248
       parent: 1
-  - uid: 3720
+  - uid: 3722
     components:
     - type: Transform
       pos: 9.412235,-27.269903
       parent: 1
 - proto: RMCBoxHandcuffs
   entities:
-  - uid: 3721
+  - uid: 3723
     components:
     - type: Transform
       pos: 6.5120564,-32.44819
       parent: 1
-  - uid: 3722
+  - uid: 3724
     components:
     - type: Transform
       pos: 6.625852,-32.307564
       parent: 1
-  - uid: 3723
+  - uid: 3725
     components:
     - type: Transform
       pos: 6.420615,-32.21192
       parent: 1
 - proto: RMCBoxMRE
   entities:
-  - uid: 3724
+  - uid: 3726
     components:
     - type: Transform
       pos: 11.508452,-24.605438
       parent: 1
-  - uid: 3725
+  - uid: 3727
     components:
     - type: Transform
       pos: 11.508452,-24.209604
       parent: 1
 - proto: RMCBoxPizzaGalaxyMargherita
   entities:
-  - uid: 3726
+  - uid: 3728
     components:
     - type: Transform
       pos: -6.3819513,-32.110573
       parent: 1
 - proto: RMCBoxPizzaGalaxyMeat
   entities:
-  - uid: 3727
+  - uid: 3729
     components:
     - type: Transform
       pos: -2.6475763,-30.594946
       parent: 1
 - proto: RMCBoxPizzaGalaxyMushroom
   entities:
-  - uid: 3728
+  - uid: 3730
     components:
     - type: Transform
       pos: -2.4913263,-33.079323
       parent: 1
 - proto: RMCBoxPizzaGalaxyVegetable
   entities:
-  - uid: 3729
+  - uid: 3731
     components:
     - type: Transform
       pos: -10.491326,-30.407446
       parent: 1
 - proto: RMCBucketJanitorial
   entities:
-  - uid: 749
+  - uid: 740
     components:
     - type: Transform
-      parent: 747
+      parent: 738
     - type: Physics
       canCollide: False
-  - uid: 751
+  - uid: 742
     components:
     - type: Transform
-      parent: 750
+      parent: 741
     - type: Physics
       canCollide: False
 - proto: RMCCableHeavy
   entities:
-  - uid: 3730
+  - uid: 3732
     components:
     - type: Transform
       pos: -5.5,-41.5
       parent: 1
-  - uid: 3731
+  - uid: 3733
     components:
     - type: Transform
       pos: -4.5,-39.5
       parent: 1
-  - uid: 3732
+  - uid: 3734
     components:
     - type: Transform
       pos: -4.5,-41.5
       parent: 1
-  - uid: 3733
+  - uid: 3735
     components:
     - type: Transform
       pos: -4.5,-40.5
       parent: 1
-  - uid: 3734
+  - uid: 3736
     components:
     - type: Transform
       pos: -4.5,-49.5
       parent: 1
-  - uid: 3735
+  - uid: 3737
     components:
     - type: Transform
       pos: -4.5,-51.5
       parent: 1
-  - uid: 3736
+  - uid: 3738
     components:
     - type: Transform
       pos: -4.5,-50.5
       parent: 1
-  - uid: 3737
+  - uid: 3739
     components:
     - type: Transform
       pos: -4.5,-48.5
       parent: 1
-  - uid: 3738
+  - uid: 3740
     components:
     - type: Transform
       pos: -4.5,-46.5
       parent: 1
-  - uid: 3739
+  - uid: 3741
     components:
     - type: Transform
       pos: -27.5,1.5
       parent: 1
-  - uid: 3740
+  - uid: 3742
     components:
     - type: Transform
       pos: 9.5,-6.5
       parent: 1
-  - uid: 3741
+  - uid: 3743
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 3742
+  - uid: 3744
     components:
     - type: Transform
       pos: 2.5,-13.5
       parent: 1
-  - uid: 3743
+  - uid: 3745
     components:
     - type: Transform
       pos: 5.5,-13.5
       parent: 1
-  - uid: 3744
+  - uid: 3746
     components:
     - type: Transform
       pos: 15.5,-13.5
       parent: 1
-  - uid: 3745
+  - uid: 3747
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 3746
+  - uid: 3748
     components:
     - type: Transform
       pos: 4.5,-13.5
       parent: 1
-  - uid: 3747
+  - uid: 3749
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 1
-  - uid: 3748
+  - uid: 3750
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 3749
+  - uid: 3751
     components:
     - type: Transform
       pos: 15.5,13.5
       parent: 1
-  - uid: 3750
+  - uid: 3752
     components:
     - type: Transform
       pos: 15.5,14.5
       parent: 1
-  - uid: 3751
+  - uid: 3753
     components:
     - type: Transform
       pos: 15.5,10.5
       parent: 1
-  - uid: 3752
+  - uid: 3754
     components:
     - type: Transform
       pos: 15.5,22.5
       parent: 1
-  - uid: 3753
+  - uid: 3755
     components:
     - type: Transform
       pos: 15.5,23.5
       parent: 1
-  - uid: 3754
+  - uid: 3756
     components:
     - type: Transform
       pos: 15.5,24.5
       parent: 1
-  - uid: 3755
+  - uid: 3757
     components:
     - type: Transform
       pos: 15.5,25.5
       parent: 1
-  - uid: 3756
+  - uid: 3758
     components:
     - type: Transform
       pos: 15.5,26.5
       parent: 1
-  - uid: 3757
+  - uid: 3759
     components:
     - type: Transform
       pos: 15.5,16.5
       parent: 1
-  - uid: 3758
+  - uid: 3760
     components:
     - type: Transform
       pos: 15.5,17.5
       parent: 1
-  - uid: 3759
+  - uid: 3761
     components:
     - type: Transform
       pos: 15.5,18.5
       parent: 1
-  - uid: 3760
+  - uid: 3762
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 1
-  - uid: 3761
+  - uid: 3763
     components:
     - type: Transform
       pos: 15.5,8.5
       parent: 1
-  - uid: 3762
+  - uid: 3764
     components:
     - type: Transform
       pos: 15.5,9.5
       parent: 1
-  - uid: 3763
+  - uid: 3765
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 3764
+  - uid: 3766
     components:
     - type: Transform
       pos: 10.5,2.5
       parent: 1
-  - uid: 3765
+  - uid: 3767
     components:
     - type: Transform
       pos: 0.5,15.5
       parent: 1
-  - uid: 3766
+  - uid: 3768
     components:
     - type: Transform
       pos: -11.5,38.5
       parent: 1
-  - uid: 3767
+  - uid: 3769
     components:
     - type: Transform
       pos: -11.5,39.5
       parent: 1
-  - uid: 3768
+  - uid: 3770
     components:
     - type: Transform
       pos: -11.5,41.5
       parent: 1
-  - uid: 3769
+  - uid: 3771
     components:
     - type: Transform
       pos: -11.5,40.5
       parent: 1
-  - uid: 3770
+  - uid: 3772
     components:
     - type: Transform
       pos: 13.5,-15.5
       parent: 1
-  - uid: 3771
+  - uid: 3773
     components:
     - type: Transform
       pos: 14.5,-15.5
       parent: 1
-  - uid: 3772
+  - uid: 3774
     components:
     - type: Transform
       pos: -14.5,-3.5
       parent: 1
-  - uid: 3773
+  - uid: 3775
     components:
     - type: Transform
       pos: -14.5,-4.5
       parent: 1
-  - uid: 3774
+  - uid: 3776
     components:
     - type: Transform
       pos: -14.5,-5.5
       parent: 1
-  - uid: 3775
+  - uid: 3777
     components:
     - type: Transform
       pos: -14.5,-6.5
       parent: 1
-  - uid: 3776
+  - uid: 3778
     components:
     - type: Transform
       pos: -12.5,-8.5
       parent: 1
-  - uid: 3777
+  - uid: 3779
     components:
     - type: Transform
       pos: -12.5,-7.5
       parent: 1
-  - uid: 3778
+  - uid: 3780
     components:
     - type: Transform
       pos: -12.5,-6.5
       parent: 1
-  - uid: 3779
+  - uid: 3781
     components:
     - type: Transform
       pos: -12.5,-5.5
       parent: 1
-  - uid: 3780
-    components:
-    - type: Transform
-      pos: -12.5,-4.5
-      parent: 1
-  - uid: 3781
-    components:
-    - type: Transform
-      pos: -12.5,-4.5
-      parent: 1
   - uid: 3782
     components:
     - type: Transform
-      pos: -12.5,-3.5
+      pos: -12.5,-4.5
       parent: 1
   - uid: 3783
     components:
     - type: Transform
-      pos: -12.5,-2.5
+      pos: -12.5,-4.5
       parent: 1
   - uid: 3784
     components:
     - type: Transform
-      pos: -12.5,-1.5
+      pos: -12.5,-3.5
       parent: 1
   - uid: 3785
     components:
     - type: Transform
-      pos: -11.5,-8.5
+      pos: -12.5,-2.5
       parent: 1
   - uid: 3786
     components:
     - type: Transform
-      pos: -16.5,-8.5
+      pos: -12.5,-1.5
       parent: 1
   - uid: 3787
     components:
     - type: Transform
-      pos: -16.5,-7.5
+      pos: -11.5,-8.5
       parent: 1
   - uid: 3788
     components:
     - type: Transform
-      pos: -16.5,-6.5
+      pos: -16.5,-8.5
       parent: 1
   - uid: 3789
     components:
     - type: Transform
-      pos: -16.5,-5.5
+      pos: -16.5,-7.5
       parent: 1
   - uid: 3790
     components:
     - type: Transform
-      pos: -16.5,-5.5
+      pos: -16.5,-6.5
       parent: 1
   - uid: 3791
     components:
     - type: Transform
-      pos: -16.5,-4.5
+      pos: -16.5,-5.5
       parent: 1
   - uid: 3792
     components:
     - type: Transform
-      pos: -16.5,-3.5
+      pos: -16.5,-5.5
       parent: 1
   - uid: 3793
     components:
     - type: Transform
-      pos: -16.5,-3.5
+      pos: -16.5,-4.5
       parent: 1
   - uid: 3794
     components:
     - type: Transform
-      pos: -16.5,-2.5
+      pos: -16.5,-3.5
       parent: 1
   - uid: 3795
     components:
     - type: Transform
-      pos: -16.5,-2.5
+      pos: -16.5,-3.5
       parent: 1
   - uid: 3796
     components:
     - type: Transform
-      pos: -17.5,-2.5
+      pos: -16.5,-2.5
       parent: 1
   - uid: 3797
     components:
     - type: Transform
-      pos: -16.5,-1.5
+      pos: -16.5,-2.5
       parent: 1
   - uid: 3798
     components:
     - type: Transform
-      pos: -12.5,-9.5
+      pos: -17.5,-2.5
       parent: 1
   - uid: 3799
     components:
     - type: Transform
-      pos: 7.5,-12.5
+      pos: -16.5,-1.5
       parent: 1
   - uid: 3800
     components:
     - type: Transform
-      pos: -12.5,-32.5
+      pos: -12.5,-9.5
       parent: 1
   - uid: 3801
     components:
     - type: Transform
-      pos: -12.5,-31.5
+      pos: 7.5,-12.5
       parent: 1
   - uid: 3802
     components:
     - type: Transform
-      pos: -12.5,-30.5
+      pos: -12.5,-32.5
       parent: 1
   - uid: 3803
     components:
     - type: Transform
-      pos: -12.5,-29.5
+      pos: -12.5,-31.5
       parent: 1
   - uid: 3804
     components:
     - type: Transform
-      pos: -12.5,-28.5
+      pos: -12.5,-30.5
       parent: 1
   - uid: 3805
     components:
     - type: Transform
-      pos: -12.5,-27.5
+      pos: -12.5,-29.5
       parent: 1
   - uid: 3806
     components:
     - type: Transform
-      pos: -12.5,-27.5
+      pos: -12.5,-28.5
       parent: 1
   - uid: 3807
     components:
     - type: Transform
-      pos: -11.5,-27.5
+      pos: -12.5,-27.5
       parent: 1
   - uid: 3808
     components:
     - type: Transform
-      pos: -10.5,-27.5
+      pos: -12.5,-27.5
       parent: 1
   - uid: 3809
     components:
     - type: Transform
-      pos: -9.5,-27.5
+      pos: -11.5,-27.5
       parent: 1
   - uid: 3810
     components:
     - type: Transform
-      pos: -8.5,-27.5
+      pos: -10.5,-27.5
       parent: 1
   - uid: 3811
     components:
     - type: Transform
-      pos: -7.5,-27.5
+      pos: -9.5,-27.5
       parent: 1
   - uid: 3812
     components:
     - type: Transform
-      pos: -6.5,-27.5
+      pos: -8.5,-27.5
       parent: 1
   - uid: 3813
     components:
     - type: Transform
-      pos: -5.5,-27.5
+      pos: -7.5,-27.5
       parent: 1
   - uid: 3814
     components:
     - type: Transform
-      pos: -4.5,-27.5
+      pos: -6.5,-27.5
       parent: 1
   - uid: 3815
     components:
     - type: Transform
-      pos: -3.5,-27.5
+      pos: -5.5,-27.5
       parent: 1
   - uid: 3816
     components:
     - type: Transform
-      pos: -12.5,-33.5
+      pos: -4.5,-27.5
       parent: 1
   - uid: 3817
     components:
     - type: Transform
-      pos: -8.5,-33.5
+      pos: -3.5,-27.5
       parent: 1
   - uid: 3818
     components:
     - type: Transform
-      pos: -8.5,-32.5
+      pos: -12.5,-33.5
       parent: 1
   - uid: 3819
     components:
     - type: Transform
-      pos: -8.5,-31.5
+      pos: -8.5,-33.5
       parent: 1
   - uid: 3820
     components:
     - type: Transform
-      pos: -8.5,-30.5
+      pos: -8.5,-32.5
       parent: 1
   - uid: 3821
     components:
     - type: Transform
-      pos: -8.5,-29.5
+      pos: -8.5,-31.5
       parent: 1
   - uid: 3822
     components:
     - type: Transform
-      pos: -8.5,-28.5
+      pos: -8.5,-30.5
       parent: 1
   - uid: 3823
     components:
     - type: Transform
-      pos: -8.5,-27.5
+      pos: -8.5,-29.5
       parent: 1
   - uid: 3824
     components:
     - type: Transform
-      pos: -4.5,-33.5
+      pos: -8.5,-28.5
       parent: 1
   - uid: 3825
     components:
     - type: Transform
-      pos: -4.5,-32.5
+      pos: -8.5,-27.5
       parent: 1
   - uid: 3826
     components:
     - type: Transform
-      pos: -4.5,-31.5
+      pos: -4.5,-33.5
       parent: 1
   - uid: 3827
     components:
     - type: Transform
-      pos: -4.5,-30.5
+      pos: -4.5,-32.5
       parent: 1
   - uid: 3828
     components:
     - type: Transform
-      pos: -4.5,-29.5
+      pos: -4.5,-31.5
       parent: 1
   - uid: 3829
     components:
     - type: Transform
-      pos: -4.5,-28.5
+      pos: -4.5,-30.5
       parent: 1
   - uid: 3830
     components:
     - type: Transform
-      pos: -4.5,-27.5
+      pos: -4.5,-29.5
       parent: 1
   - uid: 3831
     components:
     - type: Transform
-      pos: -3.5,-27.5
+      pos: -4.5,-28.5
       parent: 1
   - uid: 3832
     components:
     - type: Transform
-      pos: -2.5,-27.5
+      pos: -4.5,-27.5
       parent: 1
   - uid: 3833
     components:
     - type: Transform
-      pos: 15.5,-15.5
+      pos: -3.5,-27.5
       parent: 1
   - uid: 3834
     components:
     - type: Transform
-      pos: 15.5,-15.5
+      pos: -2.5,-27.5
       parent: 1
   - uid: 3835
     components:
     - type: Transform
-      pos: 16.5,-15.5
+      pos: 15.5,-15.5
       parent: 1
   - uid: 3836
     components:
     - type: Transform
-      pos: -1.5,-13.5
+      pos: 15.5,-15.5
       parent: 1
   - uid: 3837
     components:
     - type: Transform
-      pos: -0.5,-0.5
+      pos: 16.5,-15.5
       parent: 1
   - uid: 3838
     components:
     - type: Transform
-      pos: -11.5,36.5
+      pos: -1.5,-13.5
       parent: 1
   - uid: 3839
     components:
     - type: Transform
-      pos: 9.5,2.5
+      pos: -0.5,-0.5
       parent: 1
   - uid: 3840
     components:
     - type: Transform
-      pos: 11.5,2.5
+      pos: -11.5,36.5
       parent: 1
   - uid: 3841
     components:
     - type: Transform
-      pos: 3.5,1.5
+      pos: 9.5,2.5
       parent: 1
   - uid: 3842
     components:
     - type: Transform
-      pos: 12.5,2.5
+      pos: 11.5,2.5
       parent: 1
   - uid: 3843
     components:
     - type: Transform
-      pos: -5.5,51.5
+      pos: 3.5,1.5
       parent: 1
   - uid: 3844
     components:
     - type: Transform
-      pos: -5.5,51.5
+      pos: 12.5,2.5
       parent: 1
   - uid: 3845
     components:
     - type: Transform
-      pos: -2.5,51.5
+      pos: -5.5,51.5
       parent: 1
   - uid: 3846
     components:
     - type: Transform
-      pos: -2.5,52.5
+      pos: -5.5,51.5
       parent: 1
   - uid: 3847
     components:
     - type: Transform
-      pos: -1.5,52.5
+      pos: -2.5,51.5
       parent: 1
   - uid: 3848
     components:
     - type: Transform
-      pos: -0.5,52.5
+      pos: -2.5,52.5
       parent: 1
   - uid: 3849
     components:
     - type: Transform
-      pos: -0.5,51.5
+      pos: -1.5,52.5
       parent: 1
   - uid: 3850
     components:
     - type: Transform
-      pos: -0.5,50.5
+      pos: -0.5,52.5
       parent: 1
   - uid: 3851
     components:
     - type: Transform
-      pos: -0.5,50.5
+      pos: -0.5,51.5
       parent: 1
   - uid: 3852
     components:
     - type: Transform
-      pos: -1.5,50.5
+      pos: -0.5,50.5
       parent: 1
   - uid: 3853
     components:
     - type: Transform
-      pos: -2.5,50.5
+      pos: -0.5,50.5
       parent: 1
   - uid: 3854
     components:
     - type: Transform
-      pos: -2.5,49.5
+      pos: -1.5,50.5
       parent: 1
   - uid: 3855
     components:
     - type: Transform
-      pos: -3.5,50.5
+      pos: -2.5,50.5
       parent: 1
   - uid: 3856
     components:
     - type: Transform
-      pos: -0.5,49.5
+      pos: -2.5,49.5
       parent: 1
   - uid: 3857
     components:
     - type: Transform
-      pos: 0.5,50.5
+      pos: -3.5,50.5
       parent: 1
   - uid: 3858
     components:
     - type: Transform
-      pos: 0.5,52.5
+      pos: -0.5,49.5
       parent: 1
   - uid: 3859
     components:
     - type: Transform
-      pos: -0.5,53.5
+      pos: 0.5,50.5
       parent: 1
   - uid: 3860
     components:
     - type: Transform
-      pos: -2.5,53.5
+      pos: 0.5,52.5
       parent: 1
   - uid: 3861
     components:
     - type: Transform
-      pos: -3.5,52.5
+      pos: -0.5,53.5
       parent: 1
   - uid: 3862
     components:
     - type: Transform
-      pos: -3.5,55.5
+      pos: -2.5,53.5
       parent: 1
   - uid: 3863
     components:
     - type: Transform
-      pos: -3.5,56.5
+      pos: -3.5,52.5
       parent: 1
   - uid: 3864
     components:
     - type: Transform
-      pos: -3.5,57.5
+      pos: -3.5,55.5
       parent: 1
   - uid: 3865
     components:
     - type: Transform
-      pos: -3.5,58.5
+      pos: -3.5,56.5
       parent: 1
   - uid: 3866
     components:
     - type: Transform
-      pos: -3.5,59.5
+      pos: -3.5,57.5
       parent: 1
   - uid: 3867
     components:
     - type: Transform
-      pos: -3.5,60.5
+      pos: -3.5,58.5
       parent: 1
   - uid: 3868
     components:
     - type: Transform
-      pos: -3.5,61.5
+      pos: -3.5,59.5
       parent: 1
   - uid: 3869
     components:
     - type: Transform
-      pos: -3.5,62.5
+      pos: -3.5,60.5
       parent: 1
   - uid: 3870
     components:
     - type: Transform
-      pos: -3.5,63.5
+      pos: -3.5,61.5
       parent: 1
   - uid: 3871
     components:
     - type: Transform
-      pos: 0.5,55.5
+      pos: -3.5,62.5
       parent: 1
   - uid: 3872
     components:
     - type: Transform
-      pos: 0.5,56.5
+      pos: -3.5,63.5
       parent: 1
   - uid: 3873
     components:
     - type: Transform
-      pos: 0.5,57.5
+      pos: 0.5,55.5
       parent: 1
   - uid: 3874
     components:
     - type: Transform
-      pos: 0.5,58.5
+      pos: 0.5,56.5
       parent: 1
   - uid: 3875
     components:
     - type: Transform
-      pos: 0.5,59.5
+      pos: 0.5,57.5
       parent: 1
   - uid: 3876
     components:
     - type: Transform
-      pos: 0.5,60.5
+      pos: 0.5,58.5
       parent: 1
   - uid: 3877
     components:
     - type: Transform
-      pos: 0.5,61.5
+      pos: 0.5,59.5
       parent: 1
   - uid: 3878
     components:
     - type: Transform
-      pos: 0.5,62.5
+      pos: 0.5,60.5
       parent: 1
   - uid: 3879
     components:
     - type: Transform
-      pos: 0.5,63.5
+      pos: 0.5,61.5
       parent: 1
   - uid: 3880
     components:
     - type: Transform
-      pos: -3.5,55.5
+      pos: 0.5,62.5
       parent: 1
   - uid: 3881
     components:
     - type: Transform
-      pos: 0.5,55.5
+      pos: 0.5,63.5
       parent: 1
   - uid: 3882
     components:
     - type: Transform
-      pos: -0.5,55.5
+      pos: -3.5,55.5
       parent: 1
   - uid: 3883
     components:
     - type: Transform
-      pos: -1.5,55.5
+      pos: 0.5,55.5
       parent: 1
   - uid: 3884
     components:
     - type: Transform
-      pos: -2.5,55.5
+      pos: -0.5,55.5
       parent: 1
   - uid: 3885
     components:
     - type: Transform
-      pos: -3.5,55.5
+      pos: -1.5,55.5
       parent: 1
   - uid: 3886
     components:
@@ -28625,883 +28620,893 @@ entities:
   - uid: 3887
     components:
     - type: Transform
-      pos: -2.5,54.5
+      pos: -3.5,55.5
       parent: 1
   - uid: 3888
     components:
     - type: Transform
-      pos: -2.5,53.5
+      pos: -2.5,55.5
       parent: 1
   - uid: 3889
     components:
     - type: Transform
-      pos: -3.5,64.5
+      pos: -2.5,54.5
       parent: 1
   - uid: 3890
     components:
     - type: Transform
-      pos: -3.5,65.5
+      pos: -2.5,53.5
       parent: 1
   - uid: 3891
     components:
     - type: Transform
-      pos: -3.5,66.5
+      pos: -3.5,64.5
       parent: 1
   - uid: 3892
     components:
     - type: Transform
-      pos: -3.5,67.5
+      pos: -3.5,65.5
       parent: 1
   - uid: 3893
     components:
     - type: Transform
-      pos: -3.5,67.5
+      pos: -3.5,66.5
       parent: 1
   - uid: 3894
     components:
     - type: Transform
-      pos: -2.5,67.5
+      pos: -3.5,67.5
       parent: 1
   - uid: 3895
     components:
     - type: Transform
-      pos: -0.5,67.5
+      pos: -3.5,67.5
       parent: 1
   - uid: 3896
     components:
     - type: Transform
-      pos: 0.5,67.5
+      pos: -2.5,67.5
       parent: 1
   - uid: 3897
     components:
     - type: Transform
-      pos: 0.5,67.5
+      pos: -0.5,67.5
       parent: 1
   - uid: 3898
     components:
     - type: Transform
-      pos: 0.5,66.5
+      pos: 0.5,67.5
       parent: 1
   - uid: 3899
     components:
     - type: Transform
-      pos: 0.5,65.5
+      pos: 0.5,67.5
       parent: 1
   - uid: 3900
     components:
     - type: Transform
-      pos: 0.5,64.5
+      pos: 0.5,66.5
       parent: 1
   - uid: 3901
     components:
     - type: Transform
-      pos: 0.5,63.5
+      pos: 0.5,65.5
       parent: 1
   - uid: 3902
     components:
     - type: Transform
-      pos: -0.5,68.5
+      pos: 0.5,64.5
       parent: 1
   - uid: 3903
     components:
     - type: Transform
-      pos: -1.5,68.5
+      pos: 0.5,63.5
       parent: 1
   - uid: 3904
     components:
     - type: Transform
-      pos: -2.5,68.5
+      pos: -0.5,68.5
       parent: 1
   - uid: 3905
     components:
     - type: Transform
-      pos: 0.5,50.5
+      pos: -1.5,68.5
       parent: 1
   - uid: 3906
     components:
     - type: Transform
-      pos: 1.5,50.5
+      pos: -2.5,68.5
       parent: 1
   - uid: 3907
     components:
     - type: Transform
-      pos: 1.5,52.5
+      pos: 0.5,50.5
       parent: 1
   - uid: 3908
     components:
     - type: Transform
-      pos: 0.5,52.5
+      pos: 1.5,50.5
       parent: 1
   - uid: 3909
     components:
     - type: Transform
-      pos: 6.5,45.5
+      pos: 1.5,52.5
       parent: 1
   - uid: 3910
     components:
     - type: Transform
-      pos: 11.5,-6.5
+      pos: 0.5,52.5
       parent: 1
   - uid: 3911
     components:
     - type: Transform
-      pos: 7.5,-6.5
+      pos: 6.5,45.5
       parent: 1
   - uid: 3912
     components:
     - type: Transform
-      pos: 7.5,2.5
+      pos: 11.5,-6.5
       parent: 1
   - uid: 3913
     components:
     - type: Transform
-      pos: 15.5,7.5
+      pos: 7.5,-6.5
       parent: 1
   - uid: 3914
     components:
     - type: Transform
-      pos: 6.5,2.5
+      pos: 7.5,2.5
       parent: 1
   - uid: 3915
     components:
     - type: Transform
-      pos: 6.5,1.5
+      pos: 15.5,7.5
       parent: 1
   - uid: 3916
     components:
     - type: Transform
-      pos: 15.5,10.5
+      pos: 6.5,2.5
       parent: 1
   - uid: 3917
     components:
     - type: Transform
-      pos: -11.5,37.5
+      pos: 6.5,1.5
       parent: 1
   - uid: 3918
     components:
     - type: Transform
-      pos: -11.5,42.5
+      pos: 15.5,10.5
       parent: 1
   - uid: 3919
     components:
     - type: Transform
-      pos: 0.5,-6.5
+      pos: -11.5,37.5
       parent: 1
   - uid: 3920
     components:
     - type: Transform
-      pos: 2.5,-6.5
+      pos: -11.5,42.5
       parent: 1
   - uid: 3921
     components:
     - type: Transform
-      pos: 13.5,-6.5
+      pos: 0.5,-6.5
       parent: 1
   - uid: 3922
     components:
     - type: Transform
-      pos: 14.5,-6.5
+      pos: 2.5,-6.5
       parent: 1
   - uid: 3923
     components:
     - type: Transform
-      pos: 2.5,1.5
+      pos: 13.5,-6.5
       parent: 1
   - uid: 3924
     components:
     - type: Transform
-      pos: 0.5,-13.5
+      pos: 14.5,-6.5
       parent: 1
   - uid: 3925
     components:
     - type: Transform
-      pos: 6.5,-13.5
+      pos: 2.5,1.5
       parent: 1
   - uid: 3926
     components:
     - type: Transform
-      pos: -0.5,13.5
+      pos: 0.5,-13.5
       parent: 1
   - uid: 3927
     components:
     - type: Transform
-      pos: -0.5,15.5
+      pos: 6.5,-13.5
       parent: 1
   - uid: 3928
     components:
     - type: Transform
-      pos: 15.5,6.5
+      pos: -0.5,13.5
       parent: 1
   - uid: 3929
     components:
     - type: Transform
-      pos: 8.5,2.5
+      pos: -0.5,15.5
       parent: 1
   - uid: 3930
     components:
     - type: Transform
-      pos: 15.5,5.5
+      pos: 15.5,6.5
       parent: 1
   - uid: 3931
     components:
     - type: Transform
-      pos: 15.5,-6.5
+      pos: 8.5,2.5
       parent: 1
   - uid: 3932
     components:
     - type: Transform
-      pos: -0.5,12.5
+      pos: 15.5,5.5
       parent: 1
   - uid: 3933
     components:
     - type: Transform
-      pos: 15.5,19.5
+      pos: 15.5,-6.5
       parent: 1
   - uid: 3934
     components:
     - type: Transform
-      pos: 15.5,20.5
+      pos: -0.5,12.5
       parent: 1
   - uid: 3935
     components:
     - type: Transform
-      pos: 15.5,11.5
+      pos: 15.5,19.5
       parent: 1
   - uid: 3936
     components:
     - type: Transform
-      pos: 15.5,21.5
+      pos: 15.5,20.5
       parent: 1
   - uid: 3937
     components:
     - type: Transform
-      pos: 15.5,15.5
+      pos: 15.5,11.5
       parent: 1
   - uid: 3938
     components:
     - type: Transform
-      pos: 15.5,12.5
+      pos: 15.5,21.5
       parent: 1
   - uid: 3939
     components:
     - type: Transform
-      pos: 16.5,-13.5
+      pos: 15.5,15.5
       parent: 1
   - uid: 3940
     components:
     - type: Transform
-      pos: 7.5,-13.5
+      pos: 15.5,12.5
       parent: 1
   - uid: 3941
     components:
     - type: Transform
-      pos: 7.5,-9.5
+      pos: 16.5,-13.5
       parent: 1
   - uid: 3942
     components:
     - type: Transform
-      pos: 7.5,-7.5
+      pos: 7.5,-13.5
       parent: 1
   - uid: 3943
     components:
     - type: Transform
-      pos: 12.5,-13.5
+      pos: 7.5,-9.5
       parent: 1
   - uid: 3944
     components:
     - type: Transform
-      pos: 8.5,-13.5
+      pos: 7.5,-7.5
       parent: 1
   - uid: 3945
     components:
     - type: Transform
-      pos: 7.5,-11.5
+      pos: 12.5,-13.5
       parent: 1
   - uid: 3946
     components:
     - type: Transform
-      pos: 7.5,-12.5
+      pos: 8.5,-13.5
       parent: 1
   - uid: 3947
     components:
     - type: Transform
-      pos: 7.5,-10.5
+      pos: 7.5,-11.5
       parent: 1
   - uid: 3948
     components:
     - type: Transform
-      pos: 7.5,-8.5
+      pos: 7.5,-12.5
       parent: 1
   - uid: 3949
     components:
     - type: Transform
-      pos: 10.5,-13.5
+      pos: 7.5,-10.5
       parent: 1
   - uid: 3950
     components:
     - type: Transform
-      pos: 9.5,-13.5
+      pos: 7.5,-8.5
       parent: 1
   - uid: 3951
     components:
     - type: Transform
-      pos: -0.5,-6.5
+      pos: 10.5,-13.5
       parent: 1
   - uid: 3952
     components:
     - type: Transform
-      pos: 8.5,-6.5
+      pos: 9.5,-13.5
       parent: 1
   - uid: 3953
     components:
     - type: Transform
-      pos: 1.5,-6.5
+      pos: -0.5,-6.5
       parent: 1
   - uid: 3954
     components:
     - type: Transform
-      pos: 13.5,-13.5
+      pos: 8.5,-6.5
       parent: 1
   - uid: 3955
     components:
     - type: Transform
-      pos: 12.5,-6.5
+      pos: 1.5,-6.5
       parent: 1
   - uid: 3956
     components:
     - type: Transform
-      pos: 10.5,-6.5
+      pos: 13.5,-13.5
       parent: 1
   - uid: 3957
     components:
     - type: Transform
-      pos: 3.5,-6.5
+      pos: 12.5,-6.5
       parent: 1
   - uid: 3958
     components:
     - type: Transform
-      pos: 14.5,-13.5
+      pos: 10.5,-6.5
       parent: 1
   - uid: 3959
     components:
     - type: Transform
-      pos: 6.5,-6.5
+      pos: 3.5,-6.5
       parent: 1
   - uid: 3960
     components:
     - type: Transform
-      pos: 16.5,-6.5
+      pos: 14.5,-13.5
       parent: 1
   - uid: 3961
     components:
     - type: Transform
-      pos: 5.5,-6.5
+      pos: 6.5,-6.5
       parent: 1
   - uid: 3962
     components:
     - type: Transform
-      pos: 3.5,-13.5
+      pos: 16.5,-6.5
       parent: 1
   - uid: 3963
     components:
     - type: Transform
-      pos: -0.5,-13.5
+      pos: 5.5,-6.5
       parent: 1
   - uid: 3964
     components:
     - type: Transform
-      pos: 11.5,-13.5
+      pos: 3.5,-13.5
       parent: 1
   - uid: 3965
     components:
     - type: Transform
-      pos: 10.5,38.5
+      pos: -0.5,-13.5
       parent: 1
   - uid: 3966
     components:
     - type: Transform
-      pos: 10.5,37.5
+      pos: 11.5,-13.5
       parent: 1
   - uid: 3967
     components:
     - type: Transform
-      pos: 10.5,36.5
+      pos: 10.5,38.5
       parent: 1
   - uid: 3968
     components:
     - type: Transform
-      pos: 10.5,42.5
+      pos: 10.5,37.5
       parent: 1
   - uid: 3969
     components:
     - type: Transform
-      pos: 10.5,39.5
+      pos: 10.5,36.5
       parent: 1
   - uid: 3970
     components:
     - type: Transform
-      pos: 10.5,40.5
+      pos: 10.5,42.5
       parent: 1
   - uid: 3971
     components:
     - type: Transform
-      pos: 10.5,41.5
+      pos: 10.5,39.5
       parent: 1
   - uid: 3972
     components:
     - type: Transform
-      pos: -27.5,5.5
+      pos: 10.5,40.5
       parent: 1
   - uid: 3973
     components:
     - type: Transform
-      pos: -27.5,4.5
+      pos: 10.5,41.5
       parent: 1
   - uid: 3974
     components:
     - type: Transform
-      pos: -27.5,3.5
+      pos: -27.5,5.5
       parent: 1
   - uid: 3975
     components:
     - type: Transform
-      pos: -27.5,2.5
+      pos: -27.5,4.5
       parent: 1
   - uid: 3976
     components:
     - type: Transform
-      pos: -27.5,0.5
+      pos: -27.5,3.5
       parent: 1
   - uid: 3977
     components:
     - type: Transform
-      pos: -27.5,6.5
+      pos: -27.5,2.5
       parent: 1
   - uid: 3978
     components:
     - type: Transform
-      pos: -8.5,-62.5
+      pos: -27.5,0.5
       parent: 1
   - uid: 3979
     components:
     - type: Transform
-      pos: -7.5,-62.5
+      pos: -27.5,6.5
       parent: 1
   - uid: 3980
     components:
     - type: Transform
-      pos: -6.5,-62.5
+      pos: -8.5,-62.5
       parent: 1
   - uid: 3981
     components:
     - type: Transform
-      pos: -5.5,-62.5
+      pos: -7.5,-62.5
       parent: 1
   - uid: 3982
     components:
     - type: Transform
-      pos: -3.5,-62.5
+      pos: -6.5,-62.5
       parent: 1
   - uid: 3983
     components:
     - type: Transform
-      pos: -2.5,-62.5
+      pos: -5.5,-62.5
       parent: 1
   - uid: 3984
     components:
     - type: Transform
-      pos: -4.5,-62.5
+      pos: -3.5,-62.5
       parent: 1
   - uid: 3985
     components:
     - type: Transform
-      pos: -5.5,-59.5
+      pos: -2.5,-62.5
       parent: 1
   - uid: 3986
     components:
     - type: Transform
-      pos: -5.5,-60.5
+      pos: -4.5,-62.5
       parent: 1
   - uid: 3987
     components:
     - type: Transform
-      pos: -5.5,-61.5
+      pos: -5.5,-59.5
       parent: 1
   - uid: 3988
     components:
     - type: Transform
-      pos: -5.5,-62.5
+      pos: -5.5,-60.5
       parent: 1
   - uid: 3989
     components:
     - type: Transform
-      pos: -5.5,-63.5
+      pos: -5.5,-61.5
       parent: 1
   - uid: 3990
     components:
     - type: Transform
-      pos: -5.5,-64.5
+      pos: -5.5,-62.5
       parent: 1
   - uid: 3991
     components:
     - type: Transform
-      pos: -5.5,-65.5
+      pos: -5.5,-63.5
       parent: 1
   - uid: 3992
     components:
     - type: Transform
-      pos: 23.5,5.5
+      pos: -5.5,-64.5
       parent: 1
   - uid: 3993
     components:
     - type: Transform
-      pos: 24.5,5.5
+      pos: -5.5,-65.5
       parent: 1
   - uid: 3994
     components:
     - type: Transform
-      pos: 25.5,5.5
+      pos: 23.5,5.5
       parent: 1
   - uid: 3995
     components:
     - type: Transform
-      pos: 27.5,5.5
+      pos: 24.5,5.5
       parent: 1
   - uid: 3996
     components:
     - type: Transform
-      pos: 28.5,5.5
+      pos: 25.5,5.5
       parent: 1
   - uid: 3997
     components:
     - type: Transform
-      pos: 26.5,5.5
+      pos: 27.5,5.5
       parent: 1
   - uid: 3998
     components:
     - type: Transform
-      pos: 26.5,4.5
+      pos: 28.5,5.5
       parent: 1
   - uid: 3999
     components:
     - type: Transform
-      pos: 26.5,3.5
+      pos: 26.5,5.5
       parent: 1
   - uid: 4000
     components:
     - type: Transform
-      pos: 26.5,1.5
+      pos: 26.5,4.5
       parent: 1
   - uid: 4001
     components:
     - type: Transform
-      pos: 26.5,2.5
+      pos: 26.5,3.5
       parent: 1
   - uid: 4002
     components:
     - type: Transform
-      pos: -5.5,-35.5
+      pos: 26.5,1.5
       parent: 1
   - uid: 4003
     components:
     - type: Transform
-      pos: -4.5,-47.5
+      pos: 26.5,2.5
       parent: 1
   - uid: 4004
     components:
     - type: Transform
-      pos: -5.5,-45.5
+      pos: -5.5,-35.5
       parent: 1
   - uid: 4005
     components:
     - type: Transform
-      pos: -10.5,-38.5
+      pos: -4.5,-47.5
       parent: 1
   - uid: 4006
     components:
     - type: Transform
-      pos: -4.5,-45.5
+      pos: -5.5,-45.5
       parent: 1
   - uid: 4007
+    components:
+    - type: Transform
+      pos: -10.5,-38.5
+      parent: 1
+  - uid: 4008
+    components:
+    - type: Transform
+      pos: -4.5,-45.5
+      parent: 1
+  - uid: 4009
     components:
     - type: Transform
       pos: -4.5,-51.5
       parent: 1
 - proto: RMCCarpetBeige1
   entities:
-  - uid: 4008
+  - uid: 4010
     components:
     - type: Transform
       pos: -17.5,47.5
       parent: 1
 - proto: RMCCarpetBeige2
   entities:
-  - uid: 4009
+  - uid: 4011
     components:
     - type: Transform
       pos: -16.5,47.5
       parent: 1
 - proto: RMCCarpetBeige3
   entities:
-  - uid: 4010
+  - uid: 4012
     components:
     - type: Transform
       pos: -15.5,47.5
       parent: 1
 - proto: RMCCarpetBeige4
   entities:
-  - uid: 4011
+  - uid: 4013
     components:
     - type: Transform
       pos: -17.5,46.5
       parent: 1
 - proto: RMCCarpetBeige5
   entities:
-  - uid: 4012
+  - uid: 4014
     components:
     - type: Transform
       pos: -16.5,46.5
       parent: 1
 - proto: RMCCarpetBeige6
   entities:
-  - uid: 4013
+  - uid: 4015
     components:
     - type: Transform
       pos: -15.5,46.5
       parent: 1
 - proto: RMCCarpetBeige7
   entities:
-  - uid: 4014
+  - uid: 4016
     components:
     - type: Transform
       pos: -17.5,45.5
       parent: 1
 - proto: RMCCarpetBeige8
   entities:
-  - uid: 4015
+  - uid: 4017
     components:
     - type: Transform
       pos: -16.5,45.5
       parent: 1
 - proto: RMCCarpetBeige9
   entities:
-  - uid: 4016
+  - uid: 4018
     components:
     - type: Transform
       pos: -15.5,45.5
       parent: 1
 - proto: RMCCarpetBlack1
   entities:
-  - uid: 4017
+  - uid: 4019
     components:
     - type: Transform
       pos: 12.5,48.5
       parent: 1
-  - uid: 4018
-    components:
-    - type: Transform
-      pos: -3.5,40.5
-      parent: 1
-  - uid: 4019
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-5.5
-      parent: 1
   - uid: 4020
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-9.5
+      pos: -3.5,40.5
       parent: 1
   - uid: 4021
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-1.5
+      pos: -3.5,-5.5
       parent: 1
   - uid: 4022
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 4023
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 4024
     components:
     - type: Transform
       pos: -12.5,47.5
       parent: 1
 - proto: RMCCarpetBlack2
   entities:
-  - uid: 4023
+  - uid: 4025
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-5.5
       parent: 1
-  - uid: 4024
+  - uid: 4026
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-1.5
       parent: 1
-  - uid: 4025
+  - uid: 4027
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-9.5
       parent: 1
-  - uid: 4026
+  - uid: 4028
     components:
     - type: Transform
       pos: -11.5,47.5
       parent: 1
 - proto: RMCCarpetBlack3
   entities:
-  - uid: 4027
+  - uid: 4029
     components:
     - type: Transform
       pos: -2.5,40.5
       parent: 1
-  - uid: 4028
+  - uid: 4030
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-1.5
       parent: 1
-  - uid: 4029
+  - uid: 4031
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-9.5
       parent: 1
-  - uid: 4030
+  - uid: 4032
     components:
     - type: Transform
       pos: 13.5,48.5
       parent: 1
-  - uid: 4031
+  - uid: 4033
     components:
     - type: Transform
       pos: -10.5,47.5
       parent: 1
-  - uid: 4032
+  - uid: 4034
     components:
     - type: Transform
       pos: -1.5,-43.5
       parent: 1
 - proto: RMCCarpetBlack4
   entities:
-  - uid: 4033
+  - uid: 4035
     components:
     - type: Transform
       pos: 12.5,47.5
       parent: 1
-  - uid: 4034
+  - uid: 4036
     components:
     - type: Transform
       pos: -12.5,46.5
       parent: 1
 - proto: RMCCarpetBlack5
   entities:
-  - uid: 4035
+  - uid: 4037
     components:
     - type: Transform
       pos: -11.5,46.5
       parent: 1
 - proto: RMCCarpetBlack6
   entities:
-  - uid: 4036
+  - uid: 4038
     components:
     - type: Transform
       pos: -2.5,39.5
       parent: 1
-  - uid: 4037
+  - uid: 4039
     components:
     - type: Transform
       pos: 13.5,47.5
       parent: 1
-  - uid: 4038
+  - uid: 4040
     components:
     - type: Transform
       pos: -10.5,46.5
       parent: 1
-  - uid: 4039
+  - uid: 4041
     components:
     - type: Transform
       pos: -1.5,-44.5
       parent: 1
-  - uid: 4040
+  - uid: 4042
     components:
     - type: Transform
       pos: -1.5,-45.5
       parent: 1
-  - uid: 4041
+  - uid: 4043
     components:
     - type: Transform
       pos: -1.5,-46.5
       parent: 1
 - proto: RMCCarpetBlack7
   entities:
-  - uid: 4042
+  - uid: 4044
     components:
     - type: Transform
       pos: -3.5,38.5
       parent: 1
-  - uid: 4043
+  - uid: 4045
     components:
     - type: Transform
       pos: 12.5,46.5
       parent: 1
-  - uid: 4044
+  - uid: 4046
     components:
     - type: Transform
       pos: -12.5,45.5
       parent: 1
 - proto: RMCCarpetBlack8
   entities:
-  - uid: 4045
+  - uid: 4047
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-5.5
       parent: 1
-  - uid: 4046
+  - uid: 4048
     components:
     - type: Transform
       pos: -11.5,45.5
       parent: 1
 - proto: RMCCarpetBlack9
   entities:
-  - uid: 4047
+  - uid: 4049
     components:
     - type: Transform
       pos: 13.5,46.5
       parent: 1
-  - uid: 4048
+  - uid: 4050
     components:
     - type: Transform
       pos: -2.5,38.5
       parent: 1
-  - uid: 4049
+  - uid: 4051
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-5.5
       parent: 1
-  - uid: 4050
+  - uid: 4052
     components:
     - type: Transform
       pos: -10.5,45.5
       parent: 1
-  - uid: 4051
+  - uid: 4053
     components:
     - type: Transform
       pos: -1.5,-47.5
       parent: 1
 - proto: RMCCashRegisterOn
   entities:
-  - uid: 4052
+  - uid: 4054
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-21.5
       parent: 1
-  - uid: 4053
+  - uid: 4055
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29509,246 +29514,237 @@ entities:
       parent: 1
 - proto: RMCCassettePlayer
   entities:
-  - uid: 4054
+  - uid: 4056
     components:
     - type: Transform
       pos: 2.8756518,65.38194
       parent: 1
 - proto: RMCCatwalkAI
   entities:
-  - uid: 4055
+  - uid: 4057
     components:
     - type: Transform
       pos: -12.5,-24.5
       parent: 1
-  - uid: 4056
+  - uid: 4058
     components:
     - type: Transform
       pos: -6.5,-22.5
       parent: 1
-  - uid: 4057
+  - uid: 4059
     components:
     - type: Transform
       pos: -6.5,-23.5
       parent: 1
-  - uid: 4058
+  - uid: 4060
     components:
     - type: Transform
       pos: -5.5,-24.5
       parent: 1
-  - uid: 4059
+  - uid: 4061
     components:
     - type: Transform
       pos: -10.5,-22.5
       parent: 1
-  - uid: 4060
+  - uid: 4062
     components:
     - type: Transform
       pos: -10.5,-23.5
       parent: 1
-  - uid: 4061
+  - uid: 4063
     components:
     - type: Transform
       pos: -3.5,-24.5
       parent: 1
-  - uid: 4062
+  - uid: 4064
     components:
     - type: Transform
       pos: -6.5,-21.5
       parent: 1
-  - uid: 4063
+  - uid: 4065
     components:
     - type: Transform
       pos: -10.5,-21.5
       parent: 1
-  - uid: 4064
+  - uid: 4066
     components:
     - type: Transform
       pos: -11.5,-24.5
       parent: 1
 - proto: RMCCatwalkStrata
   entities:
-  - uid: 4065
+  - uid: 4067
     components:
     - type: Transform
       pos: -5.5,-60.5
       parent: 1
-  - uid: 4066
+  - uid: 4068
     components:
     - type: Transform
       pos: -5.5,-61.5
       parent: 1
-  - uid: 4067
+  - uid: 4069
     components:
     - type: Transform
       pos: -5.5,-62.5
       parent: 1
-  - uid: 4068
+  - uid: 4070
     components:
     - type: Transform
       pos: -5.5,-64.5
       parent: 1
-  - uid: 4069
+  - uid: 4071
     components:
     - type: Transform
       pos: -5.5,-63.5
       parent: 1
-  - uid: 4070
+  - uid: 4072
     components:
     - type: Transform
       pos: -7.5,-62.5
       parent: 1
-  - uid: 4071
+  - uid: 4073
     components:
     - type: Transform
       pos: -6.5,-62.5
       parent: 1
-  - uid: 4072
+  - uid: 4074
     components:
     - type: Transform
       pos: -4.5,-62.5
       parent: 1
-  - uid: 4073
+  - uid: 4075
     components:
     - type: Transform
       pos: -3.5,-62.5
       parent: 1
-  - uid: 4074
+  - uid: 4076
     components:
     - type: Transform
       pos: -5.5,-62.5
       parent: 1
 - proto: RMCChefApron
   entities:
-  - uid: 4075
+  - uid: 4077
     components:
     - type: Transform
       pos: -8.919378,-21.460232
       parent: 1
 - proto: RMCChemDispenserCorpsmanMedbay
   entities:
-  - uid: 4076
+  - uid: 4078
     components:
     - type: Transform
       pos: -29.5,19.5
       parent: 1
 - proto: RMCChemDispenserMedbay
   entities:
-  - uid: 4077
-    components:
-    - type: Transform
-      pos: -25.5,25.5
-      parent: 1
-  - uid: 4078
+  - uid: 4079
     components:
     - type: Transform
       pos: -24.5,20.5
       parent: 1
+  - uid: 4080
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -25.5,24.5
+      parent: 1
+- proto: RMCChemStorageDrinks
+  entities:
+  - uid: 4081
+    components:
+    - type: Transform
+      pos: 23.5,24.5
+      parent: 1
+- proto: RMCChemStorageMedbay
+  entities:
+  - uid: 4082
+    components:
+    - type: Transform
+      pos: -25.5,25.5
+      parent: 1
 - proto: RMCCigarCase
   entities:
-  - uid: 4079
+  - uid: 4083
     components:
     - type: Transform
       pos: 26.461397,3.3707585
       parent: 1
 - proto: RMCCigarette
   entities:
-  - uid: 4080
+  - uid: 4084
     components:
     - type: Transform
       pos: -3.706686,-3.167245
       parent: 1
-  - uid: 4081
+  - uid: 4085
     components:
     - type: Transform
       pos: -3.342103,-3.1464114
       parent: 1
-  - uid: 4082
+  - uid: 4086
     components:
     - type: Transform
       pos: -3.675436,-3.448495
       parent: 1
-  - uid: 4083
+  - uid: 4087
     components:
     - type: Transform
       pos: -2.3045685,-67.299385
       parent: 1
 - proto: RMCCigaretteSpent
   entities:
-  - uid: 4084
+  - uid: 4088
     components:
     - type: Transform
       pos: -2.6959476,-67.40946
       parent: 1
-- proto: RMCCoffeeCup
-  entities:
-  - uid: 4085
-    components:
-    - type: Transform
-      pos: 9.959949,-48.278618
-      parent: 1
-  - uid: 4086
-    components:
-    - type: Transform
-      pos: 10.241199,-48.54945
-      parent: 1
-- proto: RMCCoffeeCupFilled
-  entities:
-  - uid: 4087
-    components:
-    - type: Transform
-      pos: 10.407865,-48.184868
-      parent: 1
 - proto: RMCComputerIntelGovfor
   entities:
-  - uid: 4088
+  - uid: 4089
     components:
     - type: Transform
       pos: -2.5,46.5
       parent: 1
 - proto: RMCCouchEnd
   entities:
-  - uid: 4089
+  - uid: 4090
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-36.5
       parent: 1
-  - uid: 4090
+  - uid: 4091
     components:
     - type: Transform
       pos: -11.5,-36.5
       parent: 1
 - proto: RMCCouchMid
   entities:
-  - uid: 4091
+  - uid: 4092
     components:
     - type: Transform
       pos: -9.5,-36.5
       parent: 1
-  - uid: 4092
+  - uid: 4093
     components:
     - type: Transform
       pos: -10.5,-36.5
       parent: 1
 - proto: RMCCrateGeneratorPACMAN
   entities:
-  - uid: 4093
+  - uid: 4094
     components:
     - type: Transform
       pos: 4.5,-68.5
       parent: 1
 - proto: RMCCrateLarge
   entities:
-  - uid: 4094
-    components:
-    - type: Transform
-      pos: 1.5,-65.5
-      parent: 1
   - uid: 4095
     components:
     - type: Transform
-      pos: 23.5,24.5
+      pos: 1.5,-65.5
       parent: 1
   - uid: 4096
     components:
@@ -29774,6 +29770,31 @@ entities:
     - type: Transform
       pos: 2.5,-68.5
       parent: 1
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.4,-0.4
+            - 0.4,-0.4
+            - 0.4,0.29
+            - -0.4,0.29
+          mask:
+          - Impassable
+          - HighImpassable
+          - LowImpassable
+          layer:
+          - Opaque
+          density: 50
+          hard: True
+          restitution: 0
+          friction: 0.4
+    - type: EntityStorage
+      open: True
+      removedMasks: 20
+    - type: PlaceableSurface
+      isPlaceable: True
     - type: Lock
       locked: False
 - proto: RMCCrateSupplyJanitor
@@ -29842,7 +29863,7 @@ entities:
       pos: -5.5,-11.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -76615.35
+      secondsUntilStateChange: -77238.914
       state: Closing
   - uid: 4110
     components:
@@ -30048,151 +30069,151 @@ entities:
       parent: 1
 - proto: RMCDrinkAlcoholWhiskey
   entities:
-  - uid: 3547
+  - uid: 4143
     components:
     - type: Transform
       pos: -12.421261,46.602837
       parent: 1
 - proto: RMCDrinkCoffee
   entities:
-  - uid: 4143
+  - uid: 4144
     components:
     - type: Transform
       pos: 11.39498,-27.242014
       parent: 1
-  - uid: 4144
+  - uid: 4145
     components:
     - type: Transform
       pos: 11.728313,-27.242014
       parent: 1
-  - uid: 4145
+  - uid: 4146
     components:
     - type: Transform
       pos: 11.723659,-27.58762
       parent: 1
-  - uid: 4146
+  - uid: 4147
     components:
     - type: Transform
       pos: 11.061647,-27.242014
       parent: 1
-  - uid: 4147
+  - uid: 4148
     components:
     - type: Transform
       pos: 10.721369,-27.23507
       parent: 1
-  - uid: 4148
+  - uid: 4149
     components:
     - type: Transform
       pos: 11.411159,-27.59618
       parent: 1
-  - uid: 4149
+  - uid: 4150
     components:
     - type: Transform
       pos: 10.737548,-27.623959
       parent: 1
-  - uid: 4150
+  - uid: 4151
     components:
     - type: Transform
       pos: 11.050048,-27.61007
       parent: 1
-  - uid: 4151
+  - uid: 4152
     components:
     - type: Transform
       pos: -1.8707304,70.25563
       parent: 1
 - proto: RMCDrinkCoffeeGrind
   entities:
-  - uid: 4152
+  - uid: 4153
     components:
     - type: Transform
       pos: 11.263392,-50.307076
       parent: 1
-  - uid: 4153
+  - uid: 4154
     components:
     - type: Transform
       pos: 9.212846,-48.30876
       parent: 1
-  - uid: 4154
+  - uid: 4155
     components:
     - type: Transform
       pos: 9.431596,-48.52751
       parent: 1
-  - uid: 4155
+  - uid: 4156
     components:
     - type: Transform
       pos: -26.75311,15.690163
       parent: 1
-  - uid: 4156
+  - uid: 4157
     components:
     - type: Transform
       pos: -0.62014115,65.1866
       parent: 1
-  - uid: 4157
+  - uid: 4158
     components:
     - type: Transform
       pos: 1.2524049,42.583397
       parent: 1
 - proto: RMCDropshipFabricator
   entities:
-  - uid: 4158
+  - uid: 4159
     components:
     - type: Transform
       pos: -12.5,43.5
       parent: 1
-  - uid: 4159
+  - uid: 4160
     components:
     - type: Transform
       pos: 9.5,43.5
       parent: 1
 - proto: RMCExtinguisherCabinetAltFilled
   entities:
-  - uid: 4160
+  - uid: 4161
     components:
     - type: Transform
       pos: 10.5,-33.5
       parent: 1
-  - uid: 4161
+  - uid: 4162
     components:
     - type: Transform
       pos: -13.5,-53.5
       parent: 1
-  - uid: 4162
+  - uid: 4163
     components:
     - type: Transform
       pos: 17.5,34.5
       parent: 1
-  - uid: 4163
+  - uid: 4164
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,53.5
       parent: 1
-  - uid: 4164
+  - uid: 4165
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 1
-  - uid: 4165
+  - uid: 4166
     components:
     - type: Transform
       pos: 12.5,37.5
       parent: 1
-  - uid: 4166
+  - uid: 4167
     components:
     - type: Transform
       pos: -18.5,34.5
       parent: 1
-  - uid: 4167
+  - uid: 4168
     components:
     - type: Transform
       pos: 12.5,-53.5
       parent: 1
-  - uid: 4168
+  - uid: 4169
     components:
     - type: Transform
       pos: 1.5,70.5
       parent: 1
-  - uid: 4169
+  - uid: 4170
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30200,51 +30221,44 @@ entities:
       parent: 1
 - proto: RMCFoamedAluminiumMetal
   entities:
-  - uid: 4170
+  - uid: 4171
     components:
     - type: Transform
       pos: -0.5,-36.5
       parent: 1
-  - uid: 4171
+  - uid: 4172
     components:
     - type: Transform
       pos: -1.5,-36.5
       parent: 1
 - proto: RMCFoodPizzaMeatFull
   entities:
-  - uid: 4172
+  - uid: 4173
     components:
     - type: Transform
       pos: -6.40543,-32.759888
       parent: 1
 - proto: RMCFoodSnackCheeseburgerPackaged
   entities:
-  - uid: 4173
+  - uid: 4174
     components:
     - type: Transform
       pos: 6.703054,-21.326504
       parent: 1
-  - uid: 4174
+  - uid: 4175
     components:
     - type: Transform
       pos: 6.359304,-21.680672
       parent: 1
-  - uid: 4175
+  - uid: 4176
     components:
     - type: Transform
       pos: 6.7238874,-21.659838
       parent: 1
-  - uid: 4176
-    components:
-    - type: Transform
-      pos: 6.359304,-21.316088
-      parent: 1
-- proto: RMCFoodSnackKeplarFlamehotCrisps
-  entities:
   - uid: 4177
     components:
     - type: Transform
-      pos: 11.397449,-48.351433
+      pos: 6.359304,-21.316088
       parent: 1
 - proto: RMCFuelPump
   entities:
@@ -30693,70 +30707,70 @@ entities:
       parent: 1
 - proto: RMCGuidebookBase
   entities:
-  - uid: 3706
+  - uid: 3708
     components:
     - type: Transform
-      parent: 3705
+      parent: 3707
     - type: Physics
       canCollide: False
 - proto: RMCGuidebookLawMarine
   entities:
-  - uid: 3707
+  - uid: 3709
     components:
     - type: Transform
-      parent: 3705
-    - type: Physics
-      canCollide: False
-  - uid: 3711
-    components:
-    - type: Transform
-      parent: 3710
-    - type: Physics
-      canCollide: False
-  - uid: 3712
-    components:
-    - type: Transform
-      parent: 3710
+      parent: 3707
     - type: Physics
       canCollide: False
   - uid: 3713
     components:
     - type: Transform
-      parent: 3710
-    - type: Physics
-      canCollide: False
-- proto: RMCGuidebookLawMarineProvost
-  entities:
-  - uid: 3708
-    components:
-    - type: Transform
-      parent: 3705
-    - type: Physics
-      canCollide: False
-- proto: RMCGuidebookSOP
-  entities:
-  - uid: 3709
-    components:
-    - type: Transform
-      parent: 3705
+      parent: 3712
     - type: Physics
       canCollide: False
   - uid: 3714
     components:
     - type: Transform
-      parent: 3710
+      parent: 3712
     - type: Physics
       canCollide: False
   - uid: 3715
     components:
     - type: Transform
-      parent: 3710
+      parent: 3712
+    - type: Physics
+      canCollide: False
+- proto: RMCGuidebookLawMarineProvost
+  entities:
+  - uid: 3710
+    components:
+    - type: Transform
+      parent: 3707
+    - type: Physics
+      canCollide: False
+- proto: RMCGuidebookSOP
+  entities:
+  - uid: 3711
+    components:
+    - type: Transform
+      parent: 3707
     - type: Physics
       canCollide: False
   - uid: 3716
     components:
     - type: Transform
-      parent: 3710
+      parent: 3712
+    - type: Physics
+      canCollide: False
+  - uid: 3717
+    components:
+    - type: Transform
+      parent: 3712
+    - type: Physics
+      canCollide: False
+  - uid: 3718
+    components:
+    - type: Transform
+      parent: 3712
     - type: Physics
       canCollide: False
 - proto: RMCHospitalDivider
@@ -31459,1738 +31473,1738 @@ entities:
       parent: 1
 - proto: RMCLightFixtureBlueDouble
   entities:
-  - uid: 70
+  - uid: 4348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,42.5
       parent: 1
-  - uid: 73
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,42.5
-      parent: 1
-  - uid: 3550
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,38.5
-      parent: 1
-  - uid: 3586
-    components:
-    - type: Transform
-      pos: 8.5,38.5
-      parent: 1
-  - uid: 4348
+  - uid: 4349
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,46.5
       parent: 1
-  - uid: 4349
+  - uid: 4350
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,46.5
       parent: 1
-  - uid: 4350
+  - uid: 4351
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,42
       parent: 1
-  - uid: 4351
+  - uid: 4352
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,47
       parent: 1
-  - uid: 4352
+  - uid: 4353
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,48.5
       parent: 1
-  - uid: 4353
+  - uid: 4354
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,48.5
       parent: 1
-  - uid: 4354
+  - uid: 4355
     components:
     - type: Transform
       pos: -0.5,45.5
       parent: 1
-  - uid: 4355
-    components:
-    - type: Transform
-      pos: 5.5,45.5
-      parent: 1
   - uid: 4356
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,39.5
+      pos: 5.5,45.5
       parent: 1
   - uid: 4357
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,42.5
+      pos: 2.5,39.5
       parent: 1
   - uid: 4358
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,42.5
+      rot: 1.5707963267948966 rad
+      pos: 2.5,42.5
       parent: 1
   - uid: 4359
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,39.5
+      pos: -3.5,42.5
       parent: 1
   - uid: 4360
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,39.5
+      parent: 1
+  - uid: 4361
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,8.5
       parent: 1
-  - uid: 4361
+  - uid: 4362
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,3.5
       parent: 1
-  - uid: 4362
+  - uid: 4363
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,8.5
       parent: 1
-  - uid: 4363
+  - uid: 4364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,7.5
       parent: 1
-  - uid: 4364
+  - uid: 4365
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,3.5
       parent: 1
-  - uid: 4365
+  - uid: 4366
     components:
     - type: Transform
       pos: 21.5,0.5
       parent: 1
-  - uid: 4366
+  - uid: 4367
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-40.5
       parent: 1
-  - uid: 4367
+  - uid: 4368
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-54.5
       parent: 1
-  - uid: 4368
+  - uid: 4369
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-50.5
       parent: 1
-  - uid: 4369
+  - uid: 4370
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-42.5
       parent: 1
-  - uid: 4370
-    components:
-    - type: Transform
-      pos: 9.5,-39.5
-      parent: 1
   - uid: 4371
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,-45.5
+      pos: 9.5,-39.5
       parent: 1
   - uid: 4372
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 13.5,-43
+      pos: 14.5,-45.5
       parent: 1
   - uid: 4373
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-43
+      parent: 1
+  - uid: 4374
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,9.5
       parent: 1
-  - uid: 4374
+  - uid: 4375
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,28.5
       parent: 1
-  - uid: 4375
+  - uid: 4376
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,19.5
       parent: 1
-  - uid: 4376
+  - uid: 4377
     components:
     - type: Transform
       pos: 3.5,32.5
       parent: 1
-  - uid: 4377
+  - uid: 4378
     components:
     - type: Transform
       pos: 8.5,32.5
       parent: 1
-  - uid: 4378
+  - uid: 4379
     components:
     - type: Transform
       pos: -4.5,32.5
       parent: 1
-  - uid: 4379
+  - uid: 4380
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,9.5
       parent: 1
-  - uid: 4380
+  - uid: 4381
     components:
     - type: Transform
       pos: 3.5,-47.5
       parent: 1
-  - uid: 4381
+  - uid: 4382
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,-6.5
       parent: 1
-  - uid: 4382
+  - uid: 4383
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,-17.5
       parent: 1
-  - uid: 4383
+  - uid: 4384
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-3.5
       parent: 1
-  - uid: 4384
+  - uid: 4385
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,-11.5
       parent: 1
-  - uid: 4385
+  - uid: 4386
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-48
       parent: 1
-  - uid: 4386
+  - uid: 4387
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,52.5
       parent: 1
-  - uid: 4387
+  - uid: 4388
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-6.5
       parent: 1
-  - uid: 4388
+  - uid: 4389
     components:
     - type: Transform
       pos: 10.5,-7.5
       parent: 1
-  - uid: 4389
+  - uid: 4390
     components:
     - type: Transform
       pos: 12.5,38.5
       parent: 1
-  - uid: 4390
+  - uid: 4391
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 4391
+  - uid: 4392
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-9
       parent: 1
-  - uid: 4392
+  - uid: 4393
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-14
       parent: 1
-  - uid: 4393
+  - uid: 4394
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,30.5
       parent: 1
-  - uid: 4394
+  - uid: 4395
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-34.5
       parent: 1
-  - uid: 4395
+  - uid: 4396
     components:
     - type: Transform
       pos: 7.5,-47.5
       parent: 1
-  - uid: 4396
+  - uid: 4397
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,42.5
       parent: 1
-  - uid: 4397
+  - uid: 4398
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-14
       parent: 1
-  - uid: 4398
+  - uid: 4399
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-42.5
       parent: 1
-  - uid: 4399
+  - uid: 4400
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-23.5
       parent: 1
-  - uid: 4400
+  - uid: 4401
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-46.5
       parent: 1
-  - uid: 4401
+  - uid: 4402
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-21.5
       parent: 1
-  - uid: 4402
+  - uid: 4403
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-3.5
       parent: 1
-  - uid: 4403
+  - uid: 4404
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-44.5
       parent: 1
-  - uid: 4404
+  - uid: 4405
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-44.5
       parent: 1
-  - uid: 4405
-    components:
-    - type: Transform
-      pos: 3.5,-39.5
-      parent: 1
   - uid: 4406
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,-42.5
+      pos: 3.5,-39.5
       parent: 1
   - uid: 4407
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,-42.5
+      pos: 8.5,-42.5
       parent: 1
   - uid: 4408
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-29.5
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-42.5
       parent: 1
   - uid: 4409
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,-34.5
+      pos: 7.5,-29.5
       parent: 1
   - uid: 4410
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 10.5,-29.5
+      pos: 5.5,-34.5
       parent: 1
   - uid: 4411
     components:
     - type: Transform
-      pos: 6.5,-39.5
+      rot: 3.141592653589793 rad
+      pos: 10.5,-29.5
       parent: 1
   - uid: 4412
+    components:
+    - type: Transform
+      pos: 6.5,-39.5
+      parent: 1
+  - uid: 4413
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-40.5
       parent: 1
-  - uid: 4413
+  - uid: 4414
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,-13.5
       parent: 1
-  - uid: 4414
+  - uid: 4415
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,-6.5
       parent: 1
-  - uid: 4415
+  - uid: 4416
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-13.5
       parent: 1
-  - uid: 4416
+  - uid: 4417
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,38.5
       parent: 1
-  - uid: 4417
+  - uid: 4418
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,42.5
       parent: 1
-  - uid: 4418
-    components:
-    - type: Transform
-      pos: 10.5,-51.5
-      parent: 1
   - uid: 4419
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,24.5
+      pos: 10.5,-51.5
       parent: 1
   - uid: 4420
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 19.5,9.5
+      pos: 19.5,24.5
       parent: 1
   - uid: 4421
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 18.5,42
+      pos: 19.5,9.5
       parent: 1
   - uid: 4422
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 18.5,37
+      pos: 18.5,42
       parent: 1
   - uid: 4423
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 19.5,39.5
+      pos: 18.5,37
       parent: 1
   - uid: 4424
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,39.5
+      parent: 1
+  - uid: 4425
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,52.5
       parent: 1
-  - uid: 4425
+  - uid: 4426
     components:
     - type: Transform
       pos: -13.5,38.5
       parent: 1
-  - uid: 4426
+  - uid: 4427
     components:
     - type: Transform
       pos: -9.5,38.5
       parent: 1
-  - uid: 4427
+  - uid: 4428
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,38.5
       parent: 1
-  - uid: 4428
+  - uid: 4429
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,38.5
       parent: 1
-  - uid: 4429
+  - uid: 4430
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,42.5
       parent: 1
-  - uid: 4430
+  - uid: 4431
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,42.5
       parent: 1
-  - uid: 4431
+  - uid: 4432
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,42.5
       parent: 1
-  - uid: 4432
+  - uid: 4433
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,42.5
       parent: 1
-  - uid: 4433
+  - uid: 4434
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,19.5
       parent: 1
-  - uid: 4434
+  - uid: 4435
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,4.5
       parent: 1
-  - uid: 4435
+  - uid: 4436
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-12.5
       parent: 1
-  - uid: 4436
+  - uid: 4437
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,14.5
       parent: 1
-  - uid: 4437
+  - uid: 4438
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,9.5
       parent: 1
-  - uid: 4438
+  - uid: 4439
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,19.5
       parent: 1
-  - uid: 4439
+  - uid: 4440
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,24.5
       parent: 1
-  - uid: 4440
+  - uid: 4441
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,44.5
       parent: 1
-  - uid: 4441
+  - uid: 4442
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,-6.5
       parent: 1
-  - uid: 4442
+  - uid: 4443
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-49.5
       parent: 1
-  - uid: 4443
+  - uid: 4444
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-49.5
       parent: 1
-  - uid: 4444
+  - uid: 4445
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-37.5
       parent: 1
-  - uid: 4445
+  - uid: 4446
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-36.5
       parent: 1
-  - uid: 4446
+  - uid: 4447
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-29.5
       parent: 1
-  - uid: 4447
-    components:
-    - type: Transform
-      pos: 3.5,-32.5
-      parent: 1
   - uid: 4448
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-44.5
+      pos: 3.5,-32.5
       parent: 1
   - uid: 4449
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 9.5,52.5
+      pos: 6.5,-44.5
       parent: 1
   - uid: 4450
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,52.5
+      parent: 1
+  - uid: 4451
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.261492,-33
       parent: 1
-  - uid: 4451
+  - uid: 4452
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.400851,-28
       parent: 1
-  - uid: 4452
+  - uid: 4453
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.400851,-33
       parent: 1
-  - uid: 4453
+  - uid: 4454
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.308367,-23
       parent: 1
-  - uid: 4454
+  - uid: 4455
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,-21.5
       parent: 1
-  - uid: 4455
+  - uid: 4456
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-26.5
       parent: 1
-  - uid: 4456
+  - uid: 4457
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-1.5
       parent: 1
-  - uid: 4457
+  - uid: 4458
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-5.5
       parent: 1
-  - uid: 4458
+  - uid: 4459
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-9.5
       parent: 1
-  - uid: 4459
+  - uid: 4460
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,-10.5
       parent: 1
-  - uid: 4460
+  - uid: 4461
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-7.5
       parent: 1
-  - uid: 4461
+  - uid: 4462
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-7.5
       parent: 1
-  - uid: 4462
+  - uid: 4463
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-2.5
       parent: 1
-  - uid: 4463
+  - uid: 4464
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-2.5
       parent: 1
-  - uid: 4464
+  - uid: 4465
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-10.5
       parent: 1
-  - uid: 4465
+  - uid: 4466
     components:
     - type: Transform
       pos: -16.5,-14.5
       parent: 1
-  - uid: 4466
-    components:
-    - type: Transform
-      pos: -12.5,-14.5
-      parent: 1
   - uid: 4467
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-8.5
+      pos: -12.5,-14.5
       parent: 1
   - uid: 4468
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -7.5,-4.5
+      pos: -7.5,-8.5
       parent: 1
   - uid: 4469
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-4.5
+      parent: 1
+  - uid: 4470
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-36.5
       parent: 1
-  - uid: 4470
+  - uid: 4471
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-29.5
       parent: 1
-  - uid: 4471
+  - uid: 4472
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-16.5
       parent: 1
-  - uid: 4472
+  - uid: 4473
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-16.5
       parent: 1
-  - uid: 4473
+  - uid: 4474
     components:
     - type: Transform
       pos: -4.5,-19.5
       parent: 1
-  - uid: 4474
+  - uid: 4475
     components:
     - type: Transform
       pos: -12.5,-19.5
       parent: 1
-  - uid: 4475
+  - uid: 4476
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-16.5
       parent: 1
-  - uid: 4476
+  - uid: 4477
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-25.5
       parent: 1
-  - uid: 4477
+  - uid: 4478
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-20.5
       parent: 1
-  - uid: 4478
+  - uid: 4479
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-30.5
       parent: 1
-  - uid: 4479
+  - uid: 4480
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-35.5
       parent: 1
-  - uid: 4480
+  - uid: 4481
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-29.5
       parent: 1
-  - uid: 4481
+  - uid: 4482
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-29.5
       parent: 1
-  - uid: 4482
+  - uid: 4483
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-29.5
       parent: 1
-  - uid: 4483
+  - uid: 4484
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,-17.5
       parent: 1
-  - uid: 4484
+  - uid: 4485
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,-16.5
       parent: 1
-  - uid: 4485
+  - uid: 4486
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-29.5
       parent: 1
-  - uid: 4486
+  - uid: 4487
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-29.5
       parent: 1
-  - uid: 4487
+  - uid: 4488
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-33.5
       parent: 1
-  - uid: 4488
+  - uid: 4489
     components:
     - type: Transform
       pos: -13.5,32.5
       parent: 1
-  - uid: 4489
+  - uid: 4490
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-21.5
       parent: 1
-  - uid: 4490
+  - uid: 4491
     components:
     - type: Transform
       pos: 3.5,-19.5
       parent: 1
-  - uid: 4491
+  - uid: 4492
     components:
     - type: Transform
       pos: -0.5,-19.5
       parent: 1
-  - uid: 4492
+  - uid: 4493
     components:
     - type: Transform
       pos: 7.5,-19.5
       parent: 1
-  - uid: 4493
-    components:
-    - type: Transform
-      pos: 11.5,-19.5
-      parent: 1
   - uid: 4494
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,-25.5
+      pos: 11.5,-19.5
       parent: 1
   - uid: 4495
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 14.5,-30.5
+      pos: 14.5,-25.5
       parent: 1
   - uid: 4496
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 14.5,-35.5
+      pos: 14.5,-30.5
       parent: 1
   - uid: 4497
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 14.5,-20.5
+      pos: 14.5,-35.5
       parent: 1
   - uid: 4498
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-20.5
+      parent: 1
+  - uid: 4499
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-12.5
       parent: 1
-  - uid: 4499
+  - uid: 4500
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,14.5
       parent: 1
-  - uid: 4500
+  - uid: 4501
     components:
     - type: Transform
       pos: 8.5,-26.5
       parent: 1
-  - uid: 4501
+  - uid: 4502
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-24.5
       parent: 1
-  - uid: 4502
+  - uid: 4503
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-24.5
       parent: 1
-  - uid: 4503
+  - uid: 4504
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-26.5
       parent: 1
-  - uid: 4504
+  - uid: 4505
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-21.5
       parent: 1
-  - uid: 4505
+  - uid: 4506
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-21.5
       parent: 1
-  - uid: 4506
+  - uid: 4507
     components:
     - type: Transform
       pos: 2.5,-24.5
       parent: 1
-  - uid: 4507
+  - uid: 4508
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,59.5
       parent: 1
-  - uid: 4508
+  - uid: 4509
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,59.5
       parent: 1
-  - uid: 4509
+  - uid: 4510
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,55.5
       parent: 1
-  - uid: 4510
+  - uid: 4511
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,55.5
       parent: 1
-  - uid: 4511
+  - uid: 4512
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,52.5
       parent: 1
-  - uid: 4512
+  - uid: 4513
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,52.5
       parent: 1
-  - uid: 4513
+  - uid: 4514
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,52.5
       parent: 1
-  - uid: 4514
+  - uid: 4515
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,46.5
       parent: 1
-  - uid: 4515
+  - uid: 4516
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,47.5
       parent: 1
-  - uid: 4516
+  - uid: 4517
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,64.5
       parent: 1
-  - uid: 4517
+  - uid: 4518
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,64.5
       parent: 1
-  - uid: 4518
+  - uid: 4519
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,68.5
       parent: 1
-  - uid: 4519
+  - uid: 4520
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,68.5
       parent: 1
-  - uid: 4520
+  - uid: 4521
     components:
     - type: Transform
       pos: 2.5,65.5
       parent: 1
-  - uid: 4521
+  - uid: 4522
     components:
     - type: Transform
       pos: -5.5,65.5
       parent: 1
-  - uid: 4522
+  - uid: 4523
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,70.5
       parent: 1
-  - uid: 4523
+  - uid: 4524
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,70.5
       parent: 1
-  - uid: 4524
+  - uid: 4525
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-9
       parent: 1
-  - uid: 4525
+  - uid: 4526
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-1.5
       parent: 1
-  - uid: 4526
+  - uid: 4527
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,-1.5
       parent: 1
-  - uid: 4527
+  - uid: 4528
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-1.5
       parent: 1
-  - uid: 4528
+  - uid: 4529
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-1.5
       parent: 1
-  - uid: 4529
+  - uid: 4530
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-1.5
       parent: 1
-  - uid: 4530
+  - uid: 4531
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-23.5
       parent: 1
-  - uid: 4531
+  - uid: 4532
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,-11.5
       parent: 1
-  - uid: 4532
+  - uid: 4533
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,19.5
       parent: 1
-  - uid: 4533
-    components:
-    - type: Transform
-      pos: 12.5,32.5
-      parent: 1
   - uid: 4534
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,29.5
+      pos: 12.5,32.5
       parent: 1
   - uid: 4535
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -16.5,31.5
+      pos: -20.5,29.5
       parent: 1
   - uid: 4536
     components:
     - type: Transform
-      pos: -9.5,32.5
+      rot: 1.5707963267948966 rad
+      pos: -16.5,31.5
       parent: 1
   - uid: 4537
+    components:
+    - type: Transform
+      pos: -9.5,32.5
+      parent: 1
+  - uid: 4538
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,24.5
       parent: 1
-  - uid: 4538
+  - uid: 4539
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,28.5
       parent: 1
-  - uid: 4539
-    components:
-    - type: Transform
-      pos: 18.5,30.5
-      parent: 1
   - uid: 4540
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,31.5
+      pos: 18.5,30.5
       parent: 1
   - uid: 4541
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 19.5,29.5
+      pos: 15.5,31.5
       parent: 1
   - uid: 4542
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,29.5
+      parent: 1
+  - uid: 4543
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,14.5
       parent: 1
-  - uid: 4543
+  - uid: 4544
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,30.5
       parent: 1
-  - uid: 4544
+  - uid: 4545
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,14.5
       parent: 1
-  - uid: 4545
+  - uid: 4546
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,30.5
       parent: 1
-  - uid: 4546
+  - uid: 4547
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,24.5
       parent: 1
-  - uid: 4547
+  - uid: 4548
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,30.5
       parent: 1
-  - uid: 4548
+  - uid: 4549
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,30.5
       parent: 1
-  - uid: 4549
+  - uid: 4550
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,30.5
       parent: 1
-  - uid: 4550
+  - uid: 4551
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-45.5
       parent: 1
-  - uid: 4551
+  - uid: 4552
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-54.5
       parent: 1
-  - uid: 4552
+  - uid: 4553
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-54.5
       parent: 1
-  - uid: 4553
+  - uid: 4554
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-54.5
       parent: 1
-  - uid: 4554
+  - uid: 4555
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-54.5
       parent: 1
-  - uid: 4555
+  - uid: 4556
     components:
     - type: Transform
       pos: -24.5,10.5
       parent: 1
-  - uid: 4556
+  - uid: 4557
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,8.5
       parent: 1
-  - uid: 4557
+  - uid: 4558
     components:
     - type: Transform
       pos: -29.5,10.5
       parent: 1
-  - uid: 4558
+  - uid: 4559
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,8.5
       parent: 1
-  - uid: 4559
+  - uid: 4560
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,47.5
       parent: 1
-  - uid: 4560
+  - uid: 4561
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-47.5
       parent: 1
-  - uid: 4561
+  - uid: 4562
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-42.5
       parent: 1
-  - uid: 4562
+  - uid: 4563
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-48.5
       parent: 1
-  - uid: 4563
+  - uid: 4564
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-54.5
       parent: 1
-  - uid: 4564
+  - uid: 4565
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-50.5
       parent: 1
-  - uid: 4565
+  - uid: 4566
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,16.5
       parent: 1
-  - uid: 4566
+  - uid: 4567
     components:
     - type: Transform
       pos: -31.5,13.5
       parent: 1
-  - uid: 4567
+  - uid: 4568
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,25.5
       parent: 1
-  - uid: 4568
+  - uid: 4569
     components:
     - type: Transform
       pos: -31.5,17.5
       parent: 1
-  - uid: 4569
+  - uid: 4570
     components:
     - type: Transform
       pos: -27.5,21.5
       parent: 1
-  - uid: 4570
+  - uid: 4571
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,4.5
       parent: 1
-  - uid: 4571
+  - uid: 4572
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,11.5
       parent: 1
-  - uid: 4572
+  - uid: 4573
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,12.5
       parent: 1
-  - uid: 4573
+  - uid: 4574
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,19.5
       parent: 1
-  - uid: 4574
+  - uid: 4575
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,8.5
       parent: 1
-  - uid: 4575
+  - uid: 4576
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,14.5
       parent: 1
-  - uid: 4576
+  - uid: 4577
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,3.5
       parent: 1
-  - uid: 4577
-    components:
-    - type: Transform
-      pos: -22.5,0.5
-      parent: 1
   - uid: 4578
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,3.5
+      pos: -22.5,0.5
       parent: 1
   - uid: 4579
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -30.5,6.5
+      pos: -29.5,3.5
       parent: 1
   - uid: 4580
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,39.5
+      rot: -1.5707963267948966 rad
+      pos: -30.5,6.5
       parent: 1
   - uid: 4581
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -20.5,44.5
+      pos: -20.5,39.5
       parent: 1
   - uid: 4582
     components:
     - type: Transform
-      pos: -19.5,50.5
+      rot: 1.5707963267948966 rad
+      pos: -20.5,44.5
       parent: 1
   - uid: 4583
+    components:
+    - type: Transform
+      pos: -19.5,50.5
+      parent: 1
+  - uid: 4584
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,33.5
       parent: 1
-  - uid: 4584
+  - uid: 4585
     components:
     - type: Transform
       pos: 18.5,50.5
       parent: 1
-  - uid: 4585
+  - uid: 4586
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,57.5
       parent: 1
-  - uid: 4586
+  - uid: 4587
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,57.5
       parent: 1
-  - uid: 4587
+  - uid: 4588
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,52.5
       parent: 1
-  - uid: 4588
+  - uid: 4589
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,47.5
       parent: 1
-  - uid: 4589
+  - uid: 4590
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,14.5
       parent: 1
-  - uid: 4590
+  - uid: 4591
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,52.5
       parent: 1
-  - uid: 4591
+  - uid: 4592
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-53.5
       parent: 1
-  - uid: 4592
+  - uid: 4593
     components:
     - type: Transform
       pos: -15.5,-56.5
       parent: 1
-  - uid: 4593
-    components:
-    - type: Transform
-      pos: 14.5,-56.5
-      parent: 1
   - uid: 4594
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-53.5
+      pos: 14.5,-56.5
       parent: 1
   - uid: 4595
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 23.5,19.5
+      pos: 13.5,-53.5
       parent: 1
   - uid: 4596
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 23.5,24.5
+      pos: 23.5,19.5
       parent: 1
   - uid: 4597
     components:
     - type: Transform
-      pos: 25.5,10.5
+      rot: -1.5707963267948966 rad
+      pos: 23.5,24.5
       parent: 1
   - uid: 4598
+    components:
+    - type: Transform
+      pos: 25.5,10.5
+      parent: 1
+  - uid: 4599
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.5,14.5
       parent: 1
-  - uid: 4599
+  - uid: 4600
     components:
     - type: Transform
       pos: 29.5,10.5
       parent: 1
-  - uid: 4600
-    components:
-    - type: Transform
-      pos: 31.5,9.5
-      parent: 1
   - uid: 4601
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 30.5,19.5
+      pos: 31.5,9.5
       parent: 1
   - uid: 4602
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 27.5,23.5
+      pos: 30.5,19.5
       parent: 1
   - uid: 4603
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 27.5,23.5
+      parent: 1
+  - uid: 4604
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,47.5
       parent: 1
-  - uid: 4604
+  - uid: 4605
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,46.5
       parent: 1
-  - uid: 4605
+  - uid: 4606
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,37
       parent: 1
-  - uid: 4606
+  - uid: 4607
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,47.5
       parent: 1
-  - uid: 4607
+  - uid: 4608
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,47
       parent: 1
-  - uid: 4608
+  - uid: 4609
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4,-53.5
       parent: 1
-  - uid: 4609
+  - uid: 4610
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10,-53.5
       parent: 1
-  - uid: 4610
+  - uid: 4611
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-53.5
       parent: 1
-  - uid: 4611
+  - uid: 4612
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-51.5
       parent: 1
-  - uid: 4612
+  - uid: 4613
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-43.5
       parent: 1
-  - uid: 4613
+  - uid: 4614
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-39.5
       parent: 1
-  - uid: 4614
+  - uid: 4615
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-36.5
       parent: 1
-  - uid: 4615
+  - uid: 4616
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-36.5
       parent: 1
-  - uid: 4616
+  - uid: 4617
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-37.5
       parent: 1
-  - uid: 4617
+  - uid: 4618
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-38.5
       parent: 1
+  - uid: 4619
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,42.5
+      parent: 1
+  - uid: 4620
+    components:
+    - type: Transform
+      pos: 8.5,38.5
+      parent: 1
+  - uid: 4621
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,38.5
+      parent: 1
 - proto: RMCLightFixtureDouble
   entities:
-  - uid: 4618
+  - uid: 4622
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,-60.5
       parent: 1
-  - uid: 4619
+  - uid: 4623
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,-65.5
       parent: 1
-  - uid: 4620
+  - uid: 4624
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-65.5
       parent: 1
-  - uid: 4621
+  - uid: 4625
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-60.5
       parent: 1
-  - uid: 4622
-    components:
-    - type: Transform
-      pos: -11.5,-59.5
-      parent: 1
-  - uid: 4623
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-63.5
-      parent: 1
-  - uid: 4624
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-60.5
-      parent: 1
-  - uid: 4625
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-60.5
-      parent: 1
   - uid: 4626
     components:
     - type: Transform
-      pos: 5.5,-58.5
+      pos: -11.5,-59.5
       parent: 1
   - uid: 4627
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 9.5,-62.5
+      pos: 4.5,-63.5
       parent: 1
   - uid: 4628
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-60.5
+      parent: 1
+  - uid: 4629
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-60.5
+      parent: 1
+  - uid: 4630
+    components:
+    - type: Transform
+      pos: 5.5,-58.5
+      parent: 1
+  - uid: 4631
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-62.5
+      parent: 1
+  - uid: 4632
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-64.5
       parent: 1
-  - uid: 4629
+  - uid: 4633
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-65.5
       parent: 1
-  - uid: 4630
+  - uid: 4634
     components:
     - type: Transform
       pos: 3.5,-68.5
       parent: 1
-  - uid: 4631
+  - uid: 4635
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-68.5
       parent: 1
-  - uid: 4632
+  - uid: 4636
     components:
     - type: Transform
       pos: -9.5,-68.5
       parent: 1
-  - uid: 4633
+  - uid: 4637
     components:
     - type: Transform
       pos: -1.5,-68.5
       parent: 1
 - proto: RMCLightFixtureSmall
   entities:
-  - uid: 4634
+  - uid: 4638
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-60.5
       parent: 1
-  - uid: 4635
+  - uid: 4639
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-59.5
       parent: 1
-  - uid: 4636
+  - uid: 4640
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-60.5
       parent: 1
-  - uid: 4637
+  - uid: 4641
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-65.5
       parent: 1
-  - uid: 4638
+  - uid: 4642
     components:
     - type: Transform
       pos: -2.5,-64.5
       parent: 1
-  - uid: 4639
+  - uid: 4643
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-59.5
       parent: 1
-  - uid: 4640
+  - uid: 4644
     components:
     - type: Transform
       pos: -8.5,-64.5
       parent: 1
-  - uid: 4641
+  - uid: 4645
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -33198,7 +33212,7 @@ entities:
       parent: 1
 - proto: RMCLockerFridgeDry
   entities:
-  - uid: 4642
+  - uid: 4646
     components:
     - type: Transform
       pos: -6.5,-21.5
@@ -33207,7 +33221,7 @@ entities:
       locked: False
 - proto: RMCLockerFridgeGroceries
   entities:
-  - uid: 4643
+  - uid: 4647
     components:
     - type: Transform
       pos: -12.5,-24.5
@@ -33216,7 +33230,7 @@ entities:
       locked: False
 - proto: RMCLockerFridgeMeat
   entities:
-  - uid: 4644
+  - uid: 4648
     components:
     - type: Transform
       pos: -11.5,-24.5
@@ -33225,35 +33239,49 @@ entities:
       locked: False
 - proto: RMCLockerGunRed
   entities:
-  - uid: 4645
+  - uid: 4649
     components:
     - type: Transform
       pos: 10.5,-29.5
       parent: 1
     - type: Lock
       locked: False
-  - uid: 4649
+  - uid: 4651
+    components:
+    - type: Transform
+      pos: 9.5,-29.5
+      parent: 1
+    - type: Lock
+      locked: False
+  - uid: 4653
     components:
     - type: Transform
       pos: 11.5,-29.5
       parent: 1
     - type: Lock
       locked: False
-  - uid: 4651
+  - uid: 4654
+    components:
+    - type: Transform
+      pos: 8.5,-29.5
+      parent: 1
+    - type: Lock
+      locked: False
+  - uid: 4655
     components:
     - type: Transform
       pos: 11.5,-51.5
       parent: 1
     - type: Lock
       locked: False
-  - uid: 4652
+  - uid: 4656
     components:
     - type: Transform
       pos: 16.5,3.5
       parent: 1
     - type: Lock
       locked: False
-  - uid: 4653
+  - uid: 4657
     components:
     - type: Transform
       pos: -17.5,3.5
@@ -33262,406 +33290,446 @@ entities:
       locked: False
 - proto: RMCLockerSecureSafe
   entities:
-  - uid: 4654
+  - uid: 4658
     components:
     - type: Transform
       pos: -17.5,45.5
       parent: 1
-    - type: Lock
-      locked: False
-  - uid: 4655
+  - uid: 4659
     components:
     - type: Transform
       pos: -12.5,45.5
       parent: 1
 - proto: RMCLZFloodlight
   entities:
-  - uid: 4656
-    components:
-    - type: Transform
-      pos: 14.5,56.5
-      parent: 1
-  - uid: 4657
-    components:
-    - type: Transform
-      pos: 33.5,3.5
-      parent: 1
-  - uid: 4658
-    components:
-    - type: Transform
-      pos: -32.5,-1.5
-      parent: 1
-  - uid: 4659
-    components:
-    - type: Transform
-      pos: -36.5,2.5
-      parent: 1
   - uid: 4660
     components:
     - type: Transform
-      pos: 31.5,-0.5
+      rot: -1.5707963267948966 rad
+      pos: 24.5,49.5
       parent: 1
   - uid: 4661
     components:
     - type: Transform
-      pos: 35.5,8.5
+      pos: 14.5,56.5
       parent: 1
   - uid: 4662
     components:
     - type: Transform
-      pos: 20.5,-56.5
+      pos: 33.5,3.5
       parent: 1
   - uid: 4663
     components:
     - type: Transform
-      pos: 7.5,26.5
+      pos: -32.5,-1.5
       parent: 1
   - uid: 4664
     components:
     - type: Transform
-      pos: 1.5,4.5
+      pos: -36.5,2.5
       parent: 1
   - uid: 4665
     components:
     - type: Transform
-      pos: -25.5,44.5
+      pos: 31.5,-0.5
       parent: 1
   - uid: 4666
     components:
     - type: Transform
-      pos: -25.5,49.5
+      pos: 35.5,8.5
       parent: 1
   - uid: 4667
+    components:
+    - type: Transform
+      pos: 20.5,-56.5
+      parent: 1
+  - uid: 4668
+    components:
+    - type: Transform
+      pos: 7.5,26.5
+      parent: 1
+  - uid: 4669
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 4670
+    components:
+    - type: Transform
+      pos: -25.5,44.5
+      parent: 1
+  - uid: 4671
+    components:
+    - type: Transform
+      pos: -25.5,49.5
+      parent: 1
+  - uid: 4672
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,-16.5
       parent: 1
-  - uid: 4668
+  - uid: 4673
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,-11.5
       parent: 1
-  - uid: 4669
+  - uid: 4674
     components:
     - type: Transform
       pos: -25.5,29.5
       parent: 1
-  - uid: 4670
+  - uid: 4675
     components:
     - type: Transform
       pos: -25.5,34.5
       parent: 1
-  - uid: 4671
+  - uid: 4676
     components:
     - type: Transform
       pos: -25.5,39.5
       parent: 1
-  - uid: 4672
+  - uid: 4677
     components:
     - type: Transform
       pos: -14.5,19.5
       parent: 1
-  - uid: 4673
+  - uid: 4678
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
-  - uid: 4674
+  - uid: 4679
     components:
     - type: Transform
       pos: -8.5,26.5
       parent: 1
-  - uid: 4675
+  - uid: 4680
     components:
     - type: Transform
       pos: -14.5,26.5
       parent: 1
-  - uid: 4676
+  - uid: 4681
     components:
     - type: Transform
       pos: -2.5,26.5
       parent: 1
-  - uid: 4677
+  - uid: 4682
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,57.5
       parent: 1
-  - uid: 4678
+  - uid: 4683
     components:
     - type: Transform
       pos: 13.5,-64.5
       parent: 1
-  - uid: 4679
+  - uid: 4684
     components:
     - type: Transform
       pos: -8.5,4.5
       parent: 1
-  - uid: 4680
+  - uid: 4685
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 1
-  - uid: 4681
+  - uid: 4686
     components:
     - type: Transform
       pos: -14.5,11.5
       parent: 1
-  - uid: 4682
+  - uid: 4687
     components:
     - type: Transform
       pos: -23.5,56.5
       parent: 1
-  - uid: 4683
+  - uid: 4688
     components:
     - type: Transform
       pos: 13.5,19.5
       parent: 1
-  - uid: 4684
+  - uid: 4689
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,-45.5
       parent: 1
-  - uid: 4685
+  - uid: 4690
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,-30.5
       parent: 1
-  - uid: 4686
+  - uid: 4691
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,-35.5
       parent: 1
-  - uid: 4687
+  - uid: 4692
     components:
     - type: Transform
       pos: 19.5,-30.5
       parent: 1
-  - uid: 4688
+  - uid: 4693
     components:
     - type: Transform
       pos: 19.5,-35.5
       parent: 1
-  - uid: 4689
+  - uid: 4694
     components:
     - type: Transform
       pos: 19.5,-40.5
       parent: 1
-  - uid: 4690
-    components:
-    - type: Transform
-      pos: -20.5,-40.5
-      parent: 1
-  - uid: 4691
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,74.5
-      parent: 1
-  - uid: 4692
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,74.5
-      parent: 1
-  - uid: 4693
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,68.5
-      parent: 1
-  - uid: 4694
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,68.5
-      parent: 1
   - uid: 4695
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,64.5
+      pos: -20.5,-40.5
       parent: 1
   - uid: 4696
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -9.5,59.5
+      pos: -5.5,74.5
       parent: 1
   - uid: 4697
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,64.5
+      pos: 2.5,74.5
       parent: 1
   - uid: 4698
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,59.5
+      pos: -9.5,68.5
       parent: 1
   - uid: 4699
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,72.5
+      pos: 6.5,68.5
       parent: 1
   - uid: 4700
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -8.5,72.5
+      pos: -9.5,64.5
       parent: 1
   - uid: 4701
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -12.5,57.5
+      pos: -9.5,59.5
       parent: 1
   - uid: 4702
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -17.5,57.5
+      pos: 6.5,64.5
       parent: 1
   - uid: 4703
     components:
     - type: Transform
-      pos: -2.5,19.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,59.5
       parent: 1
   - uid: 4704
     components:
     - type: Transform
-      pos: -14.5,4.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,72.5
       parent: 1
   - uid: 4705
     components:
     - type: Transform
-      pos: 7.5,4.5
+      rot: -1.5707963267948966 rad
+      pos: -8.5,72.5
       parent: 1
   - uid: 4706
     components:
     - type: Transform
-      pos: 13.5,4.5
+      rot: -1.5707963267948966 rad
+      pos: -12.5,57.5
       parent: 1
   - uid: 4707
     components:
     - type: Transform
-      pos: 1.5,11.5
+      rot: -1.5707963267948966 rad
+      pos: -17.5,57.5
       parent: 1
   - uid: 4708
     components:
     - type: Transform
-      pos: 13.5,11.5
+      pos: -2.5,19.5
       parent: 1
   - uid: 4709
     components:
     - type: Transform
-      pos: 13.5,26.5
+      pos: -14.5,4.5
       parent: 1
   - uid: 4710
     components:
     - type: Transform
-      pos: 1.5,19.5
+      pos: 7.5,4.5
       parent: 1
   - uid: 4711
     components:
     - type: Transform
-      pos: 1.5,26.5
+      pos: 13.5,4.5
       parent: 1
   - uid: 4712
     components:
     - type: Transform
-      pos: -29.5,28.5
+      pos: 1.5,11.5
       parent: 1
   - uid: 4713
     components:
     - type: Transform
-      pos: -32.5,24.5
+      pos: 13.5,11.5
       parent: 1
   - uid: 4714
     components:
     - type: Transform
-      pos: -36.5,20.5
+      pos: 13.5,26.5
       parent: 1
   - uid: 4715
     components:
     - type: Transform
-      pos: -36.5,16.5
+      pos: 1.5,19.5
       parent: 1
   - uid: 4716
     components:
     - type: Transform
-      pos: -36.5,12.5
+      pos: 1.5,26.5
       parent: 1
   - uid: 4717
     components:
     - type: Transform
-      pos: 21.5,56.5
+      pos: -29.5,28.5
       parent: 1
   - uid: 4718
     components:
     - type: Transform
-      pos: 24.5,-11.5
+      pos: -32.5,24.5
       parent: 1
   - uid: 4719
     components:
     - type: Transform
-      pos: 24.5,-16.5
+      pos: -36.5,20.5
       parent: 1
   - uid: 4720
     components:
     - type: Transform
-      pos: 25.5,-8.5
+      pos: -36.5,16.5
       parent: 1
   - uid: 4721
     components:
     - type: Transform
-      pos: -26.5,-8.5
+      pos: -36.5,12.5
       parent: 1
   - uid: 4722
     components:
     - type: Transform
-      pos: -20.5,-45.5
+      pos: 21.5,56.5
       parent: 1
   - uid: 4723
     components:
     - type: Transform
-      pos: 19.5,-51.5
+      pos: 24.5,-11.5
       parent: 1
   - uid: 4724
     components:
     - type: Transform
-      pos: 12.5,-69.5
+      pos: 24.5,-16.5
       parent: 1
   - uid: 4725
     components:
     - type: Transform
-      pos: 9.5,-71.5
+      pos: 25.5,-8.5
       parent: 1
   - uid: 4726
     components:
     - type: Transform
-      pos: 4.5,-71.5
+      pos: -26.5,-8.5
       parent: 1
   - uid: 4727
     components:
     - type: Transform
-      pos: -20.5,-51.5
+      pos: -20.5,-45.5
       parent: 1
   - uid: 4728
     components:
     - type: Transform
+      pos: 19.5,-51.5
+      parent: 1
+  - uid: 4729
+    components:
+    - type: Transform
+      pos: 12.5,-69.5
+      parent: 1
+  - uid: 4730
+    components:
+    - type: Transform
+      pos: 9.5,-71.5
+      parent: 1
+  - uid: 4731
+    components:
+    - type: Transform
+      pos: 4.5,-71.5
+      parent: 1
+  - uid: 4732
+    components:
+    - type: Transform
+      pos: -20.5,-51.5
+      parent: 1
+  - uid: 4733
+    components:
+    - type: Transform
       pos: -21.5,-56.5
+      parent: 1
+  - uid: 4734
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -25.5,54.5
+      parent: 1
+  - uid: 4735
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,54.5
+      parent: 1
+  - uid: 4736
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,44.5
+      parent: 1
+  - uid: 4737
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,39.5
+      parent: 1
+  - uid: 4738
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,34.5
+      parent: 1
+  - uid: 4739
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,29.5
       parent: 1
 - proto: RMCMagazineBootsN54
   entities:
-  - uid: 4729
+  - uid: 4740
     components:
     - type: MetaData
       desc: The only official USCM magazine, the headline reads 'AEGIS strikes back against litigants in M54C-MK2 self cleaning case'.
@@ -33671,18 +33739,18 @@ entities:
       parent: 1
 - proto: RMCMechPowerLoader
   entities:
-  - uid: 72
+  - uid: 4741
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -12.306686,41.186146
+      pos: -7.538216,40.36347
       parent: 1
-  - uid: 4730
+  - uid: 4742
     components:
     - type: Transform
       pos: 14.941125,42.984573
       parent: 1
-  - uid: 4731
+  - uid: 4743
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -33690,99 +33758,99 @@ entities:
       parent: 1
 - proto: RMCMedilathe
   entities:
-  - uid: 4732
+  - uid: 4744
     components:
     - type: Transform
       pos: -26.5,24.5
       parent: 1
 - proto: RMCMirror
   entities:
-  - uid: 4733
+  - uid: 4745
     components:
     - type: Transform
       pos: -2.5,44.5
       parent: 1
-  - uid: 4734
+  - uid: 4746
     components:
     - type: Transform
       pos: 1.5,-40.5
       parent: 1
-  - uid: 4735
+  - uid: 4747
     components:
     - type: Transform
       pos: 7.5,-40.5
       parent: 1
-  - uid: 4736
+  - uid: 4748
     components:
     - type: Transform
       pos: 4.5,-40.5
       parent: 1
-  - uid: 4737
+  - uid: 4749
     components:
     - type: Transform
       pos: 10.5,-40.5
       parent: 1
-  - uid: 4738
+  - uid: 4750
     components:
     - type: Transform
       pos: -32.5,16.5
       parent: 1
-  - uid: 4739
+  - uid: 4751
     components:
     - type: Transform
       pos: -32.5,20.5
       parent: 1
-  - uid: 4740
+  - uid: 4752
     components:
     - type: Transform
       pos: 10.5,49.5
       parent: 1
 - proto: RMCMultiMonitorBig
   entities:
-  - uid: 4741
+  - uid: 4753
     components:
     - type: Transform
       pos: 2.5,-28.5
       parent: 1
 - proto: RMCMultiMonitorMedium
   entities:
-  - uid: 4742
+  - uid: 4754
     components:
     - type: Transform
       pos: 3.5,-28.5
       parent: 1
 - proto: RMCMultiMonitorSmall
   entities:
-  - uid: 4743
+  - uid: 4755
     components:
     - type: Transform
       pos: 1.5,-28.5
       parent: 1
 - proto: RMCNutriCoVendor
   entities:
-  - uid: 4744
+  - uid: 4756
     components:
     - type: Transform
       pos: -2.5,-26.5
       parent: 1
-  - uid: 4745
+  - uid: 4757
     components:
     - type: Transform
       pos: -0.5,-26.5
       parent: 1
-  - uid: 4746
+  - uid: 4758
     components:
     - type: Transform
       pos: -10.5,-26.5
       parent: 1
-  - uid: 4747
+  - uid: 4759
     components:
     - type: Transform
       pos: -12.5,-26.5
       parent: 1
 - proto: RMCOrbitalCannonCable
   entities:
-  - uid: 4748
+  - uid: 4760
     components:
     - type: Transform
       anchored: False
@@ -33790,150 +33858,150 @@ entities:
       parent: 1
 - proto: RMCOuterClothingExternalWebbingBlack
   entities:
-  - uid: 4749
+  - uid: 4761
     components:
     - type: Transform
       pos: 5.249924,-27.242516
       parent: 1
-  - uid: 4750
+  - uid: 4762
     components:
     - type: Transform
       pos: 5.263813,-27.63835
       parent: 1
-  - uid: 4751
+  - uid: 4763
     components:
     - type: Transform
       pos: 5.652702,-27.652239
       parent: 1
-  - uid: 4752
+  - uid: 4764
     components:
     - type: Transform
       pos: 5.638813,-27.24946
       parent: 1
 - proto: RMCPhotocopier
   entities:
-  - uid: 4753
+  - uid: 4765
     components:
     - type: Transform
       pos: -9.5,48.5
       parent: 1
-  - uid: 4754
+  - uid: 4766
     components:
     - type: Transform
       pos: -14.5,48.5
       parent: 1
-  - uid: 4755
+  - uid: 4767
     components:
     - type: Transform
       pos: -0.5,-51.5
       parent: 1
-  - uid: 4756
+  - uid: 4768
     components:
     - type: Transform
       pos: 16.5,45.5
       parent: 1
 - proto: RMCPhotocopierSmallHitbox
   entities:
-  - uid: 4757
+  - uid: 4769
     components:
     - type: Transform
       pos: 1.5,69.5
       parent: 1
 - proto: RMCPlatformCornerSmall
   entities:
-  - uid: 4758
+  - uid: 4770
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,42.5
       parent: 1
-  - uid: 4759
-    components:
-    - type: Transform
-      pos: 13.5,36.5
-      parent: 1
-  - uid: 4760
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,36.5
-      parent: 1
-  - uid: 4761
-    components:
-    - type: Transform
-      pos: 13.5,42.5
-      parent: 1
-  - uid: 4762
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-40.5
-      parent: 1
-  - uid: 4763
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-39.5
-      parent: 1
-  - uid: 4764
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,38.5
-      parent: 1
-  - uid: 4765
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-49.5
-      parent: 1
-  - uid: 4766
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-41.5
-      parent: 1
-  - uid: 4767
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,38.5
-      parent: 1
-  - uid: 4768
-    components:
-    - type: Transform
-      pos: -8.5,42.5
-      parent: 1
-  - uid: 4769
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -14.5,38.5
-      parent: 1
-  - uid: 4770
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-50.5
-      parent: 1
   - uid: 4771
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-10.5
+      pos: 13.5,36.5
       parent: 1
   - uid: 4772
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -13.5,-10.5
+      pos: 16.5,36.5
       parent: 1
   - uid: 4773
     components:
     - type: Transform
-      pos: -15.5,-10.5
+      pos: 13.5,42.5
       parent: 1
   - uid: 4774
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-40.5
+      parent: 1
+  - uid: 4775
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-39.5
+      parent: 1
+  - uid: 4776
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,38.5
+      parent: 1
+  - uid: 4777
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-49.5
+      parent: 1
+  - uid: 4778
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-41.5
+      parent: 1
+  - uid: 4779
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,38.5
+      parent: 1
+  - uid: 4780
+    components:
+    - type: Transform
+      pos: -8.5,42.5
+      parent: 1
+  - uid: 4781
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -14.5,38.5
+      parent: 1
+  - uid: 4782
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-50.5
+      parent: 1
+  - uid: 4783
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-10.5
+      parent: 1
+  - uid: 4784
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,-10.5
+      parent: 1
+  - uid: 4785
+    components:
+    - type: Transform
+      pos: -15.5,-10.5
+      parent: 1
+  - uid: 4786
     components:
     - type: Transform
       anchored: False
@@ -33941,65 +34009,65 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Dynamic
-  - uid: 4775
+  - uid: 4787
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,62.5
       parent: 1
-  - uid: 4776
+  - uid: 4788
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,62.5
       parent: 1
-  - uid: 4777
+  - uid: 4789
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,56.5
       parent: 1
-  - uid: 4778
+  - uid: 4790
     components:
     - type: Transform
       pos: 0.5,56.5
       parent: 1
-  - uid: 4779
+  - uid: 4791
     components:
     - type: Transform
       pos: 0.5,57.5
       parent: 1
-  - uid: 4780
+  - uid: 4792
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,66.5
       parent: 1
-  - uid: 4781
+  - uid: 4793
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,66.5
       parent: 1
-  - uid: 4782
+  - uid: 4794
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,47.5
       parent: 1
-  - uid: 4783
+  - uid: 4795
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,48.5
       parent: 1
-  - uid: 4784
+  - uid: 4796
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,38.5
       parent: 1
-  - uid: 4785
+  - uid: 4797
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -34007,2518 +34075,2518 @@ entities:
       parent: 1
 - proto: RMCPlatformHybrisaThree
   entities:
-  - uid: 4786
+  - uid: 4798
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,1.5
       parent: 1
-  - uid: 4787
+  - uid: 4799
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,2.5
       parent: 1
-  - uid: 4788
+  - uid: 4800
     components:
     - type: Transform
       pos: 27.5,0.5
       parent: 1
-  - uid: 4789
+  - uid: 4801
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,3.5
       parent: 1
-  - uid: 4790
+  - uid: 4802
     components:
     - type: Transform
       pos: 29.5,4.5
       parent: 1
-  - uid: 4791
+  - uid: 4803
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,8.5
       parent: 1
-  - uid: 4792
+  - uid: 4804
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,8.5
       parent: 1
-  - uid: 4793
+  - uid: 4805
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,6.5
       parent: 1
-  - uid: 4794
+  - uid: 4806
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,-15.5
       parent: 1
-  - uid: 4795
+  - uid: 4807
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-10.5
       parent: 1
-  - uid: 4796
+  - uid: 4808
     components:
     - type: Transform
       pos: 10.5,53.5
       parent: 1
-  - uid: 4797
+  - uid: 4809
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-14.5
       parent: 1
-  - uid: 4798
+  - uid: 4810
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,4.5
       parent: 1
-  - uid: 4799
+  - uid: 4811
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-15.5
       parent: 1
-  - uid: 4800
+  - uid: 4812
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,5.5
       parent: 1
-  - uid: 4801
+  - uid: 4813
     components:
     - type: Transform
       pos: -4.5,72.5
       parent: 1
-  - uid: 4802
+  - uid: 4814
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-42.5
       parent: 1
-  - uid: 4803
+  - uid: 4815
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-53.5
       parent: 1
-  - uid: 4804
+  - uid: 4816
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-47.5
       parent: 1
-  - uid: 4805
+  - uid: 4817
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-43.5
       parent: 1
-  - uid: 4806
+  - uid: 4818
     components:
     - type: Transform
       pos: 11.5,-16.5
       parent: 1
-  - uid: 4807
-    components:
-    - type: Transform
-      pos: 16.5,-16.5
-      parent: 1
-  - uid: 4808
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-55.5
-      parent: 1
-  - uid: 4809
-    components:
-    - type: Transform
-      pos: 3.5,0.5
-      parent: 1
-  - uid: 4810
-    components:
-    - type: Transform
-      pos: -3.5,0.5
-      parent: 1
-  - uid: 4811
-    components:
-    - type: Transform
-      pos: 11.5,0.5
-      parent: 1
-  - uid: 4812
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,4.5
-      parent: 1
-  - uid: 4813
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,-44.5
-      parent: 1
-  - uid: 4814
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-54.5
-      parent: 1
-  - uid: 4815
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,-41.5
-      parent: 1
-  - uid: 4816
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,-48.5
-      parent: 1
-  - uid: 4817
-    components:
-    - type: Transform
-      pos: 6.5,0.5
-      parent: 1
-  - uid: 4818
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,8.5
-      parent: 1
   - uid: 4819
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,6.5
+      pos: 16.5,-16.5
       parent: 1
   - uid: 4820
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -18.5,7.5
+      pos: 16.5,-55.5
       parent: 1
   - uid: 4821
     components:
     - type: Transform
-      pos: -17.5,5.5
+      pos: 3.5,0.5
       parent: 1
   - uid: 4822
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-12.5
+      pos: -3.5,0.5
       parent: 1
   - uid: 4823
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-7.5
+      pos: 11.5,0.5
       parent: 1
   - uid: 4824
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,17.5
+      rot: -1.5707963267948966 rad
+      pos: -15.5,4.5
       parent: 1
   - uid: 4825
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,16.5
+      pos: 13.5,-44.5
       parent: 1
   - uid: 4826
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,15.5
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-54.5
       parent: 1
   - uid: 4827
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,25.5
+      pos: 13.5,-41.5
       parent: 1
   - uid: 4828
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,6.5
+      pos: -17.5,-48.5
       parent: 1
   - uid: 4829
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,41.5
+      pos: 6.5,0.5
       parent: 1
   - uid: 4830
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,-14.5
+      rot: -1.5707963267948966 rad
+      pos: -18.5,8.5
       parent: 1
   - uid: 4831
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,-13.5
+      rot: -1.5707963267948966 rad
+      pos: -18.5,6.5
       parent: 1
   - uid: 4832
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -19.5,-3.5
+      pos: -18.5,7.5
       parent: 1
   - uid: 4833
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-1.5
+      pos: -17.5,5.5
       parent: 1
   - uid: 4834
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -19.5,-2.5
+      pos: -19.5,-12.5
       parent: 1
   - uid: 4835
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -19.5,-14.5
+      pos: -19.5,-7.5
       parent: 1
   - uid: 4836
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-15.5
+      rot: 1.5707963267948966 rad
+      pos: -22.5,17.5
       parent: 1
   - uid: 4837
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,35.5
+      pos: -22.5,16.5
       parent: 1
   - uid: 4838
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,32.5
+      pos: -22.5,15.5
       parent: 1
   - uid: 4839
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,5.5
+      pos: -22.5,25.5
       parent: 1
   - uid: 4840
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,30.5
+      pos: -22.5,6.5
       parent: 1
   - uid: 4841
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -19.5,38.5
+      pos: -19.5,41.5
       parent: 1
   - uid: 4842
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,52.5
+      pos: -22.5,-14.5
       parent: 1
   - uid: 4843
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,40.5
+      pos: -22.5,-13.5
       parent: 1
   - uid: 4844
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,38.5
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-3.5
       parent: 1
   - uid: 4845
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,46.5
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-1.5
       parent: 1
   - uid: 4846
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,48.5
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-2.5
       parent: 1
   - uid: 4847
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,47.5
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-14.5
       parent: 1
   - uid: 4848
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -18.5,26.5
+      pos: -19.5,-15.5
       parent: 1
   - uid: 4849
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-9.5
+      rot: 1.5707963267948966 rad
+      pos: -22.5,35.5
       parent: 1
   - uid: 4850
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-8.5
+      rot: 1.5707963267948966 rad
+      pos: -22.5,32.5
       parent: 1
   - uid: 4851
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-10.5
+      rot: 1.5707963267948966 rad
+      pos: -22.5,5.5
       parent: 1
   - uid: 4852
     components:
     - type: Transform
-      pos: 15.5,5.5
+      rot: 1.5707963267948966 rad
+      pos: -22.5,30.5
       parent: 1
   - uid: 4853
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,4.5
+      rot: -1.5707963267948966 rad
+      pos: -19.5,38.5
       parent: 1
   - uid: 4854
     components:
     - type: Transform
-      pos: 16.5,5.5
+      rot: 1.5707963267948966 rad
+      pos: -22.5,52.5
       parent: 1
   - uid: 4855
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,-8.5
+      pos: -22.5,40.5
       parent: 1
   - uid: 4856
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,-7.5
+      pos: -22.5,38.5
       parent: 1
   - uid: 4857
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,-9.5
+      pos: -22.5,46.5
       parent: 1
   - uid: 4858
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,-10.5
+      pos: -22.5,48.5
       parent: 1
   - uid: 4859
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -17.5,-39.5
+      pos: -22.5,47.5
       parent: 1
   - uid: 4860
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -18.5,26.5
+      parent: 1
+  - uid: 4861
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-9.5
+      parent: 1
+  - uid: 4862
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-8.5
+      parent: 1
+  - uid: 4863
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-10.5
+      parent: 1
+  - uid: 4864
+    components:
+    - type: Transform
+      pos: 15.5,5.5
+      parent: 1
+  - uid: 4865
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,4.5
+      parent: 1
+  - uid: 4866
+    components:
+    - type: Transform
+      pos: 16.5,5.5
+      parent: 1
+  - uid: 4867
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-8.5
+      parent: 1
+  - uid: 4868
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-7.5
+      parent: 1
+  - uid: 4869
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-9.5
+      parent: 1
+  - uid: 4870
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-10.5
+      parent: 1
+  - uid: 4871
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-39.5
+      parent: 1
+  - uid: 4872
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-42.5
       parent: 1
-  - uid: 4861
+  - uid: 4873
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-41.5
       parent: 1
-  - uid: 4862
+  - uid: 4874
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-43.5
       parent: 1
-  - uid: 4863
+  - uid: 4875
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-15.5
       parent: 1
-  - uid: 4864
+  - uid: 4876
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-49.5
       parent: 1
-  - uid: 4865
+  - uid: 4877
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 1
-  - uid: 4866
+  - uid: 4878
     components:
     - type: Transform
       pos: -1.5,-16.5
       parent: 1
-  - uid: 4867
+  - uid: 4879
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 1
-  - uid: 4868
+  - uid: 4880
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,15.5
       parent: 1
-  - uid: 4869
+  - uid: 4881
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,16.5
       parent: 1
-  - uid: 4870
+  - uid: 4882
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,18.5
       parent: 1
-  - uid: 4871
+  - uid: 4883
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,31.5
       parent: 1
-  - uid: 4872
+  - uid: 4884
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,30.5
       parent: 1
-  - uid: 4873
+  - uid: 4885
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,31.5
       parent: 1
-  - uid: 4874
+  - uid: 4886
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,30.5
       parent: 1
-  - uid: 4875
+  - uid: 4887
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-3.5
       parent: 1
-  - uid: 4876
+  - uid: 4888
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-5.5
       parent: 1
-  - uid: 4877
+  - uid: 4889
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-2.5
       parent: 1
-  - uid: 4878
+  - uid: 4890
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-4.5
       parent: 1
-  - uid: 4879
+  - uid: 4891
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,26.5
       parent: 1
-  - uid: 4880
+  - uid: 4892
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,27.5
       parent: 1
-  - uid: 4881
+  - uid: 4893
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,37.5
       parent: 1
-  - uid: 4882
+  - uid: 4894
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,36.5
       parent: 1
-  - uid: 4883
+  - uid: 4895
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-43.5
       parent: 1
-  - uid: 4884
+  - uid: 4896
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-42.5
       parent: 1
-  - uid: 4885
+  - uid: 4897
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-44.5
       parent: 1
-  - uid: 4886
+  - uid: 4898
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-1.5
       parent: 1
-  - uid: 4887
+  - uid: 4899
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-12.5
       parent: 1
-  - uid: 4888
+  - uid: 4900
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-13.5
       parent: 1
-  - uid: 4889
+  - uid: 4901
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-5.5
       parent: 1
-  - uid: 4890
+  - uid: 4902
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-4.5
       parent: 1
-  - uid: 4891
+  - uid: 4903
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,28.5
       parent: 1
-  - uid: 4892
+  - uid: 4904
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,40.5
       parent: 1
-  - uid: 4893
+  - uid: 4905
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,42.5
       parent: 1
-  - uid: 4894
+  - uid: 4906
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,30.5
       parent: 1
-  - uid: 4895
+  - uid: 4907
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,30.5
       parent: 1
-  - uid: 4896
+  - uid: 4908
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,30.5
       parent: 1
-  - uid: 4897
+  - uid: 4909
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,28.5
       parent: 1
-  - uid: 4898
+  - uid: 4910
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,48.5
       parent: 1
-  - uid: 4899
+  - uid: 4911
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,25.5
       parent: 1
-  - uid: 4900
+  - uid: 4912
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,28.5
       parent: 1
-  - uid: 4901
+  - uid: 4913
     components:
     - type: Transform
       pos: -16.5,5.5
       parent: 1
-  - uid: 4902
+  - uid: 4914
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,28.5
       parent: 1
-  - uid: 4903
+  - uid: 4915
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,30.5
       parent: 1
-  - uid: 4904
+  - uid: 4916
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,30.5
       parent: 1
-  - uid: 4905
+  - uid: 4917
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,28.5
       parent: 1
-  - uid: 4906
+  - uid: 4918
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,30.5
       parent: 1
-  - uid: 4907
+  - uid: 4919
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,28.5
       parent: 1
-  - uid: 4908
+  - uid: 4920
     components:
     - type: Transform
       pos: 13.5,0.5
       parent: 1
-  - uid: 4909
+  - uid: 4921
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,30.5
       parent: 1
-  - uid: 4910
+  - uid: 4922
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,30.5
       parent: 1
-  - uid: 4911
+  - uid: 4923
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,30.5
       parent: 1
-  - uid: 4912
+  - uid: 4924
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,30.5
       parent: 1
-  - uid: 4913
+  - uid: 4925
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,30.5
       parent: 1
-  - uid: 4914
+  - uid: 4926
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,37.5
       parent: 1
-  - uid: 4915
+  - uid: 4927
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,46.5
       parent: 1
-  - uid: 4916
+  - uid: 4928
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,47.5
       parent: 1
-  - uid: 4917
+  - uid: 4929
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,45.5
       parent: 1
-  - uid: 4918
+  - uid: 4930
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-39.5
       parent: 1
-  - uid: 4919
+  - uid: 4931
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-41.5
       parent: 1
-  - uid: 4920
+  - uid: 4932
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,36.5
       parent: 1
-  - uid: 4921
+  - uid: 4933
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,51.5
       parent: 1
-  - uid: 4922
+  - uid: 4934
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,50.5
       parent: 1
-  - uid: 4923
+  - uid: 4935
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,45.5
       parent: 1
-  - uid: 4924
+  - uid: 4936
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,42.5
       parent: 1
-  - uid: 4925
+  - uid: 4937
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,41.5
       parent: 1
-  - uid: 4926
+  - uid: 4938
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,25.5
       parent: 1
-  - uid: 4927
+  - uid: 4939
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,26.5
       parent: 1
-  - uid: 4928
+  - uid: 4940
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 4929
+  - uid: 4941
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 4930
+  - uid: 4942
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 4931
+  - uid: 4943
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,27.5
       parent: 1
-  - uid: 4932
+  - uid: 4944
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,17.5
       parent: 1
-  - uid: 4933
+  - uid: 4945
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,7.5
       parent: 1
-  - uid: 4934
+  - uid: 4946
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,8.5
       parent: 1
-  - uid: 4935
+  - uid: 4947
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,28.5
       parent: 1
-  - uid: 4936
+  - uid: 4948
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,30.5
       parent: 1
-  - uid: 4937
+  - uid: 4949
     components:
     - type: Transform
       pos: 9.5,0.5
       parent: 1
-  - uid: 4938
+  - uid: 4950
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,30.5
       parent: 1
-  - uid: 4939
+  - uid: 4951
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,30.5
       parent: 1
-  - uid: 4940
+  - uid: 4952
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,30.5
       parent: 1
-  - uid: 4941
+  - uid: 4953
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,29.5
       parent: 1
-  - uid: 4942
+  - uid: 4954
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,30.5
       parent: 1
-  - uid: 4943
+  - uid: 4955
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,27.5
       parent: 1
-  - uid: 4944
+  - uid: 4956
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,43.5
       parent: 1
-  - uid: 4945
+  - uid: 4957
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 4946
+  - uid: 4958
     components:
     - type: Transform
       pos: 10.5,0.5
       parent: 1
-  - uid: 4947
+  - uid: 4959
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
-  - uid: 4948
+  - uid: 4960
     components:
     - type: Transform
       pos: 8.5,0.5
       parent: 1
-  - uid: 4949
-    components:
-    - type: Transform
-      pos: 12.5,0.5
-      parent: 1
-  - uid: 4950
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-26.5
-      parent: 1
-  - uid: 4951
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-22.5
-      parent: 1
-  - uid: 4952
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,-33.5
-      parent: 1
-  - uid: 4953
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-23.5
-      parent: 1
-  - uid: 4954
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-24.5
-      parent: 1
-  - uid: 4955
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,-34.5
-      parent: 1
-  - uid: 4956
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,-31.5
-      parent: 1
-  - uid: 4957
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,-29.5
-      parent: 1
-  - uid: 4958
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,-28.5
-      parent: 1
-  - uid: 4959
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,-26.5
-      parent: 1
-  - uid: 4960
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,-27.5
-      parent: 1
   - uid: 4961
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-21.5
+      pos: 12.5,0.5
       parent: 1
   - uid: 4962
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -14.5,-34.5
+      pos: 16.5,-26.5
       parent: 1
   - uid: 4963
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -14.5,-32.5
+      pos: -14.5,-22.5
       parent: 1
   - uid: 4964
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-31.5
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-33.5
       parent: 1
   - uid: 4965
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,-19.5
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-23.5
       parent: 1
   - uid: 4966
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,-24.5
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-24.5
       parent: 1
   - uid: 4967
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -17.5,-32.5
+      pos: -17.5,-34.5
       parent: 1
   - uid: 4968
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-31.5
+      parent: 1
+  - uid: 4969
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-29.5
+      parent: 1
+  - uid: 4970
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-28.5
+      parent: 1
+  - uid: 4971
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-26.5
+      parent: 1
+  - uid: 4972
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-27.5
+      parent: 1
+  - uid: 4973
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-21.5
+      parent: 1
+  - uid: 4974
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-34.5
+      parent: 1
+  - uid: 4975
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-32.5
+      parent: 1
+  - uid: 4976
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-31.5
+      parent: 1
+  - uid: 4977
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,-19.5
+      parent: 1
+  - uid: 4978
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-24.5
+      parent: 1
+  - uid: 4979
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-32.5
+      parent: 1
+  - uid: 4980
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-33.5
       parent: 1
-  - uid: 4969
+  - uid: 4981
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-19.5
       parent: 1
-  - uid: 4970
+  - uid: 4982
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-19.5
       parent: 1
-  - uid: 4971
+  - uid: 4983
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,-19.5
       parent: 1
-  - uid: 4972
+  - uid: 4984
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-19.5
       parent: 1
-  - uid: 4973
+  - uid: 4985
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-19.5
       parent: 1
-  - uid: 4974
+  - uid: 4986
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-19.5
       parent: 1
-  - uid: 4975
+  - uid: 4987
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-19.5
       parent: 1
-  - uid: 4976
+  - uid: 4988
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-19.5
       parent: 1
-  - uid: 4977
+  - uid: 4989
     components:
     - type: Transform
       pos: -5.5,-16.5
       parent: 1
-  - uid: 4978
+  - uid: 4990
     components:
     - type: Transform
       pos: -4.5,-16.5
       parent: 1
-  - uid: 4979
+  - uid: 4991
     components:
     - type: Transform
       pos: -3.5,-16.5
       parent: 1
-  - uid: 4980
+  - uid: 4992
     components:
     - type: Transform
       pos: -11.5,-16.5
       parent: 1
-  - uid: 4981
+  - uid: 4993
     components:
     - type: Transform
       pos: -12.5,-16.5
       parent: 1
-  - uid: 4982
+  - uid: 4994
     components:
     - type: Transform
       pos: -13.5,-16.5
       parent: 1
-  - uid: 4983
+  - uid: 4995
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-19.5
       parent: 1
-  - uid: 4984
+  - uid: 4996
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-19.5
       parent: 1
-  - uid: 4985
+  - uid: 4997
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-19.5
       parent: 1
-  - uid: 4986
+  - uid: 4998
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-19.5
       parent: 1
-  - uid: 4987
+  - uid: 4999
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-19.5
       parent: 1
-  - uid: 4988
+  - uid: 5000
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-19.5
       parent: 1
-  - uid: 4989
+  - uid: 5001
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-19.5
       parent: 1
-  - uid: 4990
+  - uid: 5002
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-19.5
       parent: 1
-  - uid: 4991
+  - uid: 5003
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-19.5
       parent: 1
-  - uid: 4992
+  - uid: 5004
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-19.5
       parent: 1
-  - uid: 4993
+  - uid: 5005
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-19.5
       parent: 1
-  - uid: 4994
+  - uid: 5006
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-19.5
       parent: 1
-  - uid: 4995
+  - uid: 5007
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 1
-  - uid: 4996
+  - uid: 5008
     components:
     - type: Transform
       pos: 3.5,-16.5
       parent: 1
-  - uid: 4997
+  - uid: 5009
     components:
     - type: Transform
       pos: 4.5,-16.5
       parent: 1
-  - uid: 4998
+  - uid: 5010
     components:
     - type: Transform
       pos: 12.5,-16.5
       parent: 1
-  - uid: 4999
+  - uid: 5011
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-24.5
       parent: 1
-  - uid: 5000
+  - uid: 5012
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-27.5
       parent: 1
-  - uid: 5001
+  - uid: 5013
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-28.5
       parent: 1
-  - uid: 5002
+  - uid: 5014
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-29.5
       parent: 1
-  - uid: 5003
+  - uid: 5015
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-31.5
       parent: 1
-  - uid: 5004
+  - uid: 5016
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-32.5
       parent: 1
-  - uid: 5005
+  - uid: 5017
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-33.5
       parent: 1
-  - uid: 5006
+  - uid: 5018
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-34.5
       parent: 1
-  - uid: 5007
+  - uid: 5019
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-31.5
       parent: 1
-  - uid: 5008
+  - uid: 5020
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-32.5
       parent: 1
-  - uid: 5009
+  - uid: 5021
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-33.5
       parent: 1
-  - uid: 5010
+  - uid: 5022
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-34.5
       parent: 1
-  - uid: 5011
+  - uid: 5023
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-29.5
       parent: 1
-  - uid: 5012
+  - uid: 5024
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-28.5
       parent: 1
-  - uid: 5013
+  - uid: 5025
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-27.5
       parent: 1
-  - uid: 5014
+  - uid: 5026
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-26.5
       parent: 1
-  - uid: 5015
+  - uid: 5027
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-36.5
       parent: 1
-  - uid: 5016
+  - uid: 5028
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-37.5
       parent: 1
-  - uid: 5017
+  - uid: 5029
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-38.5
       parent: 1
-  - uid: 5018
+  - uid: 5030
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-36.5
       parent: 1
-  - uid: 5019
+  - uid: 5031
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-37.5
       parent: 1
-  - uid: 5020
+  - uid: 5032
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-38.5
       parent: 1
-  - uid: 5021
+  - uid: 5033
     components:
     - type: Transform
       pos: -16.5,53.5
       parent: 1
-  - uid: 5022
+  - uid: 5034
     components:
     - type: Transform
       pos: -15.5,53.5
       parent: 1
-  - uid: 5023
+  - uid: 5035
     components:
     - type: Transform
       pos: -14.5,53.5
       parent: 1
-  - uid: 5024
+  - uid: 5036
     components:
     - type: Transform
       pos: -13.5,53.5
       parent: 1
-  - uid: 5025
+  - uid: 5037
     components:
     - type: Transform
       pos: -10.5,53.5
       parent: 1
-  - uid: 5026
+  - uid: 5038
     components:
     - type: Transform
       pos: -11.5,53.5
       parent: 1
-  - uid: 5027
+  - uid: 5039
     components:
     - type: Transform
       pos: -9.5,53.5
       parent: 1
-  - uid: 5028
-    components:
-    - type: Transform
-      pos: -8.5,53.5
-      parent: 1
-  - uid: 5029
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,55.5
-      parent: 1
-  - uid: 5030
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,56.5
-      parent: 1
-  - uid: 5031
-    components:
-    - type: Transform
-      pos: 14.5,-16.5
-      parent: 1
-  - uid: 5032
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,57.5
-      parent: 1
-  - uid: 5033
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,58.5
-      parent: 1
-  - uid: 5034
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,59.5
-      parent: 1
-  - uid: 5035
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,64.5
-      parent: 1
-  - uid: 5036
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,65.5
-      parent: 1
-  - uid: 5037
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,66.5
-      parent: 1
-  - uid: 5038
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,67.5
-      parent: 1
-  - uid: 5039
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,68.5
-      parent: 1
   - uid: 5040
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,61.5
+      pos: -8.5,53.5
       parent: 1
   - uid: 5041
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,62.5
+      pos: 4.5,55.5
       parent: 1
   - uid: 5042
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,55.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,56.5
       parent: 1
   - uid: 5043
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,56.5
+      pos: 14.5,-16.5
       parent: 1
   - uid: 5044
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,57.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,57.5
       parent: 1
   - uid: 5045
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,58.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,58.5
       parent: 1
   - uid: 5046
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,59.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,59.5
       parent: 1
   - uid: 5047
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,62.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,64.5
       parent: 1
   - uid: 5048
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,61.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,65.5
       parent: 1
   - uid: 5049
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,64.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,66.5
       parent: 1
   - uid: 5050
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,65.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,67.5
       parent: 1
   - uid: 5051
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,66.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,68.5
       parent: 1
   - uid: 5052
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,67.5
+      rot: -1.5707963267948966 rad
+      pos: 3.5,61.5
       parent: 1
   - uid: 5053
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,68.5
+      rot: -1.5707963267948966 rad
+      pos: 3.5,62.5
       parent: 1
   - uid: 5054
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -6.5,70.5
+      pos: -7.5,55.5
       parent: 1
   - uid: 5055
     components:
     - type: Transform
-      pos: -3.5,72.5
+      rot: 1.5707963267948966 rad
+      pos: -7.5,56.5
       parent: 1
   - uid: 5056
     components:
     - type: Transform
-      pos: -2.5,72.5
+      rot: 1.5707963267948966 rad
+      pos: -7.5,57.5
       parent: 1
   - uid: 5057
     components:
     - type: Transform
-      pos: -1.5,72.5
+      rot: 1.5707963267948966 rad
+      pos: -7.5,58.5
       parent: 1
   - uid: 5058
     components:
     - type: Transform
-      pos: -0.5,72.5
+      rot: 1.5707963267948966 rad
+      pos: -7.5,59.5
       parent: 1
   - uid: 5059
     components:
     - type: Transform
-      pos: 0.5,72.5
+      rot: 1.5707963267948966 rad
+      pos: -6.5,62.5
       parent: 1
   - uid: 5060
     components:
     - type: Transform
-      pos: 1.5,72.5
+      rot: 1.5707963267948966 rad
+      pos: -6.5,61.5
       parent: 1
   - uid: 5061
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,70.5
+      rot: 1.5707963267948966 rad
+      pos: -7.5,64.5
       parent: 1
   - uid: 5062
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,18.5
+      pos: -7.5,65.5
       parent: 1
   - uid: 5063
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,66.5
+      parent: 1
+  - uid: 5064
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,67.5
+      parent: 1
+  - uid: 5065
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,68.5
+      parent: 1
+  - uid: 5066
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,70.5
+      parent: 1
+  - uid: 5067
+    components:
+    - type: Transform
+      pos: -3.5,72.5
+      parent: 1
+  - uid: 5068
+    components:
+    - type: Transform
+      pos: -2.5,72.5
+      parent: 1
+  - uid: 5069
+    components:
+    - type: Transform
+      pos: -1.5,72.5
+      parent: 1
+  - uid: 5070
+    components:
+    - type: Transform
+      pos: -0.5,72.5
+      parent: 1
+  - uid: 5071
+    components:
+    - type: Transform
+      pos: 0.5,72.5
+      parent: 1
+  - uid: 5072
+    components:
+    - type: Transform
+      pos: 1.5,72.5
+      parent: 1
+  - uid: 5073
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,70.5
+      parent: 1
+  - uid: 5074
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,18.5
+      parent: 1
+  - uid: 5075
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,30.5
       parent: 1
-  - uid: 5064
+  - uid: 5076
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,29.5
       parent: 1
-  - uid: 5065
+  - uid: 5077
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,30.5
       parent: 1
-  - uid: 5066
+  - uid: 5078
     components:
     - type: Transform
       pos: 10.5,-16.5
       parent: 1
-  - uid: 5067
+  - uid: 5079
     components:
     - type: Transform
       pos: 15.5,-16.5
       parent: 1
-  - uid: 5068
+  - uid: 5080
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 5069
+  - uid: 5081
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 5070
+  - uid: 5082
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 5071
+  - uid: 5083
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,17.5
       parent: 1
-  - uid: 5072
+  - uid: 5084
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 5073
+  - uid: 5085
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 5074
+  - uid: 5086
     components:
     - type: Transform
       pos: -12.5,0.5
       parent: 1
-  - uid: 5075
+  - uid: 5087
     components:
     - type: Transform
       pos: -10.5,0.5
       parent: 1
-  - uid: 5076
+  - uid: 5088
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,15.5
       parent: 1
-  - uid: 5077
+  - uid: 5089
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 5078
+  - uid: 5090
     components:
     - type: Transform
       pos: -11.5,0.5
       parent: 1
-  - uid: 5079
+  - uid: 5091
     components:
     - type: Transform
       pos: -9.5,0.5
       parent: 1
-  - uid: 5080
+  - uid: 5092
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,7.5
       parent: 1
-  - uid: 5081
+  - uid: 5093
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,18.5
       parent: 1
-  - uid: 5082
+  - uid: 5094
     components:
     - type: Transform
       pos: -13.5,0.5
       parent: 1
-  - uid: 5083
+  - uid: 5095
     components:
     - type: Transform
       pos: -8.5,0.5
       parent: 1
-  - uid: 5084
+  - uid: 5096
     components:
     - type: Transform
       pos: -14.5,0.5
       parent: 1
-  - uid: 5085
+  - uid: 5097
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,6.5
       parent: 1
-  - uid: 5086
+  - uid: 5098
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,8.5
       parent: 1
-  - uid: 5087
+  - uid: 5099
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,16.5
       parent: 1
-  - uid: 5088
+  - uid: 5100
     components:
     - type: Transform
       pos: -7.5,0.5
       parent: 1
-  - uid: 5089
+  - uid: 5101
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
-  - uid: 5090
+  - uid: 5102
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,33.5
       parent: 1
-  - uid: 5091
+  - uid: 5103
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,31.5
       parent: 1
-  - uid: 5092
+  - uid: 5104
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,43.5
       parent: 1
-  - uid: 5093
+  - uid: 5105
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-47.5
       parent: 1
-  - uid: 5094
+  - uid: 5106
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-46.5
       parent: 1
-  - uid: 5095
+  - uid: 5107
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-44.5
       parent: 1
-  - uid: 5096
+  - uid: 5108
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-46.5
       parent: 1
-  - uid: 5097
+  - uid: 5109
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-49.5
       parent: 1
-  - uid: 5098
+  - uid: 5110
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-48.5
       parent: 1
-  - uid: 5099
+  - uid: 5111
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-49.5
       parent: 1
-  - uid: 5100
+  - uid: 5112
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-46.5
       parent: 1
-  - uid: 5101
+  - uid: 5113
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-47.5
       parent: 1
-  - uid: 5102
+  - uid: 5114
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-48.5
       parent: 1
-  - uid: 5103
+  - uid: 5115
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-41.5
       parent: 1
-  - uid: 5104
+  - uid: 5116
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-42.5
       parent: 1
-  - uid: 5105
+  - uid: 5117
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-43.5
       parent: 1
-  - uid: 5106
+  - uid: 5118
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-44.5
       parent: 1
-  - uid: 5107
+  - uid: 5119
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-46.5
       parent: 1
-  - uid: 5108
+  - uid: 5120
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-47.5
       parent: 1
-  - uid: 5109
+  - uid: 5121
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-48.5
       parent: 1
-  - uid: 5110
+  - uid: 5122
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-49.5
       parent: 1
-  - uid: 5111
+  - uid: 5123
     components:
     - type: Transform
       pos: 7.5,-53.5
       parent: 1
-  - uid: 5112
+  - uid: 5124
     components:
     - type: Transform
       pos: 5.5,-53.5
       parent: 1
-  - uid: 5113
+  - uid: 5125
     components:
     - type: Transform
       pos: 4.5,-53.5
       parent: 1
-  - uid: 5114
+  - uid: 5126
     components:
     - type: Transform
       pos: 2.5,-53.5
       parent: 1
-  - uid: 5115
+  - uid: 5127
     components:
     - type: Transform
       pos: 3.5,-53.5
       parent: 1
-  - uid: 5116
+  - uid: 5128
     components:
     - type: Transform
       pos: 0.5,-53.5
       parent: 1
-  - uid: 5117
+  - uid: 5129
     components:
     - type: Transform
       pos: -0.5,-53.5
       parent: 1
-  - uid: 5118
+  - uid: 5130
     components:
     - type: Transform
       pos: -1.5,-53.5
       parent: 1
-  - uid: 5119
+  - uid: 5131
     components:
     - type: Transform
       pos: -8.5,-53.5
       parent: 1
-  - uid: 5120
+  - uid: 5132
     components:
     - type: Transform
       pos: -9.5,-53.5
       parent: 1
-  - uid: 5121
+  - uid: 5133
     components:
     - type: Transform
       pos: -10.5,-53.5
       parent: 1
-  - uid: 5122
+  - uid: 5134
     components:
     - type: Transform
       pos: -11.5,-53.5
       parent: 1
-  - uid: 5123
+  - uid: 5135
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-55.5
       parent: 1
-  - uid: 5124
+  - uid: 5136
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-54.5
       parent: 1
-  - uid: 5125
+  - uid: 5137
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-53.5
       parent: 1
-  - uid: 5126
+  - uid: 5138
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,8.5
       parent: 1
-  - uid: 5127
+  - uid: 5139
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,8.5
       parent: 1
-  - uid: 5128
+  - uid: 5140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,8.5
       parent: 1
-  - uid: 5129
+  - uid: 5141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,8.5
       parent: 1
-  - uid: 5130
+  - uid: 5142
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,6.5
       parent: 1
-  - uid: 5131
+  - uid: 5143
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,7.5
       parent: 1
-  - uid: 5132
+  - uid: 5144
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-13.5
       parent: 1
-  - uid: 5133
+  - uid: 5145
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-9.5
       parent: 1
-  - uid: 5134
+  - uid: 5146
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-8.5
       parent: 1
-  - uid: 5135
+  - uid: 5147
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,0.5
       parent: 1
-  - uid: 5136
+  - uid: 5148
     components:
     - type: Transform
       pos: -23.5,3.5
       parent: 1
-  - uid: 5137
+  - uid: 5149
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-12.5
       parent: 1
-  - uid: 5138
+  - uid: 5150
     components:
     - type: Transform
       pos: -24.5,0.5
       parent: 1
-  - uid: 5139
-    components:
-    - type: Transform
-      pos: -28.5,0.5
-      parent: 1
-  - uid: 5140
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,2.5
-      parent: 1
-  - uid: 5141
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,3.5
-      parent: 1
-  - uid: 5142
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-7.5
-      parent: 1
-  - uid: 5143
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-5.5
-      parent: 1
-  - uid: 5144
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-4.5
-      parent: 1
-  - uid: 5145
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-3.5
-      parent: 1
-  - uid: 5146
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-2.5
-      parent: 1
-  - uid: 5147
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-1.5
-      parent: 1
-  - uid: 5148
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-14.5
-      parent: 1
-  - uid: 5149
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-13.5
-      parent: 1
-  - uid: 5150
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-12.5
-      parent: 1
   - uid: 5151
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-10.5
+      pos: -28.5,0.5
       parent: 1
   - uid: 5152
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,-9.5
+      pos: -29.5,2.5
       parent: 1
   - uid: 5153
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,-8.5
+      pos: -29.5,3.5
       parent: 1
   - uid: 5154
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-7.5
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-7.5
       parent: 1
   - uid: 5155
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-5.5
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-5.5
       parent: 1
   - uid: 5156
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-4.5
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-4.5
       parent: 1
   - uid: 5157
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-3.5
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-3.5
       parent: 1
   - uid: 5158
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-2.5
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-2.5
       parent: 1
   - uid: 5159
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-1.5
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-1.5
       parent: 1
   - uid: 5160
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 29.5,7.5
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-14.5
       parent: 1
   - uid: 5161
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 24.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-13.5
       parent: 1
   - uid: 5162
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 26.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-12.5
       parent: 1
   - uid: 5163
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 30.5,5.5
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-10.5
       parent: 1
   - uid: 5164
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,5.5
+      pos: 21.5,-9.5
       parent: 1
   - uid: 5165
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,6.5
+      pos: 21.5,-8.5
       parent: 1
   - uid: 5166
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,7.5
+      pos: 21.5,-7.5
       parent: 1
   - uid: 5167
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,8.5
+      pos: 21.5,-5.5
       parent: 1
   - uid: 5168
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,25.5
+      pos: 21.5,-4.5
       parent: 1
   - uid: 5169
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,26.5
+      pos: 21.5,-3.5
       parent: 1
   - uid: 5170
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,27.5
+      pos: 21.5,-2.5
       parent: 1
   - uid: 5171
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,28.5
+      pos: 21.5,-1.5
       parent: 1
   - uid: 5172
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,30.5
+      rot: 3.141592653589793 rad
+      pos: 29.5,7.5
       parent: 1
   - uid: 5173
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,31.5
+      rot: 3.141592653589793 rad
+      pos: 24.5,8.5
       parent: 1
   - uid: 5174
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,32.5
+      rot: 3.141592653589793 rad
+      pos: 26.5,8.5
       parent: 1
   - uid: 5175
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,33.5
+      rot: 1.5707963267948966 rad
+      pos: 30.5,5.5
       parent: 1
   - uid: 5176
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,35.5
+      pos: 21.5,5.5
       parent: 1
   - uid: 5177
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,36.5
+      pos: 21.5,6.5
       parent: 1
   - uid: 5178
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,37.5
+      pos: 21.5,7.5
       parent: 1
   - uid: 5179
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,38.5
+      pos: 21.5,8.5
       parent: 1
   - uid: 5180
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,40.5
+      pos: 21.5,25.5
       parent: 1
   - uid: 5181
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,41.5
+      pos: 21.5,26.5
       parent: 1
   - uid: 5182
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,43.5
+      pos: 21.5,27.5
       parent: 1
   - uid: 5183
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,42.5
+      pos: 21.5,28.5
       parent: 1
   - uid: 5184
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,45.5
+      pos: 21.5,30.5
       parent: 1
   - uid: 5185
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,46.5
+      pos: 21.5,31.5
       parent: 1
   - uid: 5186
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,47.5
+      pos: 21.5,32.5
       parent: 1
   - uid: 5187
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,48.5
+      pos: 21.5,33.5
       parent: 1
   - uid: 5188
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,50.5
+      pos: 21.5,35.5
       parent: 1
   - uid: 5189
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,51.5
+      pos: 21.5,36.5
       parent: 1
   - uid: 5190
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 21.5,52.5
+      pos: 21.5,37.5
       parent: 1
   - uid: 5191
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,38.5
+      parent: 1
+  - uid: 5192
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,40.5
+      parent: 1
+  - uid: 5193
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,41.5
+      parent: 1
+  - uid: 5194
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,43.5
+      parent: 1
+  - uid: 5195
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,42.5
+      parent: 1
+  - uid: 5196
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,45.5
+      parent: 1
+  - uid: 5197
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,46.5
+      parent: 1
+  - uid: 5198
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,47.5
+      parent: 1
+  - uid: 5199
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,48.5
+      parent: 1
+  - uid: 5200
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,50.5
+      parent: 1
+  - uid: 5201
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,51.5
+      parent: 1
+  - uid: 5202
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,52.5
+      parent: 1
+  - uid: 5203
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,48.5
       parent: 1
-  - uid: 5192
+  - uid: 5204
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,47.5
       parent: 1
-  - uid: 5193
+  - uid: 5205
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,46.5
       parent: 1
-  - uid: 5194
+  - uid: 5206
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,45.5
       parent: 1
-  - uid: 5195
+  - uid: 5207
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,43.5
       parent: 1
-  - uid: 5196
+  - uid: 5208
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,42.5
       parent: 1
-  - uid: 5197
+  - uid: 5209
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,41.5
       parent: 1
-  - uid: 5198
+  - uid: 5210
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,40.5
       parent: 1
-  - uid: 5199
+  - uid: 5211
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,38.5
       parent: 1
-  - uid: 5200
+  - uid: 5212
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,37.5
       parent: 1
-  - uid: 5201
+  - uid: 5213
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,36.5
       parent: 1
-  - uid: 5202
+  - uid: 5214
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,35.5
       parent: 1
-  - uid: 5203
+  - uid: 5215
     components:
     - type: Transform
       pos: 11.5,53.5
       parent: 1
-  - uid: 5204
+  - uid: 5216
     components:
     - type: Transform
       pos: 12.5,53.5
       parent: 1
-  - uid: 5205
+  - uid: 5217
     components:
     - type: Transform
       pos: 13.5,53.5
       parent: 1
-  - uid: 5206
+  - uid: 5218
     components:
     - type: Transform
       pos: 5.5,53.5
       parent: 1
-  - uid: 5207
+  - uid: 5219
     components:
     - type: Transform
       pos: 6.5,53.5
       parent: 1
-  - uid: 5208
+  - uid: 5220
     components:
     - type: Transform
       pos: 7.5,53.5
       parent: 1
-  - uid: 5209
+  - uid: 5221
     components:
     - type: Transform
       pos: 8.5,53.5
       parent: 1
-  - uid: 5210
+  - uid: 5222
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,1.5
       parent: 1
-  - uid: 5211
+  - uid: 5223
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,6.5
       parent: 1
-  - uid: 5212
+  - uid: 5224
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,5.5
       parent: 1
-  - uid: 5213
+  - uid: 5225
     components:
     - type: Transform
       pos: 23.5,0.5
       parent: 1
-  - uid: 5214
+  - uid: 5226
     components:
     - type: Transform
       pos: 22.5,3.5
       parent: 1
-  - uid: 5215
+  - uid: 5227
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,0.5
       parent: 1
-  - uid: 5216
+  - uid: 5228
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,7.5
       parent: 1
-  - uid: 5217
+  - uid: 5229
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,6.5
       parent: 1
-  - uid: 5218
+  - uid: 5230
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,4.5
       parent: 1
-  - uid: 5219
+  - uid: 5231
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,5.5
       parent: 1
-  - uid: 5220
+  - uid: 5232
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -36526,378 +36594,378 @@ entities:
       parent: 1
 - proto: RMCPlatformHybrisaThreeCorner
   entities:
-  - uid: 5221
+  - uid: 5233
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-23.5
       parent: 1
-  - uid: 5222
+  - uid: 5234
     components:
     - type: Transform
       pos: -17.5,-21.5
       parent: 1
-  - uid: 5223
+  - uid: 5235
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-21.5
       parent: 1
-  - uid: 5224
+  - uid: 5236
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,-23.5
       parent: 1
-  - uid: 5225
+  - uid: 5237
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,0.5
       parent: 1
-  - uid: 5226
-    components:
-    - type: Transform
-      pos: -27.5,0.5
-      parent: 1
-  - uid: 5227
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,1.5
-      parent: 1
-  - uid: 5228
-    components:
-    - type: Transform
-      pos: -23.5,0.5
-      parent: 1
-  - uid: 5229
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,8.5
-      parent: 1
-  - uid: 5230
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -15.5,1.5
-      parent: 1
-  - uid: 5231
-    components:
-    - type: Transform
-      pos: 14.5,3.5
-      parent: 1
-  - uid: 5232
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,3.5
-      parent: 1
-  - uid: 5233
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,30.5
-      parent: 1
-  - uid: 5234
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,0.5
-      parent: 1
-  - uid: 5235
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,30.5
-      parent: 1
-  - uid: 5236
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,5.5
-      parent: 1
-  - uid: 5237
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -18.5,9.5
-      parent: 1
   - uid: 5238
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,14.5
+      pos: -27.5,0.5
       parent: 1
   - uid: 5239
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 17.5,9.5
+      pos: 14.5,1.5
       parent: 1
   - uid: 5240
     components:
     - type: Transform
-      pos: 17.5,5.5
+      pos: -23.5,0.5
       parent: 1
   - uid: 5241
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -18.5,28.5
+      rot: 1.5707963267948966 rad
+      pos: -24.5,8.5
       parent: 1
   - uid: 5242
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -18.5,19.5
+      pos: -15.5,1.5
       parent: 1
   - uid: 5243
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 17.5,28.5
+      pos: 14.5,3.5
       parent: 1
   - uid: 5244
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -14.5,30.5
+      rot: -1.5707963267948966 rad
+      pos: -15.5,3.5
       parent: 1
   - uid: 5245
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,24.5
+      rot: 1.5707963267948966 rad
+      pos: 13.5,30.5
       parent: 1
   - uid: 5246
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,30.5
+      rot: -1.5707963267948966 rad
+      pos: -15.5,0.5
       parent: 1
   - uid: 5247
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-26.5
+      rot: 3.141592653589793 rad
+      pos: 3.5,30.5
       parent: 1
   - uid: 5248
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -14.5,-29.5
+      rot: -1.5707963267948966 rad
+      pos: -18.5,5.5
       parent: 1
   - uid: 5249
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,-24.5
+      rot: 3.141592653589793 rad
+      pos: -18.5,9.5
       parent: 1
   - uid: 5250
     components:
     - type: Transform
-      pos: 13.5,-21.5
+      rot: -1.5707963267948966 rad
+      pos: -18.5,14.5
       parent: 1
   - uid: 5251
     components:
     - type: Transform
-      pos: 13.5,-36.5
+      rot: 1.5707963267948966 rad
+      pos: 17.5,9.5
       parent: 1
   - uid: 5252
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-36.5
+      pos: 17.5,5.5
       parent: 1
   - uid: 5253
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,63.5
+      pos: -18.5,28.5
       parent: 1
   - uid: 5254
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,60.5
+      rot: 3.141592653589793 rad
+      pos: -18.5,19.5
       parent: 1
   - uid: 5255
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,69.5
+      rot: 1.5707963267948966 rad
+      pos: 17.5,28.5
       parent: 1
   - uid: 5256
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,71.5
+      rot: 3.141592653589793 rad
+      pos: -14.5,30.5
       parent: 1
   - uid: 5257
     components:
     - type: Transform
-      pos: -5.5,71.5
+      rot: -1.5707963267948966 rad
+      pos: -18.5,24.5
       parent: 1
   - uid: 5258
     components:
     - type: Transform
-      pos: -6.5,69.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,30.5
       parent: 1
   - uid: 5259
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,63.5
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-26.5
       parent: 1
   - uid: 5260
     components:
     - type: Transform
-      pos: -6.5,60.5
+      rot: 3.141592653589793 rad
+      pos: -14.5,-29.5
       parent: 1
   - uid: 5261
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 17.5,19.5
+      pos: 13.5,-24.5
       parent: 1
   - uid: 5262
     components:
     - type: Transform
-      pos: 17.5,24.5
+      pos: 13.5,-21.5
       parent: 1
   - uid: 5263
     components:
     - type: Transform
-      pos: 17.5,14.5
+      pos: 13.5,-36.5
       parent: 1
   - uid: 5264
     components:
     - type: Transform
-      pos: 14.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-36.5
       parent: 1
   - uid: 5265
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,-39.5
+      rot: 3.141592653589793 rad
+      pos: 3.5,63.5
       parent: 1
   - uid: 5266
     components:
     - type: Transform
-      pos: 13.5,-53.5
+      rot: -1.5707963267948966 rad
+      pos: 3.5,60.5
       parent: 1
   - uid: 5267
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 10.5,-53.5
+      pos: 3.5,69.5
       parent: 1
   - uid: 5268
     components:
     - type: Transform
-      pos: 8.5,-53.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,71.5
       parent: 1
   - uid: 5269
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-53.5
+      pos: -5.5,71.5
       parent: 1
   - uid: 5270
     components:
     - type: Transform
-      pos: -6.5,-53.5
+      pos: -6.5,69.5
       parent: 1
   - uid: 5271
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-53.5
+      rot: 1.5707963267948966 rad
+      pos: -6.5,63.5
       parent: 1
   - uid: 5272
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -14.5,-39.5
+      pos: -6.5,60.5
       parent: 1
   - uid: 5273
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -30.5,7.5
+      rot: 1.5707963267948966 rad
+      pos: 17.5,19.5
       parent: 1
   - uid: 5274
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -29.5,8.5
+      pos: 17.5,24.5
       parent: 1
   - uid: 5275
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -23.5,3.5
+      pos: 17.5,14.5
       parent: 1
   - uid: 5276
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,0.5
+      pos: 14.5,0.5
       parent: 1
   - uid: 5277
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -30.5,4.5
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-39.5
       parent: 1
   - uid: 5278
     components:
     - type: Transform
-      pos: 24.5,0.5
+      pos: 13.5,-53.5
       parent: 1
   - uid: 5279
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 26.5,0.5
+      pos: 10.5,-53.5
       parent: 1
   - uid: 5280
+    components:
+    - type: Transform
+      pos: 8.5,-53.5
+      parent: 1
+  - uid: 5281
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-53.5
+      parent: 1
+  - uid: 5282
+    components:
+    - type: Transform
+      pos: -6.5,-53.5
+      parent: 1
+  - uid: 5283
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-53.5
+      parent: 1
+  - uid: 5284
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -14.5,-39.5
+      parent: 1
+  - uid: 5285
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -30.5,7.5
+      parent: 1
+  - uid: 5286
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -29.5,8.5
+      parent: 1
+  - uid: 5287
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -23.5,3.5
+      parent: 1
+  - uid: 5288
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -29.5,0.5
+      parent: 1
+  - uid: 5289
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -30.5,4.5
+      parent: 1
+  - uid: 5290
+    components:
+    - type: Transform
+      pos: 24.5,0.5
+      parent: 1
+  - uid: 5291
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,0.5
+      parent: 1
+  - uid: 5292
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,0.5
       parent: 1
-  - uid: 5281
+  - uid: 5293
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,8.5
       parent: 1
-  - uid: 5282
+  - uid: 5294
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,8.5
       parent: 1
-  - uid: 5283
+  - uid: 5295
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,7.5
       parent: 1
-  - uid: 5284
+  - uid: 5296
     components:
     - type: Transform
       pos: 30.5,4.5
       parent: 1
-  - uid: 5285
+  - uid: 5297
     components:
     - type: Transform
       pos: 28.5,0.5
       parent: 1
-  - uid: 5286
+  - uid: 5298
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -36905,335 +36973,335 @@ entities:
       parent: 1
 - proto: RMCPlatformHybrisaThreeCornerSmall
   entities:
-  - uid: 5287
+  - uid: 5299
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,1.5
       parent: 1
-  - uid: 5288
+  - uid: 5300
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,71.5
       parent: 1
-  - uid: 5289
+  - uid: 5301
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,69.5
       parent: 1
-  - uid: 5290
+  - uid: 5302
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,60.5
       parent: 1
-  - uid: 5291
+  - uid: 5303
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,63.5
       parent: 1
-  - uid: 5292
+  - uid: 5304
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,72.5
       parent: 1
-  - uid: 5293
+  - uid: 5305
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,72.5
       parent: 1
-  - uid: 5294
+  - uid: 5306
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,69.5
       parent: 1
-  - uid: 5295
+  - uid: 5307
     components:
     - type: Transform
       pos: 4.5,63.5
       parent: 1
-  - uid: 5296
+  - uid: 5308
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,60.5
       parent: 1
-  - uid: 5297
+  - uid: 5309
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,3.5
       parent: 1
-  - uid: 5298
+  - uid: 5310
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,2.5
       parent: 1
-  - uid: 5299
+  - uid: 5311
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,71.5
       parent: 1
-  - uid: 5300
+  - uid: 5312
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,19.5
       parent: 1
-  - uid: 5301
+  - uid: 5313
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,14.5
       parent: 1
-  - uid: 5302
+  - uid: 5314
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,5.5
       parent: 1
-  - uid: 5303
+  - uid: 5315
     components:
     - type: Transform
       pos: -3.5,29.5
       parent: 1
-  - uid: 5304
+  - uid: 5316
     components:
     - type: Transform
       pos: 3.5,29.5
       parent: 1
-  - uid: 5305
+  - uid: 5317
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,29.5
       parent: 1
-  - uid: 5306
+  - uid: 5318
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,14.5
       parent: 1
-  - uid: 5307
+  - uid: 5319
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,20.5
       parent: 1
-  - uid: 5308
-    components:
-    - type: Transform
-      pos: -14.5,28.5
-      parent: 1
-  - uid: 5309
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,28.5
-      parent: 1
-  - uid: 5310
-    components:
-    - type: Transform
-      pos: -17.5,9.5
-      parent: 1
-  - uid: 5311
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,10.5
-      parent: 1
-  - uid: 5312
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,10.5
-      parent: 1
-  - uid: 5313
-    components:
-    - type: Transform
-      pos: -17.5,23.5
-      parent: 1
-  - uid: 5314
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,23.5
-      parent: 1
-  - uid: 5315
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,24.5
-      parent: 1
-  - uid: 5316
-    components:
-    - type: Transform
-      pos: -17.5,19.5
-      parent: 1
-  - uid: 5317
-    components:
-    - type: Transform
-      pos: -17.5,13.5
-      parent: 1
-  - uid: 5318
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,20.5
-      parent: 1
-  - uid: 5319
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,24.5
-      parent: 1
   - uid: 5320
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,9.5
+      pos: -14.5,28.5
       parent: 1
   - uid: 5321
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 16.5,13.5
+      pos: 13.5,28.5
       parent: 1
   - uid: 5322
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,29.5
+      pos: -17.5,9.5
       parent: 1
   - uid: 5323
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -15.5,5.5
+      pos: -17.5,10.5
       parent: 1
   - uid: 5324
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -24.5,0.5
+      rot: 3.141592653589793 rad
+      pos: 16.5,10.5
       parent: 1
   - uid: 5325
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,1.5
+      pos: -17.5,23.5
       parent: 1
   - uid: 5326
     components:
     - type: Transform
-      pos: -29.5,7.5
+      rot: -1.5707963267948966 rad
+      pos: 16.5,23.5
       parent: 1
   - uid: 5327
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -24.5,3.5
+      rot: 1.5707963267948966 rad
+      pos: -17.5,24.5
       parent: 1
   - uid: 5328
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,3.5
+      pos: -17.5,19.5
       parent: 1
   - uid: 5329
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -29.5,4.5
+      pos: -17.5,13.5
       parent: 1
   - uid: 5330
     components:
     - type: Transform
-      pos: -14.5,1.5
+      rot: 3.141592653589793 rad
+      pos: 16.5,20.5
       parent: 1
   - uid: 5331
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,3.5
+      rot: 3.141592653589793 rad
+      pos: 16.5,24.5
       parent: 1
   - uid: 5332
     components:
     - type: Transform
-      pos: 23.5,3.5
+      rot: -1.5707963267948966 rad
+      pos: 16.5,9.5
       parent: 1
   - uid: 5333
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 28.5,7.5
+      pos: 16.5,13.5
       parent: 1
   - uid: 5334
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 28.5,4.5
+      rot: -1.5707963267948966 rad
+      pos: -4.5,29.5
       parent: 1
   - uid: 5335
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 23.5,3.5
+      pos: -15.5,5.5
       parent: 1
   - uid: 5336
     components:
     - type: Transform
-      pos: 23.5,2.5
+      rot: -1.5707963267948966 rad
+      pos: -24.5,0.5
       parent: 1
   - uid: 5337
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,1.5
+      parent: 1
+  - uid: 5338
+    components:
+    - type: Transform
+      pos: -29.5,7.5
+      parent: 1
+  - uid: 5339
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -24.5,3.5
+      parent: 1
+  - uid: 5340
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,3.5
+      parent: 1
+  - uid: 5341
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -29.5,4.5
+      parent: 1
+  - uid: 5342
+    components:
+    - type: Transform
+      pos: -14.5,1.5
+      parent: 1
+  - uid: 5343
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,3.5
+      parent: 1
+  - uid: 5344
+    components:
+    - type: Transform
+      pos: 23.5,3.5
+      parent: 1
+  - uid: 5345
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 28.5,7.5
+      parent: 1
+  - uid: 5346
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.5,4.5
+      parent: 1
+  - uid: 5347
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 23.5,3.5
+      parent: 1
+  - uid: 5348
+    components:
+    - type: Transform
+      pos: 23.5,2.5
+      parent: 1
+  - uid: 5349
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 23.5,1.5
       parent: 1
-  - uid: 5338
+  - uid: 5350
     components:
     - type: Transform
       pos: 23.5,0.5
       parent: 1
 - proto: RMCPlatformHybrisaThreeStair
   entities:
-  - uid: 5339
+  - uid: 5351
     components:
     - type: Transform
       pos: 17.5,10.5
       parent: 1
-  - uid: 5340
+  - uid: 5352
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,23.5
       parent: 1
-  - uid: 5341
+  - uid: 5353
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,13.5
       parent: 1
-  - uid: 5342
+  - uid: 5354
     components:
     - type: Transform
       pos: 17.5,20.5
       parent: 1
-  - uid: 5343
+  - uid: 5355
     components:
     - type: Transform
       pos: -23.5,1.5
       parent: 1
-  - uid: 5344
+  - uid: 5356
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -37241,63 +37309,63 @@ entities:
       parent: 1
 - proto: RMCPlatformHybrisaThreeStairAlt
   entities:
-  - uid: 5345
+  - uid: 5357
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,23.5
       parent: 1
-  - uid: 5346
+  - uid: 5358
     components:
     - type: Transform
       pos: -18.5,20.5
       parent: 1
-  - uid: 5347
+  - uid: 5359
     components:
     - type: Transform
       pos: -18.5,10.5
       parent: 1
-  - uid: 5348
+  - uid: 5360
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,13.5
       parent: 1
-  - uid: 5349
+  - uid: 5361
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,2.5
       parent: 1
-  - uid: 5350
+  - uid: 5362
     components:
     - type: Transform
       pos: 22.5,1.5
       parent: 1
 - proto: RMCPlatformRound
   entities:
-  - uid: 5351
+  - uid: 5363
     components:
     - type: Transform
       pos: -14.5,-6.5
       parent: 1
-  - uid: 5352
+  - uid: 5364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-3.5
       parent: 1
-  - uid: 5353
+  - uid: 5365
     components:
     - type: Transform
       pos: -4.5,64.5
       parent: 1
-  - uid: 5354
+  - uid: 5366
     components:
     - type: Transform
       pos: 1.5,64.5
       parent: 1
-  - uid: 5355
+  - uid: 5367
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -37305,65 +37373,65 @@ entities:
       parent: 1
 - proto: RMCPlatformStairLeft
   entities:
-  - uid: 5356
+  - uid: 5368
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,42.5
       parent: 1
-  - uid: 5357
+  - uid: 5369
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-49.5
       parent: 1
-  - uid: 5358
+  - uid: 5370
     components:
     - type: Transform
       pos: 12.5,38.5
       parent: 1
-  - uid: 5359
+  - uid: 5371
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,37.5
       parent: 1
-  - uid: 5360
+  - uid: 5372
     components:
     - type: Transform
       pos: -9.5,38.5
       parent: 1
-  - uid: 5361
+  - uid: 5373
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,37.5
       parent: 1
-  - uid: 5362
+  - uid: 5374
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-40.5
       parent: 1
-  - uid: 5363
+  - uid: 5375
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,64.5
       parent: 1
-  - uid: 5364
+  - uid: 5376
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,48.5
       parent: 1
-  - uid: 5365
+  - uid: 5377
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,36.5
       parent: 1
-  - uid: 5366
+  - uid: 5378
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -37371,61 +37439,61 @@ entities:
       parent: 1
 - proto: RMCPlatformStairRight
   entities:
-  - uid: 5367
+  - uid: 5379
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,42.5
       parent: 1
-  - uid: 5368
+  - uid: 5380
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,37.5
       parent: 1
-  - uid: 5369
+  - uid: 5381
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,42.5
       parent: 1
-  - uid: 5370
+  - uid: 5382
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,37.5
       parent: 1
-  - uid: 5371
+  - uid: 5383
     components:
     - type: Transform
       pos: -13.5,38.5
       parent: 1
-  - uid: 5372
+  - uid: 5384
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,57.5
       parent: 1
-  - uid: 5373
+  - uid: 5385
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,64.5
       parent: 1
-  - uid: 5374
+  - uid: 5386
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,36.5
       parent: 1
-  - uid: 5375
+  - uid: 5387
     components:
     - type: Transform
       pos: 8.5,38.5
       parent: 1
 - proto: RMCPodDoorAIBlackLockdown
   entities:
-  - uid: 5376
+  - uid: 5388
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -37433,7 +37501,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: ussgeorgebushciclockdownmghm
-  - uid: 5377
+  - uid: 5389
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -37443,7 +37511,7 @@ entities:
       id: ussgeorgebushciclockdownmghm
 - proto: RMCPodDoorButtonBigRed
   entities:
-  - uid: 5378
+  - uid: 5390
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -37453,7 +37521,7 @@ entities:
       id: 512340
     - type: Fixtures
       fixtures: {}
-  - uid: 5379
+  - uid: 5391
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -37463,7 +37531,7 @@ entities:
       id: 14327
     - type: Fixtures
       fixtures: {}
-  - uid: 5380
+  - uid: 5392
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -37475,7 +37543,16 @@ entities:
       fixtures: {}
 - proto: RMCPodDoorButtonBigRedShip
   entities:
-  - uid: 5381
+  - uid: 5393
+    components:
+    - type: Transform
+      pos: 8.5,36.5
+      parent: 1
+    - type: RMCDoorButton
+      id: 2153895539
+    - type: Fixtures
+      fixtures: {}
+  - uid: 5394
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -37485,7 +37562,7 @@ entities:
       id: 13289
     - type: Fixtures
       fixtures: {}
-  - uid: 5382
+  - uid: 5395
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -37495,7 +37572,7 @@ entities:
       id: 14418
     - type: Fixtures
       fixtures: {}
-  - uid: 5383
+  - uid: 5396
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -37505,9 +37582,36 @@ entities:
       id: 60548329
     - type: Fixtures
       fixtures: {}
+  - uid: 5397
+    components:
+    - type: Transform
+      pos: -9.5,36.5
+      parent: 1
+    - type: RMCDoorButton
+      id: 91239465
+    - type: Fixtures
+      fixtures: {}
+  - uid: 5398
+    components:
+    - type: Transform
+      pos: -13.5,36.5
+      parent: 1
+    - type: RMCDoorButton
+      id: 46789132
+    - type: Fixtures
+      fixtures: {}
+  - uid: 5399
+    components:
+    - type: Transform
+      pos: 12.5,36.5
+      parent: 1
+    - type: RMCDoorButton
+      id: 5423459816
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCPodDoorButtonShip
   entities:
-  - uid: 5384
+  - uid: 5400
     components:
     - type: Transform
       pos: 24.5,19.5
@@ -37516,7 +37620,7 @@ entities:
       id: 6767
     - type: Fixtures
       fixtures: {}
-  - uid: 5385
+  - uid: 5401
     components:
     - type: MetaData
       name: CIC Lockdown
@@ -37527,120 +37631,139 @@ entities:
       id: ussgeorgebushciclockdownmghm
     - type: Fixtures
       fixtures: {}
-  - uid: 5386
+  - uid: 5402
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6,-65.5
       parent: 1
-    - type: RMCDoorButton
-      id: georgebushengineeringsotage
-    - type: Fixtures
-      fixtures: {}
-  - uid: 5387
-    components:
-    - type: MetaData
-      name: brig cells lockdown
-    - type: Transform
-      pos: 8.5,-32.5
-      parent: 1
-    - type: RMCDoorButton
-      id: goergebushprisonlockdown
     - type: Fixtures
       fixtures: {}
 - proto: RMCPodDoorHybrisaRed
   entities:
-  - uid: 5388
+  - uid: 5403
     components:
     - type: Transform
       pos: -15.5,36.5
       parent: 1
-  - uid: 5389
+    - type: RMCPodDoor
+      id: 46789132
+  - uid: 5404
     components:
     - type: Transform
       pos: -6.5,36.5
       parent: 1
-  - uid: 5390
+    - type: RMCPodDoor
+      id: 91239465
+  - uid: 5405
     components:
     - type: Transform
       pos: -14.5,36.5
       parent: 1
-  - uid: 5391
+    - type: RMCPodDoor
+      id: 46789132
+  - uid: 5406
     components:
     - type: Transform
       pos: -17.5,36.5
       parent: 1
-  - uid: 5392
+    - type: RMCPodDoor
+      id: 46789132
+  - uid: 5407
     components:
     - type: Transform
       pos: -8.5,36.5
       parent: 1
-  - uid: 5393
+    - type: RMCPodDoor
+      id: 91239465
+  - uid: 5408
     components:
     - type: Transform
       pos: -5.5,36.5
       parent: 1
-  - uid: 5394
+    - type: RMCPodDoor
+      id: 91239465
+  - uid: 5409
     components:
     - type: Transform
       pos: -16.5,36.5
       parent: 1
-  - uid: 5395
+    - type: RMCPodDoor
+      id: 46789132
+  - uid: 5410
     components:
     - type: Transform
       pos: -7.5,36.5
       parent: 1
-  - uid: 5396
+    - type: RMCPodDoor
+      id: 91239465
+  - uid: 5411
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,36.5
       parent: 1
-  - uid: 5397
+    - type: RMCPodDoor
+      id: 5423459816
+  - uid: 5412
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,36.5
       parent: 1
-  - uid: 5398
+    - type: RMCPodDoor
+      id: 5423459816
+  - uid: 5413
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,36.5
       parent: 1
-  - uid: 5399
+    - type: RMCPodDoor
+      id: 5423459816
+  - uid: 5414
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,36.5
       parent: 1
-  - uid: 5400
+    - type: RMCPodDoor
+      id: 5423459816
+  - uid: 5415
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,36.5
       parent: 1
-  - uid: 5401
+    - type: RMCPodDoor
+      id: 2153895539
+  - uid: 5416
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,36.5
       parent: 1
-  - uid: 5402
+    - type: RMCPodDoor
+      id: 2153895539
+  - uid: 5417
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,36.5
       parent: 1
-  - uid: 5403
+    - type: RMCPodDoor
+      id: 2153895539
+  - uid: 5418
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,36.5
       parent: 1
+    - type: RMCPodDoor
+      id: 2153895539
 - proto: RMCPodDoorHybrisaRedOpen
   entities:
-  - uid: 5404
+  - uid: 5419
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -37648,71 +37771,71 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 13289
-  - uid: 5405
+  - uid: 5420
     components:
     - type: Transform
       pos: 19.5,4.5
       parent: 1
     - type: RMCPodDoor
       id: 512340
-  - uid: 5406
+  - uid: 5421
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,36.5
       parent: 1
-  - uid: 5407
+  - uid: 5422
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,36.5
       parent: 1
-  - uid: 5408
+  - uid: 5423
     components:
     - type: Transform
       pos: 20.5,4.5
       parent: 1
     - type: RMCPodDoor
       id: 512340
-  - uid: 5409
+  - uid: 5424
     components:
     - type: Transform
       pos: 19.5,-0.5
       parent: 1
     - type: RMCPodDoor
       id: 14418
-  - uid: 5410
+  - uid: 5425
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,36.5
       parent: 1
-  - uid: 5411
+  - uid: 5426
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,36.5
       parent: 1
-  - uid: 5412
+  - uid: 5427
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,36.5
       parent: 1
-  - uid: 5413
+  - uid: 5428
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,36.5
       parent: 1
-  - uid: 5414
+  - uid: 5429
     components:
     - type: Transform
       pos: 20.5,-0.5
       parent: 1
     - type: RMCPodDoor
       id: 14418
-  - uid: 5415
+  - uid: 5430
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -37720,7 +37843,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 60548329
-  - uid: 5416
+  - uid: 5431
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -37728,7 +37851,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 4718329
-  - uid: 5417
+  - uid: 5432
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -37736,7 +37859,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 4718329
-  - uid: 5418
+  - uid: 5433
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -37744,7 +37867,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 14327
-  - uid: 5419
+  - uid: 5434
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -37754,79 +37877,79 @@ entities:
       id: 14327
 - proto: RMCRackSoro
   entities:
-  - uid: 5420
+  - uid: 5435
     components:
     - type: Transform
       pos: 7.5,48.5
       parent: 1
-  - uid: 5421
+  - uid: 5436
     components:
     - type: Transform
       pos: 3.5,48.5
       parent: 1
-  - uid: 5422
+  - uid: 5437
     components:
     - type: Transform
       pos: 17.5,26.5
       parent: 1
-  - uid: 5423
+  - uid: 5438
     components:
     - type: Transform
       pos: -14.5,30.5
       parent: 1
-  - uid: 5424
+  - uid: 5439
     components:
     - type: Transform
       pos: -18.5,27.5
       parent: 1
-  - uid: 5425
+  - uid: 5440
     components:
     - type: Transform
       pos: 17.5,27.5
       parent: 1
-  - uid: 5426
+  - uid: 5441
     components:
     - type: Transform
       pos: -18.5,26.5
       parent: 1
-  - uid: 5427
+  - uid: 5442
     components:
     - type: Transform
       pos: 11.5,43.5
       parent: 1
-  - uid: 5428
+  - uid: 5443
     components:
     - type: Transform
       pos: 2.5,45.5
       parent: 1
-  - uid: 5429
+  - uid: 5444
     components:
     - type: Transform
       pos: 6.5,45.5
       parent: 1
-  - uid: 5430
+  - uid: 5445
     components:
     - type: Transform
       pos: 7.5,45.5
       parent: 1
-  - uid: 5431
+  - uid: 5446
     components:
     - type: Transform
       pos: 5.5,45.5
       parent: 1
-  - uid: 5432
+  - uid: 5447
     components:
     - type: Transform
       pos: 4.5,45.5
       parent: 1
-  - uid: 5433
+  - uid: 5448
     components:
     - type: Transform
       pos: 3.5,45.5
       parent: 1
 - proto: RMCRailgunProp
   entities:
-  - uid: 5434
+  - uid: 5449
     components:
     - type: MetaData
       desc: The Point-Defense Anti Ship Railgun is an advanced magnetic mass accelerator cannon which utilizes a long linear system of magnetic coils to propel metal payloads at incredible speeds.
@@ -37837,7 +37960,7 @@ entities:
       parent: 1
 - proto: RMCRailgunPropFlipped
   entities:
-  - uid: 5435
+  - uid: 5450
     components:
     - type: MetaData
       desc: The Point-Defense Anti Ship Railgun is an advanced magnetic mass accelerator cannon which utilizes a long linear system of magnetic coils to propel metal payloads at incredible speeds.
@@ -37847,44 +37970,44 @@ entities:
       parent: 1
 - proto: RMCRollerBedHospitalSheet2
   entities:
-  - uid: 5436
+  - uid: 5451
     components:
     - type: Transform
       pos: -27.5,15.5
       parent: 1
-  - uid: 5437
+  - uid: 5452
     components:
     - type: Transform
       pos: -27.5,14.5
       parent: 1
-  - uid: 5438
+  - uid: 5453
     components:
     - type: Transform
       pos: -27.5,13.5
       parent: 1
-  - uid: 5439
+  - uid: 5454
     components:
     - type: Transform
       pos: -27.5,12.5
       parent: 1
-  - uid: 5440
+  - uid: 5455
     components:
     - type: Transform
       pos: -25.5,15.5
       parent: 1
-  - uid: 5441
+  - uid: 5456
     components:
     - type: Transform
       pos: -25.5,14.5
       parent: 1
-  - uid: 5442
+  - uid: 5457
     components:
     - type: Transform
       pos: -25.5,13.5
       parent: 1
 - proto: RMCRotaryPhone
   entities:
-  - uid: 5443
+  - uid: 5458
     components:
     - type: MetaData
       name: Requesitions
@@ -37895,7 +38018,7 @@ entities:
       category: USS George W. Bush
     - type: Fixtures
       fixtures: {}
-  - uid: 5444
+  - uid: 5459
     components:
     - type: MetaData
       name: Brig Office
@@ -37906,7 +38029,7 @@ entities:
       category: USS George W. Bush
     - type: Fixtures
       fixtures: {}
-  - uid: 5445
+  - uid: 5460
     components:
     - type: MetaData
       name: Briefing
@@ -37917,7 +38040,7 @@ entities:
       category: USS George W. Bush
     - type: Fixtures
       fixtures: {}
-  - uid: 5446
+  - uid: 5461
     components:
     - type: MetaData
       name: Kitchen
@@ -37928,7 +38051,7 @@ entities:
       category: USS George W. Bush
     - type: Fixtures
       fixtures: {}
-  - uid: 5447
+  - uid: 5462
     components:
     - type: MetaData
       name: Post Exchange
@@ -37939,7 +38062,7 @@ entities:
       category: USS George W. Bush
     - type: Fixtures
       fixtures: {}
-  - uid: 5448
+  - uid: 5463
     components:
     - type: MetaData
       name: CIC Office
@@ -37950,7 +38073,7 @@ entities:
       category: USS George W. Bush
     - type: Fixtures
       fixtures: {}
-  - uid: 5449
+  - uid: 5464
     components:
     - type: MetaData
       name: CIC
@@ -37961,7 +38084,7 @@ entities:
       category: USS George W. Bush
     - type: Fixtures
       fixtures: {}
-  - uid: 5450
+  - uid: 5465
     components:
     - type: MetaData
       name: Chief MP's Office
@@ -37972,7 +38095,7 @@ entities:
       category: USS George W. Bush
     - type: Fixtures
       fixtures: {}
-  - uid: 5451
+  - uid: 5466
     components:
     - type: MetaData
       name: United Progressive People's Consulate
@@ -37983,7 +38106,7 @@ entities:
       category: USS George W. Bush
     - type: Fixtures
       fixtures: {}
-  - uid: 5452
+  - uid: 5467
     components:
     - type: MetaData
       name: United America's Consulate
@@ -37996,17 +38119,7 @@ entities:
       fixtures: {}
 - proto: RMCRotaryPhoneWallmount
   entities:
-  - uid: 5453
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -24,24.5
-      parent: 1
-    - type: RotaryPhone
-      category: USS George W. Bush
-    - type: Fixtures
-      fixtures: {}
-  - uid: 5454
+  - uid: 5468
     components:
     - type: MetaData
       name: Intelligence Office
@@ -38020,303 +38133,303 @@ entities:
       fixtures: {}
 - proto: RMCSecureCase
   entities:
-  - uid: 5455
+  - uid: 5469
     components:
     - type: Transform
       pos: 15.5,-14.5
       parent: 1
 - proto: RMCSecureCaseChest
   entities:
-  - uid: 5456
+  - uid: 5470
     components:
     - type: Transform
       pos: 13.5,-14.5
       parent: 1
-  - uid: 5457
+  - uid: 5471
     components:
     - type: Transform
       pos: -10.5,-64.5
       parent: 1
 - proto: RMCSecureCaseDouble
   entities:
-  - uid: 5458
+  - uid: 5472
     components:
     - type: Transform
       pos: 12.5,-14.5
       parent: 1
-  - uid: 5459
+  - uid: 5473
+    components:
+    - type: Transform
+      pos: -7.5,42.5
+      parent: 1
+  - uid: 5474
     components:
     - type: Transform
       pos: 2.5,-14.5
       parent: 1
-  - uid: 5460
+  - uid: 5475
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
-  - uid: 5461
+  - uid: 5476
     components:
     - type: Transform
       pos: 15.5,39.5
       parent: 1
-  - uid: 5462
+  - uid: 5477
+    components:
+    - type: Transform
+      pos: -7.5,38.5
+      parent: 1
+  - uid: 5478
     components:
     - type: Transform
       pos: -10.5,-63.5
       parent: 1
-  - uid: 5463
+  - uid: 5479
     components:
     - type: Transform
       pos: 23.5,25.5
       parent: 1
 - proto: RMCSecureCaseMedicalBig
   entities:
-  - uid: 5464
+  - uid: 5480
     components:
     - type: Transform
       pos: 12.5,-3.5
       parent: 1
-- proto: RMCSecureCaseMedicalBigIV
-  entities:
-  - uid: 5465
-    components:
-    - type: Transform
-      pos: -29.5,10.5
-      parent: 1
 - proto: RMCSecureCaseMini
   entities:
-  - uid: 5466
+  - uid: 5481
     components:
     - type: Transform
       pos: 3.1978776,-14.660352
       parent: 1
-  - uid: 5467
+  - uid: 5482
     components:
     - type: Transform
       pos: -10.747843,-61.92354
       parent: 1
-  - uid: 5468
+  - uid: 5483
     components:
     - type: Transform
       pos: -10.825968,-66.14229
       parent: 1
 - proto: RMCSecureCaseSmall
   entities:
-  - uid: 5469
+  - uid: 5484
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 1
-  - uid: 5470
+  - uid: 5485
     components:
     - type: Transform
       pos: 11.5,-14.5
       parent: 1
-  - uid: 5471
+  - uid: 5486
     components:
     - type: Transform
       pos: -10.5,-62.5
       parent: 1
+- proto: RMCSecureCaseStrapped
+  entities:
+  - uid: 5487
+    components:
+    - type: Transform
+      pos: -8.5,42.5
+      parent: 1
 - proto: RMCSecureCaseStrappedFlare
   entities:
-  - uid: 5473
+  - uid: 5488
     components:
     - type: Transform
       pos: 14.5,-14.5
       parent: 1
 - proto: RMCSecureCaseStrappedTripod
   entities:
-  - uid: 5474
+  - uid: 5489
     components:
     - type: Transform
       pos: 0.5,-14.5
       parent: 1
-  - uid: 5475
+  - uid: 5490
     components:
     - type: Transform
       pos: 1.5,-14.5
       parent: 1
-  - uid: 5476
+  - uid: 5491
     components:
     - type: Transform
       pos: 15.5,40.5
       parent: 1
-  - uid: 5477
+  - uid: 5492
     components:
     - type: Transform
       pos: 16.5,-14.5
       parent: 1
-  - uid: 5478
+  - uid: 5493
     components:
     - type: Transform
       pos: 14.5,38.5
       parent: 1
 - proto: RMCSecurityCameraConsole
   entities:
-  - uid: 5479
+  - uid: 5494
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-34.5
       parent: 1
-  - uid: 5480
+  - uid: 5495
     components:
     - type: Transform
       pos: 6.5,-34.5
       parent: 1
-  - uid: 5481
+  - uid: 5496
     components:
     - type: Transform
       pos: 4.5,-34.5
       parent: 1
 - proto: RMCSheetPlastic
   entities:
-  - uid: 5482
+  - uid: 5497
     components:
     - type: Transform
-      pos: -27.634829,24.568226
+      pos: -27.492714,24.423275
       parent: 1
 - proto: RMCShoesBlack
   entities:
+  - uid: 21
+    components:
+    - type: Transform
+      parent: 16
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 22
+    components:
+    - type: Transform
+      parent: 16
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
   - uid: 23
     components:
     - type: Transform
-      parent: 18
+      parent: 16
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 24
     components:
     - type: Transform
-      parent: 18
+      parent: 16
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 25
+  - uid: 30
     components:
     - type: Transform
-      parent: 18
+      parent: 25
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 26
+  - uid: 31
     components:
     - type: Transform
-      parent: 18
+      parent: 25
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 32
     components:
     - type: Transform
-      parent: 27
+      parent: 25
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 33
     components:
     - type: Transform
-      parent: 27
+      parent: 25
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 34
+  - uid: 39
     components:
     - type: Transform
-      parent: 27
+      parent: 34
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 35
+  - uid: 40
     components:
     - type: Transform
-      parent: 27
+      parent: 34
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 41
     components:
     - type: Transform
-      parent: 36
+      parent: 34
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 42
     components:
     - type: Transform
-      parent: 36
+      parent: 34
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 43
+  - uid: 48
     components:
     - type: Transform
-      parent: 36
+      parent: 43
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 44
+  - uid: 49
     components:
     - type: Transform
-      parent: 36
+      parent: 43
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 50
     components:
     - type: Transform
-      parent: 45
+      parent: 43
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 51
     components:
     - type: Transform
-      parent: 45
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 52
-    components:
-    - type: Transform
-      parent: 45
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 53
-    components:
-    - type: Transform
-      parent: 45
+      parent: 43
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: RMCShutterAlmayerAntiTheft
   entities:
-  - uid: 5483
+  - uid: 5498
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-66.5
       parent: 1
-    - type: RMCPodDoor
-      id: georgebushengineeringsotage
-  - uid: 5484
+  - uid: 5499
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-67.5
       parent: 1
-    - type: RMCPodDoor
-      id: georgebushengineeringsotage
 - proto: RMCShutterAlmayerOpen
   entities:
-  - uid: 5485
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -28.5,9.5
-      parent: 1
-  - uid: 5486
+  - uid: 5500
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -38324,21 +38437,21 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 13289
-  - uid: 5487
+  - uid: 5501
     components:
     - type: Transform
       pos: 17.5,4.5
       parent: 1
     - type: RMCPodDoor
       id: 13289
-  - uid: 5488
+  - uid: 5502
     components:
     - type: Transform
       pos: 16.5,4.5
       parent: 1
     - type: RMCPodDoor
       id: 13289
-  - uid: 5489
+  - uid: 5503
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -38346,7 +38459,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 13289
-  - uid: 5490
+  - uid: 5504
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -38354,7 +38467,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 13289
-  - uid: 5491
+  - uid: 5505
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -38362,7 +38475,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 60548329
-  - uid: 5492
+  - uid: 5506
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -38370,7 +38483,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 60548329
-  - uid: 5493
+  - uid: 5507
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -38378,7 +38491,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 60548329
-  - uid: 5494
+  - uid: 5508
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -38386,7 +38499,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 60548329
-  - uid: 5495
+  - uid: 5509
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -38394,165 +38507,147 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 60548329
-  - uid: 5496
+  - uid: 5510
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 5497
-    components:
-    - type: Transform
-      pos: 2.5,-11.5
-      parent: 1
-  - uid: 5498
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,-11.5
-      parent: 1
-  - uid: 5499
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-8.5
-      parent: 1
-  - uid: 5500
-    components:
-    - type: Transform
-      pos: -1.5,-11.5
-      parent: 1
-  - uid: 5501
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-8.5
-      parent: 1
-  - uid: 5502
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-8.5
-      parent: 1
-  - uid: 5503
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,-8.5
-      parent: 1
-  - uid: 5504
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,-8.5
-      parent: 1
-  - uid: 5505
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-8.5
-      parent: 1
-  - uid: 5506
-    components:
-    - type: Transform
-      pos: -0.5,-11.5
-      parent: 1
-  - uid: 5507
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,-8.5
-      parent: 1
-  - uid: 5508
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,-11.5
-      parent: 1
-  - uid: 5509
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-8.5
-      parent: 1
-  - uid: 5510
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,-8.5
-      parent: 1
   - uid: 5511
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-8.5
+      pos: 2.5,-11.5
       parent: 1
   - uid: 5512
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 15.5,-11.5
+      pos: 12.5,-11.5
       parent: 1
   - uid: 5513
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 13.5,-11.5
+      pos: 3.5,-8.5
       parent: 1
   - uid: 5514
     components:
     - type: Transform
-      pos: 1.5,-11.5
+      pos: -1.5,-11.5
       parent: 1
   - uid: 5515
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 12.5,-8.5
+      pos: -1.5,-8.5
       parent: 1
   - uid: 5516
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 14.5,-11.5
+      pos: -0.5,-8.5
       parent: 1
   - uid: 5517
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 11.5,-11.5
+      pos: 14.5,-8.5
       parent: 1
   - uid: 5518
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 13.5,-8.5
+      pos: 16.5,-8.5
       parent: 1
   - uid: 5519
     components:
     - type: Transform
-      pos: 3.5,-11.5
+      rot: 3.141592653589793 rad
+      pos: 0.5,-8.5
       parent: 1
   - uid: 5520
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -27.5,9.5
+      pos: -0.5,-11.5
       parent: 1
   - uid: 5521
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -26.5,9.5
+      pos: 15.5,-8.5
       parent: 1
   - uid: 5522
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -25.5,9.5
+      pos: 16.5,-11.5
+      parent: 1
+  - uid: 5523
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-8.5
+      parent: 1
+  - uid: 5524
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-8.5
+      parent: 1
+  - uid: 5525
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-8.5
+      parent: 1
+  - uid: 5526
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-11.5
+      parent: 1
+  - uid: 5527
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-11.5
+      parent: 1
+  - uid: 5528
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 1
+  - uid: 5529
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-8.5
+      parent: 1
+  - uid: 5530
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-11.5
+      parent: 1
+  - uid: 5531
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-11.5
+      parent: 1
+  - uid: 5532
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-8.5
+      parent: 1
+  - uid: 5533
+    components:
+    - type: Transform
+      pos: 3.5,-11.5
       parent: 1
 - proto: RMCShutterHybrisa
   entities:
-  - uid: 5523
+  - uid: 5534
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -38560,7 +38655,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 6767
-  - uid: 5524
+  - uid: 5535
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -38568,7 +38663,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 6767
-  - uid: 5525
+  - uid: 5536
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -38576,7 +38671,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 6767
-  - uid: 5526
+  - uid: 5537
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -38584,7 +38679,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 6767
-  - uid: 5527
+  - uid: 5538
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -38592,7 +38687,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 6767
-  - uid: 5528
+  - uid: 5539
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -38600,7 +38695,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 6767
-  - uid: 5529
+  - uid: 5540
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -38608,7 +38703,7 @@ entities:
       parent: 1
     - type: RMCPodDoor
       id: 6767
-  - uid: 5530
+  - uid: 5541
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -38618,170 +38713,170 @@ entities:
       id: 6767
 - proto: RMCShutterHybrisaWindow
   entities:
-  - uid: 5531
+  - uid: 5542
     components:
     - type: Transform
       pos: 4.5,-33.5
       parent: 1
-  - uid: 5532
+  - uid: 5543
     components:
     - type: Transform
       pos: 7.5,-33.5
       parent: 1
-  - uid: 5533
+  - uid: 5544
     components:
     - type: Transform
       pos: 10.5,-49.5
       parent: 1
-  - uid: 5534
+  - uid: 5545
     components:
     - type: Transform
       pos: 10.5,-43.5
       parent: 1
-  - uid: 5535
-    components:
-    - type: Transform
-      pos: 7.5,-43.5
-      parent: 1
-  - uid: 5536
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-29.5
-      parent: 1
-  - uid: 5537
-    components:
-    - type: Transform
-      pos: 4.5,-43.5
-      parent: 1
-  - uid: 5538
-    components:
-    - type: Transform
-      pos: 1.5,-43.5
-      parent: 1
-  - uid: 5539
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-51.5
-      parent: 1
-  - uid: 5540
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-33.5
-      parent: 1
-  - uid: 5541
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-33.5
-      parent: 1
-  - uid: 5542
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-32.5
-      parent: 1
-  - uid: 5543
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-50.5
-      parent: 1
-  - uid: 5544
-    components:
-    - type: Transform
-      pos: 6.5,-33.5
-      parent: 1
-  - uid: 5545
-    components:
-    - type: Transform
-      pos: 11.5,-49.5
-      parent: 1
   - uid: 5546
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-30.5
+      pos: 7.5,-43.5
       parent: 1
   - uid: 5547
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,-31.5
+      pos: 5.5,-29.5
       parent: 1
   - uid: 5548
     components:
     - type: Transform
-      pos: 9.5,-49.5
+      pos: 4.5,-43.5
       parent: 1
   - uid: 5549
     components:
     - type: Transform
-      pos: 11.5,-33.5
+      pos: 1.5,-43.5
       parent: 1
   - uid: 5550
     components:
     - type: Transform
-      pos: -0.5,-15.5
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-51.5
       parent: 1
   - uid: 5551
     components:
     - type: Transform
-      pos: 15.5,-15.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,-33.5
       parent: 1
   - uid: 5552
     components:
     - type: Transform
-      pos: 11.5,-15.5
+      rot: 3.141592653589793 rad
+      pos: 3.5,-33.5
       parent: 1
   - uid: 5553
     components:
     - type: Transform
-      pos: 2.5,-15.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-32.5
       parent: 1
   - uid: 5554
     components:
     - type: Transform
-      pos: 3.5,-15.5
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-50.5
       parent: 1
   - uid: 5555
     components:
     - type: Transform
-      pos: 8.5,-49.5
+      pos: 6.5,-33.5
       parent: 1
   - uid: 5556
     components:
     - type: Transform
-      pos: -1.5,-15.5
+      pos: 11.5,-49.5
       parent: 1
   - uid: 5557
     components:
     - type: Transform
-      pos: 10.5,-15.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-30.5
       parent: 1
   - uid: 5558
     components:
     - type: Transform
-      pos: 16.5,-15.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-31.5
       parent: 1
   - uid: 5559
     components:
     - type: Transform
-      pos: 0.5,-15.5
+      pos: 9.5,-49.5
       parent: 1
   - uid: 5560
     components:
     - type: Transform
-      pos: 12.5,-15.5
+      pos: 11.5,-33.5
       parent: 1
   - uid: 5561
     components:
     - type: Transform
-      pos: 14.5,-15.5
+      pos: -0.5,-15.5
       parent: 1
   - uid: 5562
+    components:
+    - type: Transform
+      pos: 15.5,-15.5
+      parent: 1
+  - uid: 5563
+    components:
+    - type: Transform
+      pos: 11.5,-15.5
+      parent: 1
+  - uid: 5564
+    components:
+    - type: Transform
+      pos: 2.5,-15.5
+      parent: 1
+  - uid: 5565
+    components:
+    - type: Transform
+      pos: 3.5,-15.5
+      parent: 1
+  - uid: 5566
+    components:
+    - type: Transform
+      pos: 8.5,-49.5
+      parent: 1
+  - uid: 5567
+    components:
+    - type: Transform
+      pos: -1.5,-15.5
+      parent: 1
+  - uid: 5568
+    components:
+    - type: Transform
+      pos: 10.5,-15.5
+      parent: 1
+  - uid: 5569
+    components:
+    - type: Transform
+      pos: 16.5,-15.5
+      parent: 1
+  - uid: 5570
+    components:
+    - type: Transform
+      pos: 0.5,-15.5
+      parent: 1
+  - uid: 5571
+    components:
+    - type: Transform
+      pos: 12.5,-15.5
+      parent: 1
+  - uid: 5572
+    components:
+    - type: Transform
+      pos: 14.5,-15.5
+      parent: 1
+  - uid: 5573
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -38789,48 +38884,40 @@ entities:
       parent: 1
 - proto: RMCShutterHybrisaWindowOpen
   entities:
-  - uid: 5563
+  - uid: 5574
     components:
     - type: Transform
       pos: -1.5,54.5
       parent: 1
     - type: RMCPodDoor
       id: ussgeorgebushciclockdownmghm
-  - uid: 5564
+  - uid: 5575
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-43.5
       parent: 1
-    - type: RMCPodDoor
-      id: goergebushprisonlockdown
-  - uid: 5565
+  - uid: 5576
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-43.5
       parent: 1
-    - type: RMCPodDoor
-      id: goergebushprisonlockdown
-  - uid: 5566
+  - uid: 5577
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-43.5
       parent: 1
-    - type: RMCPodDoor
-      id: goergebushprisonlockdown
-  - uid: 5567
+  - uid: 5578
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-43.5
       parent: 1
-    - type: RMCPodDoor
-      id: goergebushprisonlockdown
 - proto: RMCSignRequisitions
   entities:
-  - uid: 5568
+  - uid: 5579
     components:
     - type: MetaData
       name: requisitions office guidelines
@@ -38839,19 +38926,19 @@ entities:
       parent: 1
 - proto: RMCSmartFridge
   entities:
-  - uid: 5569
+  - uid: 5580
     components:
     - type: Transform
       pos: -23.5,22.5
       parent: 1
-  - uid: 5570
+  - uid: 5581
     components:
     - type: Transform
       pos: -25.5,19.5
       parent: 1
 - proto: RMCSpawnerEvacuationPodEast
   entities:
-  - uid: 5571
+  - uid: 5582
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -38859,23 +38946,23 @@ entities:
       parent: 1
 - proto: RMCSpawnerEvacuationPodNorth
   entities:
-  - uid: 5572
+  - uid: 5583
     components:
     - type: Transform
       pos: -18.5,-61.5
       parent: 1
-  - uid: 5573
+  - uid: 5584
     components:
     - type: Transform
       pos: 13.5,-61.5
       parent: 1
-  - uid: 5574
+  - uid: 5585
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,-4.5
       parent: 1
-  - uid: 5575
+  - uid: 5586
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -38883,7 +38970,7 @@ entities:
       parent: 1
 - proto: RMCSpawnerEvacuationPodWest
   entities:
-  - uid: 5576
+  - uid: 5587
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -38891,264 +38978,242 @@ entities:
       parent: 1
 - proto: RMCSpawnerRandomToolbox
   entities:
-  - uid: 5577
-    components:
-    - type: Transform
-      pos: 4.5,39.5
-      parent: 1
-  - uid: 5578
+  - uid: 5588
     components:
     - type: Transform
       pos: -12.5,-57.5
       parent: 1
-  - uid: 5579
+  - uid: 5589
     components:
     - type: Transform
       pos: -9.5,-68.5
       parent: 1
-  - uid: 5580
+  - uid: 5590
     components:
     - type: Transform
       pos: -6.5,-68.5
       parent: 1
-  - uid: 5581
+  - uid: 5591
     components:
     - type: Transform
       pos: -4.5,-68.5
       parent: 1
-  - uid: 5582
+  - uid: 5592
     components:
     - type: Transform
       pos: 27.5,2.5
       parent: 1
-  - uid: 5583
+  - uid: 5593
     components:
     - type: Transform
       pos: -2.5,-57.5
       parent: 1
-  - uid: 5584
+  - uid: 5594
     components:
     - type: Transform
       pos: -5.5,-57.5
       parent: 1
-  - uid: 5585
+  - uid: 5595
     components:
     - type: Transform
       pos: -6.5,-57.5
       parent: 1
-  - uid: 5586
-    components:
-    - type: Transform
-      pos: 7.5,38.5
-      parent: 1
-  - uid: 5587
-    components:
-    - type: Transform
-      pos: 7.5,42.5
-      parent: 1
 - proto: RMCSpawnerRandomTools
   entities:
-  - uid: 5588
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,41.5
-      parent: 1
-  - uid: 5589
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,40.5
-      parent: 1
-  - uid: 5590
-    components:
-    - type: Transform
-      pos: 7.5,41.5
-      parent: 1
-  - uid: 5591
+  - uid: 5596
     components:
     - type: Transform
       pos: 10.5,-3.5
       parent: 1
-  - uid: 5592
+  - uid: 5597
     components:
     - type: Transform
       pos: -12.5,-59.5
       parent: 1
-  - uid: 5593
+  - uid: 5598
     components:
     - type: Transform
       pos: -11.5,-57.5
       parent: 1
-  - uid: 5594
+  - uid: 5599
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-68.5
       parent: 1
-  - uid: 5595
+  - uid: 5600
     components:
     - type: Transform
       pos: -8.5,-68.5
       parent: 1
-  - uid: 5596
+  - uid: 5601
     components:
     - type: Transform
       pos: 27.5,1.5
       parent: 1
-  - uid: 5597
+  - uid: 5602
     components:
     - type: Transform
       pos: 29.5,5.5
       parent: 1
-  - uid: 5598
+  - uid: 5603
     components:
     - type: Transform
       pos: 2.5,-65.5
       parent: 1
-  - uid: 5599
+  - uid: 5604
     components:
     - type: Transform
       pos: 3.5,-65.5
       parent: 1
-  - uid: 5600
+  - uid: 5605
     components:
     - type: Transform
       pos: 4.5,-65.5
       parent: 1
-  - uid: 5601
+  - uid: 5606
     components:
     - type: Transform
       pos: -4.5,-57.5
       parent: 1
 - proto: RMCStatusDisplay
   entities:
-  - uid: 5602
+  - uid: 5607
     components:
     - type: Transform
       pos: -12.5,-0.5
       parent: 1
-  - uid: 5603
+  - uid: 5608
     components:
     - type: Transform
       pos: -10.5,-29.5
       parent: 1
-  - uid: 5604
+  - uid: 5609
     components:
     - type: Transform
       pos: -6.5,-29.5
       parent: 1
-  - uid: 5605
-    components:
-    - type: Transform
-      pos: -9.5,36.5
-      parent: 1
-  - uid: 5606
-    components:
-    - type: Transform
-      pos: 12.5,36.5
-      parent: 1
-  - uid: 5607
-    components:
-    - type: Transform
-      pos: 18.5,24.5
-      parent: 1
-  - uid: 5608
-    components:
-    - type: Transform
-      pos: -22.5,24.5
-      parent: 1
-  - uid: 5609
-    components:
-    - type: Transform
-      pos: -22.5,4.5
-      parent: 1
   - uid: 5610
     components:
     - type: Transform
-      pos: 21.5,4.5
+      pos: 18.5,34.5
       parent: 1
   - uid: 5611
     components:
     - type: Transform
-      pos: 1.5,-4.5
+      pos: 18.5,24.5
       parent: 1
   - uid: 5612
     components:
     - type: Transform
-      pos: 13.5,-4.5
+      pos: -22.5,24.5
       parent: 1
   - uid: 5613
     components:
     - type: Transform
-      pos: 7.5,-20.5
+      pos: -22.5,4.5
       parent: 1
   - uid: 5614
     components:
     - type: Transform
-      pos: 8.5,-33.5
+      pos: 21.5,4.5
       parent: 1
-- proto: RMCStatusDisplayLarge
-  entities:
   - uid: 5615
     components:
     - type: Transform
-      pos: -6.5,53.5
+      pos: 1.5,-4.5
       parent: 1
   - uid: 5616
     components:
     - type: Transform
-      pos: -16.5,-0.5
+      pos: 13.5,-4.5
       parent: 1
   - uid: 5617
+    components:
+    - type: Transform
+      pos: 7.5,-20.5
+      parent: 1
+  - uid: 5618
+    components:
+    - type: Transform
+      pos: 8.5,-33.5
+      parent: 1
+  - uid: 5619
+    components:
+    - type: Transform
+      pos: -4.5,36.5
+      parent: 1
+  - uid: 5620
+    components:
+    - type: Transform
+      pos: 3.5,36.5
+      parent: 1
+  - uid: 5621
+    components:
+    - type: Transform
+      pos: -19.5,34.5
+      parent: 1
+- proto: RMCStatusDisplayLarge
+  entities:
+  - uid: 5622
+    components:
+    - type: Transform
+      pos: -6.5,53.5
+      parent: 1
+  - uid: 5623
+    components:
+    - type: Transform
+      pos: -16.5,-0.5
+      parent: 1
+  - uid: 5624
     components:
     - type: Transform
       pos: 2.5,53.5
       parent: 1
 - proto: RMCStatusDisplayProp
   entities:
-  - uid: 5618
+  - uid: 5625
     components:
     - type: Transform
       pos: -5.5,68.5
       parent: 1
-  - uid: 5619
+  - uid: 5626
     components:
     - type: Transform
       pos: 2.5,68.5
       parent: 1
 - proto: RMCStool
   entities:
-  - uid: 5620
+  - uid: 5627
     components:
     - type: Transform
       pos: -9.5,-25.5
       parent: 1
-  - uid: 5621
+  - uid: 5628
     components:
     - type: Transform
       pos: -8.5,-25.5
       parent: 1
-  - uid: 5622
+  - uid: 5629
     components:
     - type: Transform
       pos: -7.5,-25.5
       parent: 1
 - proto: RMCSurgicalTray
   entities:
-  - uid: 5623
+  - uid: 5630
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.503433,15.498658
       parent: 1
-  - uid: 5624
+  - uid: 5631
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.503433,19.479717
       parent: 1
-  - uid: 5625
+  - uid: 5632
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -39156,14 +39221,14 @@ entities:
       parent: 1
 - proto: RMCSurveillanceCameraAlmayer
   entities:
-  - uid: 5626
+  - uid: 5633
     components:
     - type: Transform
       pos: -9.50989,-12.039097
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 5627
+  - uid: 5634
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -39171,7 +39236,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 5628
+  - uid: 5635
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -39181,13 +39246,13 @@ entities:
       fixtures: {}
 - proto: RMCSystemsComputer
   entities:
-  - uid: 5629
+  - uid: 5636
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,39.5
       parent: 1
-  - uid: 5630
+  - uid: 5637
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -39195,167 +39260,207 @@ entities:
       parent: 1
 - proto: RMCTankReagentDermaline
   entities:
-  - uid: 5631
+  - uid: 5638
     components:
     - type: Transform
       pos: -29.5,21.5
       parent: 1
 - proto: RMCTankReagentEmpty
   entities:
-  - uid: 5632
+  - uid: 5639
     components:
     - type: Transform
       pos: -29.5,23.5
       parent: 1
 - proto: RMCTankReagentFuel
   entities:
-  - uid: 5633
+  - uid: 5640
     components:
     - type: Transform
       pos: 15.5,37.5
       parent: 1
-  - uid: 5634
+  - uid: 5641
+    components:
+    - type: Transform
+      pos: -8.5,37.5
+      parent: 1
+  - uid: 5642
     components:
     - type: Transform
       pos: -29.5,2.5
       parent: 1
-  - uid: 5635
+  - uid: 5643
     components:
     - type: Transform
       pos: -10.5,-57.5
       parent: 1
-  - uid: 5636
+  - uid: 5644
     components:
     - type: Transform
       pos: -7.5,-68.5
       parent: 1
-  - uid: 5637
+  - uid: 5645
     components:
     - type: Transform
       pos: 30.5,7.5
       parent: 1
-  - uid: 5638
+  - uid: 5646
     components:
     - type: Transform
       pos: 1.5,-68.5
       parent: 1
 - proto: RMCTankReagentMeralyne
   entities:
-  - uid: 5639
+  - uid: 5647
     components:
     - type: Transform
       pos: -29.5,22.5
       parent: 1
 - proto: RMCTankReagentWater
   entities:
-  - uid: 5640
+  - uid: 5648
     components:
     - type: Transform
       pos: -3.5,-24.5
       parent: 1
-  - uid: 5641
+  - uid: 5649
     components:
     - type: Transform
       pos: -5.5,-24.5
       parent: 1
-  - uid: 5642
+  - uid: 5650
     components:
     - type: Transform
       pos: 29.5,7.5
       parent: 1
+- proto: RMCToolboxElectrical
+  entities:
+  - uid: 5651
+    components:
+    - type: Transform
+      pos: -10.518744,43.250126
+      parent: 1
+- proto: RMCToolboxElectricalFilled
+  entities:
+  - uid: 5652
+    components:
+    - type: Transform
+      pos: 11.487453,43.665348
+      parent: 1
+- proto: RMCToolboxMechanical
+  entities:
+  - uid: 5653
+    components:
+    - type: Transform
+      pos: -10.542182,43.674442
+      parent: 1
+- proto: RMCToolboxMechanicalGreenFilled
+  entities:
+  - uid: 5654
+    components:
+    - type: Transform
+      pos: 11.50547,43.234005
+      parent: 1
+- proto: RMCToolboxSyndicateFilled
+  entities:
+  - uid: 5655
+    components:
+    - type: Transform
+      pos: -7.6358356,37.426098
+      parent: 1
 - proto: RMCTrayEmpty
   entities:
-  - uid: 5645
+  - uid: 5656
     components:
     - type: Transform
       pos: -8.02593,-21.470251
       parent: 1
-  - uid: 5646
+  - uid: 5657
     components:
     - type: Transform
       pos: -7.9799814,-21.31499
       parent: 1
-  - uid: 5647
+  - uid: 5658
     components:
     - type: Transform
       pos: -7.967244,-21.15815
       parent: 1
 - proto: RMCVendorCigsFree
   entities:
-  - uid: 5648
+  - uid: 5659
     components:
     - type: Transform
       pos: 9.5,-57.5
       parent: 1
 - proto: RMCVendorCoffeeSimple
   entities:
-  - uid: 5649
+  - uid: 5660
     components:
     - type: Transform
       pos: 8.5,-57.5
       parent: 1
-  - uid: 5650
+  - uid: 5661
     components:
     - type: Transform
       pos: 24.5,10.5
       parent: 1
 - proto: RMCVendorNutriCoDrink
   entities:
-  - uid: 5651
+  - uid: 5662
     components:
     - type: Transform
       pos: -1.5,-26.5
       parent: 1
-  - uid: 5652
+  - uid: 5663
     components:
     - type: Transform
       pos: -11.5,-26.5
       parent: 1
 - proto: RMCVendorSnackSimple
   entities:
-  - uid: 5653
+  - uid: 5664
     components:
     - type: Transform
       pos: 23.5,10.5
       parent: 1
 - proto: RMCWeaponTaser
   entities:
-  - uid: 5654
+  - uid: 5665
     components:
     - type: Transform
-      pos: 7.3700547,-32.583313
+      pos: 7.5894403,-32.65815
       parent: 1
-  - uid: 5655
+  - uid: 5666
     components:
     - type: Transform
-      pos: 7.6356797,-32.239563
+      pos: 7.523015,-32.3312
       parent: 1
-  - uid: 5656
+  - uid: 5667
     components:
     - type: Transform
-      pos: 7.4950547,-32.411438
+      pos: 7.4323106,-32.067654
       parent: 1
 - proto: RMCWindoorSoro
   entities:
-  - uid: 5657
+  - uid: 5668
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,61.5
       parent: 1
-  - uid: 5658
+  - uid: 5669
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,0.5
       parent: 1
-  - uid: 5659
+  - uid: 5670
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,0.5
       parent: 1
-  - uid: 5660
+  - uid: 5671
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -39363,111 +39468,111 @@ entities:
       parent: 1
 - proto: RMCWindowDirectionalBlue
   entities:
-  - uid: 5661
-    components:
-    - type: Transform
-      pos: -0.5,58.5
-      parent: 1
-  - uid: 5662
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,61.5
-      parent: 1
-  - uid: 5663
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,60.5
-      parent: 1
-  - uid: 5664
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,59.5
-      parent: 1
-  - uid: 5665
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,58.5
-      parent: 1
-  - uid: 5666
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,57.5
-      parent: 1
-  - uid: 5667
-    components:
-    - type: Transform
-      pos: -2.5,57.5
-      parent: 1
-  - uid: 5668
-    components:
-    - type: Transform
-      pos: -0.5,57.5
-      parent: 1
-  - uid: 5669
-    components:
-    - type: Transform
-      pos: -1.5,57.5
-      parent: 1
-  - uid: 5670
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,60.5
-      parent: 1
-  - uid: 5671
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,59.5
-      parent: 1
   - uid: 5672
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,58.5
       parent: 1
   - uid: 5673
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,61.5
+      rot: 3.141592653589793 rad
+      pos: -2.5,61.5
       parent: 1
   - uid: 5674
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,61.5
+      rot: -1.5707963267948966 rad
+      pos: -2.5,60.5
       parent: 1
   - uid: 5675
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,61.5
+      pos: -2.5,59.5
       parent: 1
   - uid: 5676
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,45.5
+      pos: -2.5,58.5
       parent: 1
   - uid: 5677
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,46.5
+      pos: -2.5,57.5
       parent: 1
   - uid: 5678
+    components:
+    - type: Transform
+      pos: -2.5,57.5
+      parent: 1
+  - uid: 5679
+    components:
+    - type: Transform
+      pos: -0.5,57.5
+      parent: 1
+  - uid: 5680
+    components:
+    - type: Transform
+      pos: -1.5,57.5
+      parent: 1
+  - uid: 5681
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,60.5
+      parent: 1
+  - uid: 5682
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,59.5
+      parent: 1
+  - uid: 5683
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,58.5
+      parent: 1
+  - uid: 5684
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,61.5
+      parent: 1
+  - uid: 5685
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,61.5
+      parent: 1
+  - uid: 5686
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,61.5
+      parent: 1
+  - uid: 5687
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,45.5
+      parent: 1
+  - uid: 5688
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,46.5
+      parent: 1
+  - uid: 5689
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,47.5
       parent: 1
-  - uid: 5679
+  - uid: 5690
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -39475,950 +39580,950 @@ entities:
       parent: 1
 - proto: RMCWindowTintedDirectionalBlue
   entities:
-  - uid: 5680
+  - uid: 5691
     components:
     - type: Transform
       pos: 11.5,-35.5
       parent: 1
-  - uid: 5681
+  - uid: 5692
     components:
     - type: Transform
       pos: 5.5,-35.5
       parent: 1
-  - uid: 5682
+  - uid: 5693
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-34.5
       parent: 1
-  - uid: 5683
+  - uid: 5694
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-35.5
       parent: 1
-  - uid: 5684
+  - uid: 5695
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-34.5
       parent: 1
-  - uid: 5685
+  - uid: 5696
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-34.5
       parent: 1
-  - uid: 5686
+  - uid: 5697
     components:
     - type: Transform
       pos: -11.5,-8.5
       parent: 1
-  - uid: 5687
+  - uid: 5698
     components:
     - type: Transform
       pos: -12.5,-8.5
       parent: 1
-  - uid: 5688
+  - uid: 5699
     components:
     - type: Transform
       pos: -16.5,-8.5
       parent: 1
-  - uid: 5689
+  - uid: 5700
     components:
     - type: Transform
       pos: -17.5,-8.5
       parent: 1
-  - uid: 5690
+  - uid: 5701
     components:
     - type: Transform
       pos: 8.5,-23.5
       parent: 1
-  - uid: 5691
+  - uid: 5702
     components:
     - type: Transform
       pos: 7.5,-23.5
       parent: 1
 - proto: RMCZippoGold
   entities:
-  - uid: 5692
+  - uid: 5703
     components:
     - type: Transform
       pos: 26.148949,3.8087606
       parent: 1
 - proto: shipfetchreturnmarker
   entities:
-  - uid: 5693
+  - uid: 5704
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,55.5
       parent: 1
-  - uid: 5694
+  - uid: 5705
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,56.5
       parent: 1
-  - uid: 5695
+  - uid: 5706
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,57.5
       parent: 1
-  - uid: 5696
+  - uid: 5707
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,58.5
       parent: 1
-  - uid: 5697
+  - uid: 5708
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,59.5
       parent: 1
-  - uid: 5698
+  - uid: 5709
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,60.5
       parent: 1
-  - uid: 5699
+  - uid: 5710
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,61.5
       parent: 1
-  - uid: 5700
+  - uid: 5711
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,62.5
       parent: 1
-  - uid: 5701
+  - uid: 5712
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,63.5
       parent: 1
-  - uid: 5702
+  - uid: 5713
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,64.5
       parent: 1
-  - uid: 5703
+  - uid: 5714
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,65.5
       parent: 1
-  - uid: 5704
+  - uid: 5715
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,66.5
       parent: 1
-  - uid: 5705
+  - uid: 5716
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,67.5
       parent: 1
-  - uid: 5706
+  - uid: 5717
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,68.5
       parent: 1
-  - uid: 5707
+  - uid: 5718
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,69.5
       parent: 1
-  - uid: 5708
+  - uid: 5719
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,70.5
       parent: 1
-  - uid: 5709
+  - uid: 5720
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,55.5
       parent: 1
-  - uid: 5710
+  - uid: 5721
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,56.5
       parent: 1
-  - uid: 5711
+  - uid: 5722
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,57.5
       parent: 1
-  - uid: 5712
+  - uid: 5723
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,58.5
       parent: 1
-  - uid: 5713
+  - uid: 5724
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,59.5
       parent: 1
-  - uid: 5714
+  - uid: 5725
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,60.5
       parent: 1
-  - uid: 5715
+  - uid: 5726
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,61.5
       parent: 1
-  - uid: 5716
+  - uid: 5727
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,62.5
       parent: 1
-  - uid: 5717
+  - uid: 5728
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,63.5
       parent: 1
-  - uid: 5718
+  - uid: 5729
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,64.5
       parent: 1
-  - uid: 5719
+  - uid: 5730
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,65.5
       parent: 1
-  - uid: 5720
+  - uid: 5731
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,66.5
       parent: 1
-  - uid: 5721
+  - uid: 5732
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,67.5
       parent: 1
-  - uid: 5722
+  - uid: 5733
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,68.5
       parent: 1
-  - uid: 5723
+  - uid: 5734
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,69.5
       parent: 1
-  - uid: 5724
+  - uid: 5735
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,70.5
       parent: 1
-  - uid: 5725
+  - uid: 5736
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,55.5
       parent: 1
-  - uid: 5726
+  - uid: 5737
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,58.5
       parent: 1
-  - uid: 5727
+  - uid: 5738
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,57.5
       parent: 1
-  - uid: 5728
+  - uid: 5739
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,59.5
       parent: 1
-  - uid: 5729
+  - uid: 5740
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,60.5
       parent: 1
-  - uid: 5730
+  - uid: 5741
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,61.5
       parent: 1
-  - uid: 5731
+  - uid: 5742
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,62.5
       parent: 1
-  - uid: 5732
+  - uid: 5743
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,63.5
       parent: 1
-  - uid: 5733
+  - uid: 5744
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,64.5
       parent: 1
-  - uid: 5734
+  - uid: 5745
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,65.5
       parent: 1
-  - uid: 5735
+  - uid: 5746
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,66.5
       parent: 1
-  - uid: 5736
+  - uid: 5747
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,67.5
       parent: 1
-  - uid: 5737
+  - uid: 5748
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,56.5
       parent: 1
-  - uid: 5738
+  - uid: 5749
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,69.5
       parent: 1
-  - uid: 5739
+  - uid: 5750
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,70.5
       parent: 1
-  - uid: 5740
+  - uid: 5751
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,55.5
       parent: 1
-  - uid: 5741
+  - uid: 5752
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,56.5
       parent: 1
-  - uid: 5742
+  - uid: 5753
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,57.5
       parent: 1
-  - uid: 5743
+  - uid: 5754
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,58.5
       parent: 1
-  - uid: 5744
+  - uid: 5755
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,59.5
       parent: 1
-  - uid: 5745
+  - uid: 5756
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,60.5
       parent: 1
-  - uid: 5746
+  - uid: 5757
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,61.5
       parent: 1
-  - uid: 5747
+  - uid: 5758
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,62.5
       parent: 1
-  - uid: 5748
+  - uid: 5759
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,63.5
       parent: 1
-  - uid: 5749
+  - uid: 5760
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,64.5
       parent: 1
-  - uid: 5750
+  - uid: 5761
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,65.5
       parent: 1
-  - uid: 5751
+  - uid: 5762
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,67.5
       parent: 1
-  - uid: 5752
+  - uid: 5763
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,68.5
       parent: 1
-  - uid: 5753
+  - uid: 5764
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,69.5
       parent: 1
-  - uid: 5754
+  - uid: 5765
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,70.5
       parent: 1
-  - uid: 5755
+  - uid: 5766
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,55.5
       parent: 1
-  - uid: 5756
+  - uid: 5767
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,56.5
       parent: 1
-  - uid: 5757
+  - uid: 5768
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,57.5
       parent: 1
-  - uid: 5758
+  - uid: 5769
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,58.5
       parent: 1
-  - uid: 5759
+  - uid: 5770
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,68.5
       parent: 1
-  - uid: 5760
+  - uid: 5771
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,59.5
       parent: 1
-  - uid: 5761
+  - uid: 5772
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,60.5
       parent: 1
-  - uid: 5762
+  - uid: 5773
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,61.5
       parent: 1
-  - uid: 5763
+  - uid: 5774
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,62.5
       parent: 1
-  - uid: 5764
+  - uid: 5775
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,63.5
       parent: 1
-  - uid: 5765
+  - uid: 5776
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,64.5
       parent: 1
-  - uid: 5766
+  - uid: 5777
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,65.5
       parent: 1
-  - uid: 5767
+  - uid: 5778
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,66.5
       parent: 1
-  - uid: 5768
+  - uid: 5779
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,66.5
       parent: 1
-  - uid: 5769
+  - uid: 5780
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,68.5
       parent: 1
-  - uid: 5770
+  - uid: 5781
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,70.5
       parent: 1
-  - uid: 5771
+  - uid: 5782
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,55.5
       parent: 1
-  - uid: 5772
+  - uid: 5783
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,56.5
       parent: 1
-  - uid: 5773
+  - uid: 5784
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,57.5
       parent: 1
-  - uid: 5774
+  - uid: 5785
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,58.5
       parent: 1
-  - uid: 5775
+  - uid: 5786
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,59.5
       parent: 1
-  - uid: 5776
+  - uid: 5787
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,60.5
       parent: 1
-  - uid: 5777
+  - uid: 5788
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,61.5
       parent: 1
-  - uid: 5778
+  - uid: 5789
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,62.5
       parent: 1
-  - uid: 5779
+  - uid: 5790
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,63.5
       parent: 1
-  - uid: 5780
+  - uid: 5791
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,64.5
       parent: 1
-  - uid: 5781
+  - uid: 5792
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,65.5
       parent: 1
-  - uid: 5782
+  - uid: 5793
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,66.5
       parent: 1
-  - uid: 5783
+  - uid: 5794
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,67.5
       parent: 1
-  - uid: 5784
+  - uid: 5795
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,68.5
       parent: 1
-  - uid: 5785
+  - uid: 5796
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,69.5
       parent: 1
-  - uid: 5786
+  - uid: 5797
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,70.5
       parent: 1
-  - uid: 5787
+  - uid: 5798
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,55.5
       parent: 1
-  - uid: 5788
+  - uid: 5799
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,56.5
       parent: 1
-  - uid: 5789
+  - uid: 5800
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,57.5
       parent: 1
-  - uid: 5790
+  - uid: 5801
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,58.5
       parent: 1
-  - uid: 5791
+  - uid: 5802
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,59.5
       parent: 1
-  - uid: 5792
+  - uid: 5803
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,60.5
       parent: 1
-  - uid: 5793
+  - uid: 5804
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,61.5
       parent: 1
-  - uid: 5794
+  - uid: 5805
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,62.5
       parent: 1
-  - uid: 5795
+  - uid: 5806
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,63.5
       parent: 1
-  - uid: 5796
+  - uid: 5807
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,64.5
       parent: 1
-  - uid: 5797
+  - uid: 5808
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,69.5
       parent: 1
-  - uid: 5798
+  - uid: 5809
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,65.5
       parent: 1
-  - uid: 5799
+  - uid: 5810
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,66.5
       parent: 1
-  - uid: 5800
+  - uid: 5811
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,67.5
       parent: 1
-  - uid: 5801
+  - uid: 5812
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,68.5
       parent: 1
-  - uid: 5802
+  - uid: 5813
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,69.5
       parent: 1
-  - uid: 5803
+  - uid: 5814
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,70.5
       parent: 1
-  - uid: 5804
+  - uid: 5815
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,55.5
       parent: 1
-  - uid: 5805
+  - uid: 5816
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,56.5
       parent: 1
-  - uid: 5806
+  - uid: 5817
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,57.5
       parent: 1
-  - uid: 5807
+  - uid: 5818
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,58.5
       parent: 1
-  - uid: 5808
+  - uid: 5819
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,59.5
       parent: 1
-  - uid: 5809
+  - uid: 5820
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,60.5
       parent: 1
-  - uid: 5810
+  - uid: 5821
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,61.5
       parent: 1
-  - uid: 5811
+  - uid: 5822
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,62.5
       parent: 1
-  - uid: 5812
+  - uid: 5823
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,63.5
       parent: 1
-  - uid: 5813
+  - uid: 5824
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,64.5
       parent: 1
-  - uid: 5814
+  - uid: 5825
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,65.5
       parent: 1
-  - uid: 5815
+  - uid: 5826
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,66.5
       parent: 1
-  - uid: 5816
+  - uid: 5827
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,67.5
       parent: 1
-  - uid: 5817
+  - uid: 5828
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,68.5
       parent: 1
-  - uid: 5818
+  - uid: 5829
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,69.5
       parent: 1
-  - uid: 5819
+  - uid: 5830
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,70.5
       parent: 1
-  - uid: 5820
+  - uid: 5831
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,55.5
       parent: 1
-  - uid: 5821
+  - uid: 5832
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,56.5
       parent: 1
-  - uid: 5822
+  - uid: 5833
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,57.5
       parent: 1
-  - uid: 5823
+  - uid: 5834
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,58.5
       parent: 1
-  - uid: 5824
+  - uid: 5835
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,59.5
       parent: 1
-  - uid: 5825
+  - uid: 5836
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,60.5
       parent: 1
-  - uid: 5826
+  - uid: 5837
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,61.5
       parent: 1
-  - uid: 5827
+  - uid: 5838
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,62.5
       parent: 1
-  - uid: 5828
+  - uid: 5839
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,63.5
       parent: 1
-  - uid: 5829
+  - uid: 5840
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,64.5
       parent: 1
-  - uid: 5830
+  - uid: 5841
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,65.5
       parent: 1
-  - uid: 5831
+  - uid: 5842
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,66.5
       parent: 1
-  - uid: 5832
+  - uid: 5843
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,67.5
       parent: 1
-  - uid: 5833
+  - uid: 5844
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,68.5
       parent: 1
-  - uid: 5834
+  - uid: 5845
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,69.5
       parent: 1
-  - uid: 5835
+  - uid: 5846
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,70.5
       parent: 1
-  - uid: 5836
+  - uid: 5847
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,54.5
       parent: 1
-  - uid: 5837
+  - uid: 5848
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,54.5
       parent: 1
-  - uid: 5838
+  - uid: 5849
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -40426,26 +40531,26 @@ entities:
       parent: 1
 - proto: shipobjectivesconsolemarker
   entities:
-  - uid: 5839
+  - uid: 5850
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-46.5
       parent: 1
-  - uid: 5840
+  - uid: 5851
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-44.5
       parent: 1
-  - uid: 5897
+  - uid: 5907
     components:
     - type: Transform
       pos: -1.5,65.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 5841
+  - uid: 5852
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -40453,19 +40558,19 @@ entities:
       parent: 1
 - proto: SteelBench
   entities:
-  - uid: 5842
+  - uid: 5853
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,-11.5
       parent: 1
-  - uid: 5843
+  - uid: 5854
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-11.5
       parent: 1
-  - uid: 5844
+  - uid: 5855
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -40473,303 +40578,298 @@ entities:
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 5845
+  - uid: 5856
     components:
     - type: Transform
       pos: -8.5,-21.5
       parent: 1
-  - uid: 5846
+  - uid: 5857
     components:
     - type: Transform
       pos: -9.5,-21.5
       parent: 1
-  - uid: 5847
+  - uid: 5858
     components:
     - type: Transform
       pos: -4.5,-21.5
       parent: 1
-  - uid: 5848
+  - uid: 5859
     components:
     - type: Transform
       pos: -3.5,-21.5
       parent: 1
-  - uid: 5849
+  - uid: 5860
     components:
     - type: Transform
       pos: -5.5,-21.5
       parent: 1
-  - uid: 5850
+  - uid: 5861
     components:
     - type: Transform
       pos: -9.5,-21.5
       parent: 1
-  - uid: 5851
+  - uid: 5862
     components:
     - type: Transform
       pos: -7.5,-21.5
       parent: 1
-  - uid: 5852
+  - uid: 5863
     components:
     - type: Transform
       pos: -9.5,-24.5
       parent: 1
-  - uid: 5853
+  - uid: 5864
     components:
     - type: Transform
       pos: -7.5,-24.5
       parent: 1
-  - uid: 5854
+  - uid: 5865
     components:
     - type: Transform
       pos: -8.5,-24.5
       parent: 1
 - proto: TowelColorBlack
   entities:
-  - uid: 5855
+  - uid: 5866
     components:
     - type: Transform
       pos: 6.578745,-51.58696
       parent: 1
-  - uid: 5856
+  - uid: 5867
     components:
     - type: Transform
       pos: 6.359995,-51.68071
       parent: 1
-  - uid: 5857
+  - uid: 5868
     components:
     - type: Transform
       pos: 6.43812,-51.30571
       parent: 1
-  - uid: 5858
+  - uid: 5869
     components:
     - type: Transform
       pos: -17.730303,-12.577909
       parent: 1
-  - uid: 5859
+  - uid: 5870
     components:
     - type: Transform
       pos: -17.49072,-12.629993
       parent: 1
-  - uid: 5860
+  - uid: 5871
     components:
     - type: Transform
       pos: -17.230303,-12.609159
       parent: 1
 - proto: TowelColorWhite
   entities:
-  - uid: 5861
+  - uid: 5872
     components:
     - type: Transform
       pos: -33.57652,15.773847
       parent: 1
-  - uid: 5862
+  - uid: 5873
     components:
     - type: Transform
       pos: -33.39306,15.682117
       parent: 1
-  - uid: 5863
+  - uid: 5874
     components:
     - type: Transform
       pos: -33.594864,19.809944
       parent: 1
-  - uid: 5864
+  - uid: 5875
     components:
     - type: Transform
       pos: -33.429752,19.73656
       parent: 1
 - proto: VMarkerShipAnalyzer
   entities:
-  - uid: 5865
+  - uid: 5876
     components:
     - type: Transform
       pos: 5.5,48.5
       parent: 1
 - proto: VMarkerShipAutomaticRifleman
   entities:
-  - uid: 5866
+  - uid: 5877
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 5867
+  - uid: 5878
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 5868
+  - uid: 5879
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 5869
+  - uid: 5880
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
 - proto: VMarkershipClothing
   entities:
-  - uid: 5870
-    components:
-    - type: Transform
-      pos: 31.5,9.5
-      parent: 1
-  - uid: 5871
+  - uid: 5881
     components:
     - type: Transform
       pos: 13.5,-9.5
       parent: 1
-  - uid: 5872
+  - uid: 5882
     components:
     - type: Transform
       pos: 11.5,-9.5
       parent: 1
-  - uid: 5873
+  - uid: 5883
     components:
     - type: Transform
       pos: 11.5,-10.5
       parent: 1
-  - uid: 5874
+  - uid: 5884
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 5875
+  - uid: 5885
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 5876
+  - uid: 5886
     components:
     - type: Transform
       pos: 13.5,-10.5
       parent: 1
-  - uid: 5877
+  - uid: 5887
     components:
     - type: Transform
       pos: 15.5,-9.5
       parent: 1
-  - uid: 5878
+  - uid: 5888
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 5879
+  - uid: 5889
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 5880
+  - uid: 5890
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
-  - uid: 5881
+  - uid: 5891
     components:
     - type: Transform
       pos: 15.5,-10.5
       parent: 1
-  - uid: 5882
+  - uid: 5892
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
-  - uid: 5883
+  - uid: 5893
     components:
     - type: Transform
       pos: -9.5,-5.5
       parent: 1
-  - uid: 5884
+  - uid: 5894
     components:
     - type: Transform
       pos: -9.5,-3.5
       parent: 1
-  - uid: 5885
+  - uid: 5895
     components:
     - type: Transform
       pos: -9.5,-8.5
       parent: 1
-  - uid: 5886
+  - uid: 5896
     components:
     - type: Transform
       pos: -9.5,-6.5
       parent: 1
-  - uid: 5887
+  - uid: 5897
     components:
     - type: Transform
       pos: -9.5,-7.5
       parent: 1
-  - uid: 5888
+  - uid: 5898
     components:
     - type: Transform
       pos: -9.5,-10.5
       parent: 1
-  - uid: 5889
+  - uid: 5899
     components:
     - type: Transform
       pos: -9.5,-9.5
       parent: 1
-  - uid: 5890
+  - uid: 5900
     components:
     - type: Transform
       pos: -9.5,-4.5
       parent: 1
 - proto: VMarkerShipComtech
   entities:
-  - uid: 5891
+  - uid: 5901
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
-  - uid: 5892
+  - uid: 5902
     components:
     - type: Transform
       pos: 8.5,-3.5
       parent: 1
 - proto: VMarkerShipCorpsman
   entities:
-  - uid: 5893
+  - uid: 5903
     components:
     - type: Transform
       pos: 10.5,-1.5
       parent: 1
-  - uid: 5894
+  - uid: 5904
     components:
     - type: Transform
       pos: 12.5,-1.5
       parent: 1
 - proto: VMarkerShipDCC
   entities:
-  - uid: 5895
+  - uid: 5905
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 5896
+  - uid: 5906
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
 - proto: VMarkerShipJuniorOfficer
   entities:
-  - uid: 5898
+  - uid: 5908
     components:
     - type: Transform
       pos: -4.5,48.5
       parent: 1
 - proto: VMarkerShipLockedCommandDoor
   entities:
-  - uid: 5899
+  - uid: 5909
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,37.5
       parent: 1
-  - uid: 5900
+  - uid: 5910
     components:
     - type: Transform
       pos: -6.5,49.5
       parent: 1
-  - uid: 5901
+  - uid: 5911
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -40777,17 +40877,17 @@ entities:
       parent: 1
 - proto: VMarkerShipLockedCommandDoorGlass
   entities:
-  - uid: 5902
+  - uid: 5912
     components:
     - type: Transform
       pos: -0.5,54.5
       parent: 1
-  - uid: 5903
+  - uid: 5913
     components:
     - type: Transform
       pos: -2.5,54.5
       parent: 1
-  - uid: 5904
+  - uid: 5914
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -40795,7 +40895,7 @@ entities:
       parent: 1
 - proto: VMarkerShipLockedDoorEngineering
   entities:
-  - uid: 5905
+  - uid: 5915
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -40803,7 +40903,7 @@ entities:
       parent: 1
 - proto: VMarkerShipLockedDoorMedical
   entities:
-  - uid: 5906
+  - uid: 5916
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -40811,38 +40911,38 @@ entities:
       parent: 1
 - proto: VMarkerShipLockedGlassDoor
   entities:
-  - uid: 5907
+  - uid: 5917
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 5908
+  - uid: 5918
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 5909
+  - uid: 5919
     components:
     - type: Transform
       pos: 6.5,-15.5
       parent: 1
-  - uid: 5910
+  - uid: 5920
     components:
     - type: Transform
       pos: 8.5,-15.5
       parent: 1
-  - uid: 5911
+  - uid: 5921
     components:
     - type: Transform
       pos: 15.5,-4.5
       parent: 1
-  - uid: 5912
+  - uid: 5922
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-15.5
       parent: 1
-  - uid: 5913
+  - uid: 5923
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -40850,98 +40950,98 @@ entities:
       parent: 1
 - proto: VMarkerShipLockedGlassDoorEngineering
   entities:
-  - uid: 5914
+  - uid: 5924
     components:
     - type: Transform
       pos: 3.5,-59.5
       parent: 1
-  - uid: 5915
+  - uid: 5925
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 1
 - proto: VMarkerShipLockedGlassDoorMedical
   entities:
-  - uid: 5916
+  - uid: 5926
     components:
     - type: Transform
       pos: 11.5,-4.5
       parent: 1
-  - uid: 5917
+  - uid: 5927
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,18.5
       parent: 1
-  - uid: 5918
+  - uid: 5928
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,14.5
       parent: 1
-  - uid: 5919
+  - uid: 5929
     components:
     - type: Transform
       pos: -28.5,20.5
       parent: 1
 - proto: VMarkerShipLockedSecurityDoorGlass
   entities:
-  - uid: 5920
+  - uid: 5930
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,2.5
       parent: 1
-  - uid: 5921
+  - uid: 5931
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,2.5
       parent: 1
-  - uid: 5922
+  - uid: 5932
     components:
     - type: Transform
       pos: 5.5,-40.5
       parent: 1
-  - uid: 5923
+  - uid: 5933
     components:
     - type: Transform
       pos: 8.5,-40.5
       parent: 1
-  - uid: 5924
+  - uid: 5934
     components:
     - type: Transform
       pos: 11.5,-40.5
       parent: 1
-  - uid: 5925
+  - uid: 5935
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-52.5
       parent: 1
-  - uid: 5926
+  - uid: 5936
     components:
     - type: Transform
       pos: 9.5,-33.5
       parent: 1
-  - uid: 5927
+  - uid: 5937
     components:
     - type: Transform
       pos: 2.5,-40.5
       parent: 1
-  - uid: 5928
+  - uid: 5938
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,2.5
       parent: 1
-  - uid: 5929
+  - uid: 5939
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-33.5
       parent: 1
-  - uid: 5930
+  - uid: 5940
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -40949,213 +41049,193 @@ entities:
       parent: 1
 - proto: VMarkerShipMPPoliceman
   entities:
-  - uid: 4647
+  - uid: 4650
     components:
     - type: Transform
       pos: 6.5,-29.5
       parent: 1
-  - uid: 4650
-    components:
-    - type: Transform
-      pos: 8.5,-29.5
-      parent: 1
 - proto: VMarkerShipOperationsOfficer
   entities:
-  - uid: 5931
+  - uid: 5941
     components:
     - type: Transform
       pos: 0.5,43.5
       parent: 1
-  - uid: 5932
+  - uid: 5942
     components:
     - type: Transform
       pos: 9.5,46.5
       parent: 1
 - proto: VMarkerShipOverwatchConsole
   entities:
-  - uid: 5933
+  - uid: 5943
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,66.5
       parent: 1
-  - uid: 5934
+  - uid: 5944
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,66.5
       parent: 1
-  - uid: 5935
+  - uid: 5945
     components:
     - type: Transform
       pos: -2.5,70.5
       parent: 1
-  - uid: 5936
+  - uid: 5946
     components:
     - type: Transform
       pos: -0.5,70.5
       parent: 1
 - proto: VMarkerShipPilot
   entities:
-  - uid: 5937
+  - uid: 5947
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 5938
+  - uid: 5948
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
 - proto: VMarkerShipRadiotelephoneOperator
   entities:
-  - uid: 5939
-    components:
-    - type: Transform
-      pos: 16.5,-1.5
-      parent: 1
-  - uid: 5940
-    components:
-    - type: Transform
-      pos: 14.5,-1.5
-      parent: 1
-  - uid: 5941
+  - uid: 5949
     components:
     - type: Transform
       pos: 16.5,-3.5
       parent: 1
-  - uid: 5942
+  - uid: 5950
     components:
     - type: Transform
       pos: 14.5,-3.5
       parent: 1
 - proto: VMarkerShipRequisitionsConsole
   entities:
-  - uid: 5943
+  - uid: 5951
     components:
     - type: Transform
       pos: 23.5,20.5
       parent: 1
 - proto: VMarkerShipRequisitionsLift
   entities:
-  - uid: 5944
+  - uid: 5952
     components:
     - type: Transform
       pos: 29.5,16.5
       parent: 1
 - proto: VMarkerShipRifleman
   entities:
-  - uid: 5945
+  - uid: 5953
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
-  - uid: 5946
+  - uid: 5954
     components:
     - type: Transform
       pos: 12.5,-9.5
       parent: 1
-  - uid: 5947
+  - uid: 5955
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 5948
+  - uid: 5956
     components:
     - type: Transform
       pos: 14.5,-9.5
       parent: 1
-  - uid: 5949
+  - uid: 5957
     components:
     - type: Transform
       pos: 16.5,-9.5
       parent: 1
-  - uid: 5950
+  - uid: 5958
     components:
     - type: Transform
       pos: -1.5,-10.5
       parent: 1
-  - uid: 5951
+  - uid: 5959
     components:
     - type: Transform
       pos: 16.5,-10.5
       parent: 1
-  - uid: 5952
+  - uid: 5960
     components:
     - type: Transform
       pos: 14.5,-10.5
       parent: 1
-  - uid: 5953
+  - uid: 5961
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-  - uid: 5954
+  - uid: 5962
     components:
     - type: Transform
       pos: 12.5,-10.5
       parent: 1
-  - uid: 5955
+  - uid: 5963
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
-  - uid: 5956
+  - uid: 5964
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
+- proto: VMarkerShipSectionSergeant
+  entities:
+  - uid: 5965
+    components:
+    - type: Transform
+      pos: 14.5,-1.5
+      parent: 1
+  - uid: 5966
+    components:
+    - type: Transform
+      pos: 16.5,-1.5
+      parent: 1
 - proto: VMarkerShipSweapons
   entities:
-  - uid: 5957
+  - uid: 5967
     components:
     - type: Transform
       pos: 5.5,-9.5
       parent: 1
-- proto: VMarkerShipTacticalMap
-  entities:
-  - uid: 5958
-    components:
-    - type: Transform
-      pos: -0.5,67.5
-      parent: 1
 - proto: VMarkerShipTechTree
   entities:
-  - uid: 5959
+  - uid: 5968
     components:
     - type: Transform
       pos: -1.5,67.5
       parent: 1
 - proto: VMarkerShipWeapons
   entities:
-  - uid: 5960
-    components:
-    - type: Transform
-      pos: 32.5,9.5
-      parent: 1
-  - uid: 5961
-    components:
-    - type: Transform
-      pos: 30.5,9.5
-      parent: 1
-  - uid: 5962
+  - uid: 5969
     components:
     - type: Transform
       pos: 9.5,-10.5
       parent: 1
-  - uid: 5963
+  - uid: 5970
     components:
     - type: Transform
       pos: 9.5,-9.5
       parent: 1
-  - uid: 5964
+  - uid: 5971
     components:
     - type: Transform
       pos: 5.5,-10.5
       parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 5965
+  - uid: 5972
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -41163,14 +41243,14 @@ entities:
       parent: 1
     - type: WarpPoint
       location: Medbay
-  - uid: 5966
+  - uid: 5973
     components:
     - type: Transform
       pos: -0.5,15.5
       parent: 1
     - type: WarpPoint
       location: USS George W. Bush
-  - uid: 5967
+  - uid: 5974
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -41178,7 +41258,7 @@ entities:
       parent: 1
     - type: WarpPoint
       location: Combat Information Center
-  - uid: 5968
+  - uid: 5975
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -41186,17 +41266,18 @@ entities:
       parent: 1
     - type: WarpPoint
       location: Requestions
-  - uid: 5969
+  - uid: 5976
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-44.5
       parent: 1
     - type: WarpPoint
-      location: Breifing
+      follow: True
+      location: Briefing
 - proto: WaterTankHighCapacity
   entities:
-  - uid: 5970
+  - uid: 5977
     components:
     - type: Transform
       pos: -17.5,-9.5

--- a/Resources/Prototypes/_AU14/Maps/planets.yml
+++ b/Resources/Prototypes/_AU14/Maps/planets.yml
@@ -559,14 +559,14 @@
     camouflage: Desert
     announcement: "A remote research outpost, Shepherd's Pride, has gone silent. The UNS Almayer is dispatched to investigate the mysterious circumstances."
     platoonsOpfor:
-    - LACN
-    - USCM
-    - RMC
-    platoonsGovfor:
     - UPP
     - WEYU
     - VAIPO
     - ProdigySF
+    platoonsGovfor:
+    - LACN
+    - USCM
+    - RMC
     defaultgovfor: UPP
     defaultopfor: RMC
     govforinship: true

--- a/Resources/Prototypes/_AU14/gamemode/gamemodes.yml
+++ b/Resources/Prototypes/_AU14/gamemode/gamemodes.yml
@@ -39,6 +39,7 @@
     - AUPlanetShepherdsPride
     #- AUPlanetLV624
     - CMUPlanetLament
+    - AUPlanetStableGarrison
     #- AUPlanetLV747
     #- AUPlanetSorokyne
     #- AUPlanetLV759 removed pending rework
@@ -57,18 +58,18 @@
   description: Investigate a mysterious distress signal as government forces.
   requiresGovforVote: true
   supportedPlanets:
-  - AUPlanetShepherdsPride
-  - AUPlanetLV747
+#  - AUPlanetShepherdsPride
+#  - AUPlanetLV747
   #- AUPlanetFlight
   - AUPlanetLV327
    - AUPlanetSorokyne
   - AUPlanetCorsatStation
-  - AUPlanetStableGarrison
+#  - AUPlanetStableGarrison
   - AUPlanetTrijent
 #  - AuPlanetFiorina -removed due to load errors
   - AuPlanetKutjevo
   - AuPlanetShivasSnowball
-  - CMUPlanetLament
+#  - CMUPlanetLament
   rules:
   - AuVoteRule
   - PlatoonSpawn
@@ -92,7 +93,7 @@
    # - AUPlanetLV624
    # - AUPlanetLV327
    # - AUPlanetSorokyne
-    #- AUPlanetStableGarrison
+    - AUPlanetStableGarrison
     - CMUPlanetLament
 
 - type: gamePreset


### PR DESCRIPTION
Adds the updated Bush and Garrison maps by ven.
Takes some maps out of rotation until they can be updated.
Removes all planetside govfor maps from distress signal.


