### PR TITLE
Allow surgery takeover cancellation

### DIFF
--- a/Content.Client/_CMU14/Medical/Surgery/CMUSurgeryBui.cs
+++ b/Content.Client/_CMU14/Medical/Surgery/CMUSurgeryBui.cs
@@ -163,22 +163,16 @@ public sealed class CMUSurgeryBui : BoundUserInterface
         _window.InProgressChoiceContainer.DisposeAllChildren();
         if (inFlight is null || !TryGetInFlightPart(state, inFlight, out var part))
         {
-            if (stepArmed)
-            {
-                _window.InProgressActionRailPanel.Visible = true;
-                AddAbandonButton();
-            }
+            _window.InProgressActionRailPanel.Visible = true;
+            AddAbandonButton();
             return;
         }
-
-        if (!inFlight.OwnedByViewer && !stepArmed)
-            return;
 
         _window.InProgressActionRailPanel.Visible = true;
 
         var continuationCount = 0;
         CMUSurgeryEntry? closeUp = null;
-        if (!stepArmed && inFlight.OwnedByViewer)
+        if (!stepArmed)
         {
             foreach (var entry in part.EligibleSurgeries)
             {
@@ -214,8 +208,7 @@ public sealed class CMUSurgeryBui : BoundUserInterface
                 AddChoiceButton(part, close, Loc.GetString("cmu-medical-surgery-close-up-button"), true);
         }
 
-        if (stepArmed || inFlight.OwnedByViewer)
-            AddAbandonButton();
+        AddAbandonButton();
     }
 
     private static bool ShouldShowInProgressContinuation(CMUSurgeryEntry entry)

--- a/Content.IntegrationTests/_RMC14/RMCHumanPrototypeRegressionTest.cs
+++ b/Content.IntegrationTests/_RMC14/RMCHumanPrototypeRegressionTest.cs
@@ -326,7 +326,7 @@ public sealed class RMCHumanPrototypeRegressionTest
     }
 
     [Test]
-    public async Task CmuSurgeryToolUseByOtherSurgeonDoesNotExposeOrClearArmedStep()
+    public async Task CmuSurgeryToolUseByOtherSurgeonExposesArmedStepForTakeover()
     {
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
@@ -394,7 +394,7 @@ public sealed class RMCHumanPrototypeRegressionTest
                     Assert.That(entMan.HasComponent<CMUSurgeryWindowOpenComponent>(newSurgeon), Is.True);
                     Assert.That(currentArmed.Surgeon, Is.EqualTo(originalSurgeon));
                     Assert.That(originalState.CurrentArmedStep, Is.Not.Null);
-                    Assert.That(newState.CurrentArmedStep, Is.Null);
+                    Assert.That(newState.CurrentArmedStep, Is.Not.Null);
                 });
             }
             finally

--- a/Content.Server/_CMU14/Medical/Surgery/CMUSurgeryDispatchSystem.cs
+++ b/Content.Server/_CMU14/Medical/Surgery/CMUSurgeryDispatchSystem.cs
@@ -926,20 +926,12 @@ public sealed class CMUSurgeryDispatchSystem : EntitySystem
         var marker = ent.Comp;
         if (!marker.Patient.IsValid())
             return;
-        // BUI cancel only abandons the viewer's own armed/in-flight step.
-        // Another surgeon can keep a menu open without clearing someone
-        // else's active work.
+        // BUI cancel is deliberate takeover/abandon. Opening another
+        // surgeon's menu is harmless, but once a medic presses abandon they
+        // should be able to stop a stale or unsafe surgery order.
         var medic = ent.Owner;
-        var canClearArmed = TryComp<CMUSurgeryArmedStepComponent>(marker.Patient, out var armed)
-            && armed.Surgeon == medic;
-        var canClearInFlight = TryComp<CMUSurgeryInProgressComponent>(marker.Patient, out var lockComp)
-            && TryComp<CMUSurgeryInFlightComponent>(lockComp.Part, out var inFlight)
-            && inFlight.Surgeon == medic;
-
-        if (canClearArmed)
-            _flowSurgery.ClearArmed(marker.Patient, armed);
-        if (canClearInFlight)
-            _flowSurgery.ClearSurgeryInFlight(marker.Patient);
+        _flowSurgery.ClearArmed(marker.Patient);
+        _flowSurgery.ClearSurgeryInFlight(marker.Patient);
 
         var parts = BuildPartEntries(marker.Patient, medic);
         var refreshedArmed = CompOrNull<CMUSurgeryArmedStepComponent>(marker.Patient);

--- a/Content.Shared/_CMU14/Medical/Surgery/SharedCMUSurgeryFlowSystem.cs
+++ b/Content.Shared/_CMU14/Medical/Surgery/SharedCMUSurgeryFlowSystem.cs
@@ -912,7 +912,7 @@ public abstract class SharedCMUSurgeryFlowSystem : EntitySystem
         EntityUid? viewer = null)
     {
         CMUArmedStepInfo? armedInfo = null;
-        if (armed is not null && (viewer is null || armed.Surgeon == viewer.Value))
+        if (armed is not null)
         {
             // Surface the leaf the medic picked — SurgeryId may differ when
             // a prereq is currently being run.


### PR DESCRIPTION
Surgeons can reopen the surgery UI with a scapel mid-surgery instead of failing/damaging the patient.

Another surgeon can take over an in-progress surgery and see the armed step.

Abandon/cancel now works for takeover cases, so you are not forced to finish someone else’s surgery.

scalpel opens UI instead of randomly auto-starting surgery, and limb reattach keeps the close/stitch step available.