### PR TITLE
admin round commands + completion (new setgovforship)

### DIFF
--- a/Content.Server/AU14/Round/AuRoundSystem.cs
+++ b/Content.Server/AU14/Round/AuRoundSystem.cs
@@ -50,6 +50,8 @@ namespace Content.Server.AU14.Round
         public ThreatPrototype _selectedthreat = null!;
         private string? _selectedGovforShip;
         private string? _selectedOpforShip;
+        public void SetOpforShip(string shipId) => _selectedOpforShip = shipId;
+        public void SetGovforShip(string shipId) => _selectedGovforShip = shipId;
 
         private List<AuThirdPartyPrototype> _selectedThirdParties = new();
         public IReadOnlyList<AuThirdPartyPrototype> SelectedThirdParties => _selectedThirdParties;

--- a/Content.Server/AU14/Round/Commands/SetRoundValuesCommands.cs
+++ b/Content.Server/AU14/Round/Commands/SetRoundValuesCommands.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using Content.Server.Administration;
+using Content.Shared._RMC14.Rules;
 using Content.Shared.Administration;
 using Content.Shared.AU14.util;
 using Robust.Shared.Console;
@@ -29,8 +31,11 @@ namespace Content.Server.AU14.Round.Commands
                 return;
             }
             platoonSys.SelectedOpforPlatoon = platoon;
-            shell.WriteLine($"Opfor platoon set to: {platoon.Name.ToString()} ({platoon.ID.ToString()})");
+            shell.WriteLine($"Opfor platoon set to: {platoon.Name} ({platoon.ID})");
         }
+
+        public CompletionResult GetCompletion(IConsoleShell _, string[] args)
+            => RoundCommandCompletion.PlatoonCompletion(args);
     }
 
     [AdminCommand(AdminFlags.Admin)]
@@ -56,8 +61,57 @@ namespace Content.Server.AU14.Round.Commands
                 return;
             }
             platoonSys.SelectedGovforPlatoon = platoon;
-            shell.WriteLine($"Govfor platoon set to: {platoon.Name.ToString()} ({platoon.ID.ToString()})");
+            shell.WriteLine($"Govfor platoon set to: {platoon.Name} ({platoon.ID})");
         }
+
+        public CompletionResult GetCompletion(IConsoleShell _, string[] args)
+            => RoundCommandCompletion.PlatoonCompletion(args);
+    }
+
+    [AdminCommand(AdminFlags.Admin)]
+    public sealed class SetOpforShipCommand : IConsoleCommand
+    {
+        public string Command => "setopforship";
+        public string Description => "Sets the Opfor ship for the round.";
+        public string Help => "Usage: setopforship <shipId>";
+
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            if (args.Length != 1)
+            {
+                shell.WriteError("Usage: setopforship <shipId>");
+                return;
+            }
+            var roundSystem = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<AuRoundSystem>();
+            roundSystem.SetOpforShip(args[0]);
+            shell.WriteLine($"Opfor ship set to: {args[0]}");
+        }
+
+        public CompletionResult GetCompletion(IConsoleShell _, string[] args)
+            => RoundCommandCompletion.ShipCompletion(args);
+    }
+
+    [AdminCommand(AdminFlags.Admin)]
+    public sealed class SetGovforShipCommand : IConsoleCommand
+    {
+        public string Command => "setgovforship";
+        public string Description => "Sets the Govfor ship for the round.";
+        public string Help => "Usage: setgovforship <shipId>";
+
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            if (args.Length != 1)
+            {
+                shell.WriteError("Usage: setgovforship <shipId>");
+                return;
+            }
+            var roundSystem = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<AuRoundSystem>();
+            roundSystem.SetGovforShip(args[0]);
+            shell.WriteLine($"Govfor ship set to: {args[0]}");
+        }
+
+        public CompletionResult GetCompletion(IConsoleShell _, string[] args)
+            => RoundCommandCompletion.ShipCompletion(args);
     }
 
     [AdminCommand(AdminFlags.Admin)]
@@ -79,6 +133,54 @@ namespace Content.Server.AU14.Round.Commands
                 shell.WriteLine($"Planet set to: {args[0]}");
             else
                 shell.WriteError($"Planet prototype not found: {args[0]}");
