### PR TITLE
Many many changes to medical

### DIFF
--- a/Content.Shared/_CMU14/Medical/Items/CMUCastItemComponent.cs
+++ b/Content.Shared/_CMU14/Medical/Items/CMUCastItemComponent.cs
@@ -21,6 +21,9 @@ public sealed partial class CMUCastItemComponent : Component
     public bool ConsumedOnApply = true;
 
     [DataField]
+    public int Uses = 1;
+
+    [DataField]
     public float PostOpHealMinutes = 5f;
 
     [DataField]

--- a/Content.Shared/_CMU14/Medical/Items/CMUSplintItemComponent.cs
+++ b/Content.Shared/_CMU14/Medical/Items/CMUSplintItemComponent.cs
@@ -30,4 +30,7 @@ public sealed partial class CMUSplintItemComponent : Component
 
     [DataField]
     public bool ConsumedOnApply = true;
+
+    [DataField]
+    public int Uses = 1;
 }

--- a/Content.Shared/_CMU14/Medical/Items/SharedCMUSplintItemSystem.cs
+++ b/Content.Shared/_CMU14/Medical/Items/SharedCMUSplintItemSystem.cs
@@ -140,8 +140,7 @@ public abstract class SharedCMUSplintItemSystem : EntitySystem
         if (ent.Comp.ApplySound is not null)
             Audio.PlayPredicted(ent.Comp.ApplySound, part, null);
 
-        if (ent.Comp.ConsumedOnApply && Net.IsServer)
-            QueueDel(ent.Owner);
+        ConsumeSplintUse(ent);
 
         return true;
     }
@@ -217,10 +216,29 @@ public abstract class SharedCMUSplintItemSystem : EntitySystem
         if (ent.Comp.ApplySound is not null)
             Audio.PlayPredicted(ent.Comp.ApplySound, part, null);
 
-        if (ent.Comp.ConsumedOnApply && Net.IsServer)
-            QueueDel(ent.Owner);
+        ConsumeCastUse(ent);
 
         return true;
+    }
+
+    private void ConsumeSplintUse(Entity<CMUSplintItemComponent> ent)
+    {
+        if (!ent.Comp.ConsumedOnApply || !Net.IsServer)
+            return;
+
+        ent.Comp.Uses--;
+        if (ent.Comp.Uses <= 0)
+            QueueDel(ent.Owner);
+    }
+
+    private void ConsumeCastUse(Entity<CMUCastItemComponent> ent)
+    {
+        if (!ent.Comp.ConsumedOnApply || !Net.IsServer)
+            return;
+
+        ent.Comp.Uses--;
+        if (ent.Comp.Uses <= 0)
+            QueueDel(ent.Owner);
     }
 
     public void AddCastRemoveVerb(Entity<CMUHumanMedicalComponent> patient, ref GetVerbsEvent<AlternativeVerb> args)

--- a/Content.Shared/_CMU14/Medical/Surgery/SharedCMUSurgeryFlowSystem.cs
+++ b/Content.Shared/_CMU14/Medical/Surgery/SharedCMUSurgeryFlowSystem.cs
@@ -459,7 +459,6 @@ public abstract class SharedCMUSurgeryFlowSystem : EntitySystem
         }
 
         ApplyWrongToolDamage(user, patient, used, damageType, amount);
-        ClearArmed(patient, armed);
         return true;
     }
 

--- a/Content.Shared/_CMU14/Medical/Surgery/SharedCMUSurgerySystem.cs
+++ b/Content.Shared/_CMU14/Medical/Surgery/SharedCMUSurgerySystem.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Content.Shared._CMU14.Medical.Bones;
+using Content.Shared._CMU14.Medical.Items;
 using Content.Shared._CMU14.Medical.Organs;
 using Content.Shared._CMU14.Medical.Organs.Events;
 using Content.Shared._CMU14.Medical.Surgery.Conditions;
@@ -168,10 +169,15 @@ public abstract class SharedCMUSurgerySystem : EntitySystem
 
         Bone.RestoreIntegrity((args.Part, null), ent.Comp.IntegrityRestore);
         Fracture.SetSeverity((args.Part, frac), ent.Comp.DowngradeTo, forceUpgrade: false);
