### PR TITLE
The non-illusion of free choice

### DIFF
--- a/Resources/Prototypes/_AU14/Threats/cultistThreat/cultistThreat.yml
+++ b/Resources/Prototypes/_AU14/Threats/cultistThreat/cultistThreat.yml
@@ -29,7 +29,6 @@
     cultistJob: 3
   spawnTogether: true
 
-
 - type: partySpawn
   id: cultistParty
   leadersToSpawn:
@@ -57,10 +56,12 @@
       scale: 0.2
       whenToBeginScaling: 50
 
-
 - type: auThirdParty
   id: cultistThirdParty
   partyspawn: cultistParty
+  blacklistedgamemodes:
+  - insurgency
+  - forceonforce
   entrymethod: shuttle
   weight: 3
   minplayers: 70
@@ -71,6 +72,9 @@
 - type: auThirdParty
   id: cultistThirdPartyNoQueen
   partyspawn: cultistPartyNoQueen
+  blacklistedgamemodes:
+  - insurgency
+  - forceonforce
   entrymethod: ground
   weight: 15
   minplayers: 35
@@ -80,7 +84,7 @@
 
 - type: partySpawn
   id: cultistPartyThreatOnMarkers
-  leadersToSpawn: 
+  leadersToSpawn:
     CMXenoQueen: 1
   gruntsToSpawn:
     cultistJob: 3
@@ -95,7 +99,7 @@
   Markers:
     Member: cultcfmarker
     Leader: cultcfmarker
-    
+
 - type: lorePrimer
   id: AU14PrimerThreatCultist
   threattext: "You are a member of the hive, grow and evolve!"

--- a/Resources/Prototypes/_AU14/thirdParties/ParasiteThirdParties.yml
+++ b/Resources/Prototypes/_AU14/thirdParties/ParasiteThirdParties.yml
@@ -57,9 +57,12 @@
 - type: auThirdParty
   id: XenoParasiteRunnerParty
   partyspawn: XenoParasiteRunnerPartySpawn
+  blacklistedgamemodes:
+  - insurgency
+  - forceonforce
   entrymethod: ground
   weight: 10
   minplayers: 0
   maxplayers: 400
-  GhostsNeeded: 3
+  GhostsNeeded: 2
   roundstart: false


### PR DESCRIPTION
## About the PR
Prevents third party cultists/parasite runners from spawning in Insurgency or ForceOnForce. In theory.

## Why / Balance
Gamemodes should be different. Parasites/Larva/Queens/Eggs are incompatible with Insurgency slop.