+        }
+
+        public CompletionResult GetCompletion(IConsoleShell _, string[] args)
+            => RoundCommandCompletion.PlanetCompletion(args);
+    }
+
+    internal static class RoundCommandCompletion
+    {
+        internal static CompletionResult PlatoonCompletion(string[] args)
+        {
+            if (args.Length != 1) return CompletionResult.Empty;
+
+            var protoMan = IoCManager.Resolve<IPrototypeManager>();
+            var options = protoMan.EnumeratePrototypes<PlatoonPrototype>()
+                .OrderBy(p => p.ID)
+                .Select(p => p.ID)
+                .ToList();
+
+            return CompletionResult.FromHintOptions(options, "<platoonPrototypeId>");
+        }
+
+        internal static CompletionResult PlanetCompletion(string[] args)
+        {
+            if (args.Length != 1) return CompletionResult.Empty;
+
+            var protoMan = IoCManager.Resolve<IPrototypeManager>();
+            var factory = IoCManager.Resolve<IComponentFactory>();
+            var options = protoMan.EnumeratePrototypes<EntityPrototype>()
+                .Where(p => p.TryGetComponent(out RMCPlanetMapPrototypeComponent? _, factory))
+                .OrderBy(p => p.ID)
+                .Select(p => p.ID)
+                .ToList();
+
+            return CompletionResult.FromHintOptions(options, "<planetPrototypeId>");
+        }
+
+        internal static CompletionResult ShipCompletion(string[] args)
+        {
+            if (args.Length != 1) return CompletionResult.Empty;
+
+            var protoMan = IoCManager.Resolve<IPrototypeManager>();
+            var options = protoMan.EnumeratePrototypes<PlatoonPrototype>()
+                .SelectMany(p => p.PossibleShips)
+                .Distinct()
+                .OrderBy(id => id)
+                .ToList();
+
+            return CompletionResult.FromHintOptions(options, "<shipId>");
         }
     }
 }

--- a/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
@@ -140,6 +140,8 @@
         amount: 4
       - id: RMCM276ShotgunShellLoadingRig
         amount: 6
+      - id: RMCBeltHolsterSMGPouch
+        amount: 5
       - id: RMCBeltHolsterPistol
         amount: 20
       - id: RMCBeltHolsterRevolver

--- a/Resources/Prototypes/_RMC14/Vehicles/APC/hardpoints.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/APC/hardpoints.yml
@@ -8,8 +8,6 @@
   - type: Item
     size: Large
   - type: PowerLoaderGrabbable
-    virtualRight: RMCVirtualPowerLoaderRight
-    virtualLeft: RMCVirtualPowerLoaderLeft
   - type: RemoveComponents
     components:
     - type: Pullable

--- a/Resources/Prototypes/_RMC14/Vehicles/APC/spp_hardpoints.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/APC/spp_hardpoints.yml
@@ -8,8 +8,6 @@
   - type: Item
     size: Large
   - type: PowerLoaderGrabbable
-    virtualRight: RMCVirtualPowerLoaderRight
-    virtualLeft: RMCVirtualPowerLoaderLeft
 
 - type: entity
   parent: VehicleSPPAPCHardpointBase

--- a/Resources/Prototypes/_RMC14/Vehicles/Tank/Hardpoints/hardpoints_base.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Tank/Hardpoints/hardpoints_base.yml
@@ -8,8 +8,6 @@
   - type: Item
     size: Large
   - type: PowerLoaderGrabbable
-    virtualRight: RMCVirtualPowerLoaderRight
-    virtualLeft: RMCVirtualPowerLoaderLeft
   - type: RemoveComponents
     components:
     - type: Pullable

--- a/Resources/Prototypes/_RMC14/Vehicles/Tank/Hardpoints/spp_hardpoints.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Tank/Hardpoints/spp_hardpoints.yml
@@ -8,8 +8,6 @@
   - type: Item
     size: Large
   - type: PowerLoaderGrabbable
-    virtualRight: RMCVirtualPowerLoaderRight
-    virtualLeft: RMCVirtualPowerLoaderLeft
 
 - type: entity
   parent: VehicleTankTurret


### PR DESCRIPTION
- **✨ much needed admin commands & completions for devs**
- **⚙️ fix: VirtualLeft/VirtualRight no longer need these explicits, the component has implicit defaults (preventing null)**

## About the PR
- setgovforship, setopforship. Two new commands, though I don't think you can force these against a platoonPrototype.
- But you can try UPP on Shivas now by setting the ship, maybe it'll work haven't tested it. It's more for development.
- autocomplete of setgovfor/setopfor/setplanet because I keep forgetting the names.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: autocomplete of admin round commands for devs & setgovfor / setopforship