-        if (ent.Comp.DowngradeTo == FractureSeverity.None && HasComp<CMUMalunionComponent>(args.Part))
-            RemComp<CMUMalunionComponent>(args.Part);
-        if (ent.Comp.DowngradeTo == FractureSeverity.None && HasComp<CMUPostOpBoneSetComponent>(args.Part))
-            RemComp<CMUPostOpBoneSetComponent>(args.Part);
+        if (ent.Comp.DowngradeTo == FractureSeverity.None)
+        {
+            if (HasComp<CMUSplintedComponent>(args.Part))
+                RemComp<CMUSplintedComponent>(args.Part);
+            if (HasComp<CMUMalunionComponent>(args.Part))
+                RemComp<CMUMalunionComponent>(args.Part);
+            if (HasComp<CMUPostOpBoneSetComponent>(args.Part))
+                RemComp<CMUPostOpBoneSetComponent>(args.Part);
+        }
         Wounds.RecomputeInternalBleed(args.Part);
     }
 

--- a/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
+++ b/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
@@ -140,13 +140,24 @@ public sealed class RMCStandingSystem : EntitySystem
         if (args.Cancelled)
             return false;
 
-        if (_standing.IsDown(drop))
-        {
-            args.Cancel();
-            return true;
-        }
+        if (!ShouldBlockDownedActions(drop))
+            return false;
 
-        return false;
+        args.Cancel();
+        return true;
+    }
+
+    private bool ShouldBlockDownedActions(Entity<DropItemsOnRestComponent> drop)
+    {
+        if (!_standing.IsDown(drop))
+            return false;
+
+        if (TryComp<RMCRestComponent>(drop, out var rest) && rest.Resting)
+            return true;
+
+        return HasComp<KnockedDownComponent>(drop) ||
+               HasComp<StunnedComponent>(drop) ||
+               _mob.IsIncapacitated(drop);
     }
 
     private void OnEnterDown(Entity<DownOnEnterComponent> mob, ref EntInsertedIntoContainerMessage args)

--- a/Content.Shared/_RMC14/Xenonids/Acid/SharedXenoAcidSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Acid/SharedXenoAcidSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared._RMC14.Xenonids.Energy;
 using Content.Shared.Explosion.EntitySystems;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Coordinates;
+using Content.Shared.Body.Part;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.DoAfter;
@@ -138,7 +139,9 @@ public abstract class SharedXenoAcidSystem : EntitySystem
         if (args.Handled || args.Cancelled || args.Target is not { } target)
             return;
 
-        if (!TryComp(target, out CorrodibleComponent? corrodible) || !corrodible.IsCorrodible)
+        if (HasComp<BodyPartComponent>(target) ||
+            !TryComp(target, out CorrodibleComponent? corrodible) ||
+            !corrodible.IsCorrodible)
             return;
 
         if (!xeno.Comp.CanMeltStructures && corrodible.Structure)
@@ -205,7 +208,8 @@ public abstract class SharedXenoAcidSystem : EntitySystem
             return false;
         }
 
-        if (!TryComp(target, out CorrodibleComponent? corrodible) ||
+        if (HasComp<BodyPartComponent>(target) ||
+            !TryComp(target, out CorrodibleComponent? corrodible) ||
             !corrodible.IsCorrodible)
         {
             _popup.PopupClient(Loc.GetString("cm-xeno-acid-not-corrodible", ("target", target)), xeno, xeno, PopupType.SmallCaution);
@@ -244,6 +248,9 @@ public abstract class SharedXenoAcidSystem : EntitySystem
     public void ApplyAcid(EntProtoId acidId, XenoAcidStrength strength, EntityUid target, float dps, float lightDps, TimeSpan time, bool inherit = false)
     {
         if (_net.IsClient)
+            return;
+
+        if (HasComp<BodyPartComponent>(target))
             return;
 
         EntityUid acid;

--- a/Resources/Prototypes/_AU14/Entities/Clothing/Universal/belts.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Universal/belts.yml
@@ -373,6 +373,7 @@
       - Pill
       - RMCHandLabeler
       - RMCStethoscope
+      - CMUCastItem
       - CMUSplintItem
       - RMCLighter
   - type: FixedItemSizeStorage

--- a/Resources/Prototypes/_CMU14/Medical/items/casts.yml
+++ b/Resources/Prototypes/_CMU14/Medical/items/casts.yml
@@ -5,9 +5,10 @@
   description: A rigid cast that immobilises and slowly heals fractures up to Simple severity.
   components:
   - type: Item
-    size: Normal
+    size: Small
   - type: CMUCastItem
     applyDelay: 6
+    uses: 4
     maxSuppressed: Simple
   - type: Tag
     tags:

--- a/Resources/Prototypes/_CMU14/Medical/items/splints.yml
+++ b/Resources/Prototypes/_CMU14/Medical/items/splints.yml
@@ -9,6 +9,7 @@
     sprite: _CMU14/Objects/Medical/splint.rsi
   - type: CMUSplintItem
     applyDelay: 3
+    uses: 4
     maxSuppressed: Simple
     applySound:
       path: /Audio/_RMC14/Medical/splint.ogg

--- a/Resources/Prototypes/_RMC14/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Reactions/medicine.yml
@@ -147,6 +147,102 @@
     CMTricordrazine: 2
 
 - type: reaction
+  id: CMUParacetamol
+  reactants:
+    CMInaprovaline:
+      amount: 1
+    RMCHydrogen:
+      amount: 1
+    RMCSugar:
+      amount: 1
+  products:
+    CMUParacetamol: 3
+
+- type: reaction
+  id: CMUTramadol
+  reactants:
+    CMUParacetamol:
+      amount: 1
+    CMDylovene:
+      amount: 1
+    RMCHydrogen:
+      amount: 1
+  products:
+    CMUTramadol: 3
+
+- type: reaction
+  id: CMUOxycodone
+  reactants:
+    CMUTramadol:
+      amount: 1
+    CMEpinephrine:
+      amount: 1
+    RMCEthanol:
+      amount: 1
+  products:
+    CMUOxycodone: 3
+
+- type: reaction
+  id: CMUHepatocytin
+  reactants:
+    CMDylovene:
+      amount: 1
+    CMBicaridine:
+      amount: 1
+    RMCCarbon:
+      amount: 1
+  products:
+    CMUHepatocytin: 3
+
+- type: reaction
+  id: CMUPulmovine
+  reactants:
+    CMDexalinPlus:
+      amount: 1
+    CMBicaridine:
+      amount: 1
+    RMCOxygen:
+      amount: 1
+  products:
+    CMUPulmovine: 3
+
+- type: reaction
+  id: CMUNephronate
+  reactants:
+    CMDylovene:
+      amount: 1
+    CMEpinephrine:
+      amount: 1
+    RMCPotassium:
+      amount: 1
+  products:
+    CMUNephronate: 3
+
+- type: reaction
+  id: CMUCardiocaine
+  reactants:
+    CMEpinephrine:
+      amount: 1
+    CMBicaridine:
+      amount: 1
+    RMCIron:
+      amount: 1
+  products:
+    CMUCardiocaine: 3
+
+- type: reaction
+  id: CMUOsteoCalc
+  reactants:
+    CMBicaridine:
+      amount: 1
+    CMKelotane:
+      amount: 1
+    RMCPhosphorus:
+      amount: 1
+  products:
+    CMUOsteoCalc: 3
+
+- type: reaction
   id: CMMeralyne
   reactants:
     RMCCarbon:


### PR DESCRIPTION
Splints and casts now have 4 uses per item.

Casts are now Small instead of Normal.

Using the wrong surgery tool still hurts, but no longer forces you to abandon and restart the surgery step.

Missing a leg no longer blocks item use/pickup/equip unless you are actually resting, stunned, knocked down or incapacitated

Xeno acid can no longer melt detached body parts

Recipes for the new meds

Paracetamol: 1u Inaprovaline + 1u Hydrogen + 1u Sugar -> 3u
Tramadol: 1u Paracetamol + 1u Dylovene + 1u Hydrogen -> 3u
Oxycodone: 1u  Tramadol + 1u Epinephrine + 1u Ethanol -> 3u
Hepatocytin: 1u Dylovene + 1u Bicaridine + 1u Carbon -> 3u
Pulmovine: 1u DexalinPlus + 1u Bicaridine + 1u Oxygen -> 3u
Nephronate: 1u Dylovene + 1u Epinephrine + 1u Potassium -> 3u
Cardiocaine: 1u Epinephrine + 1u Bicaridine + 1u Iron -> 3u
OsteoCalc: 1u Bicaridine + 1u Kelotane + 1u Phosphorus -> 3u 
For like ghetto surgery and stuff
Scapel is any sharp/knife item

Retractor is knifes, crowbars (i find it funny)

hemostat is gauze surgical line, cable coils, wire cutters, and forks

Cautery is any blowtorch, lit lighters

Bone saw is hatchets, iron rods, knifes again

bone setter is wrench

bone gel is a screwdriver or metal rods

organ clamp is surgical lines cable coils or like bandanas

makes no sense but i find it funny 