### PR TITLE
Black Sludge

### DIFF
--- a/Resources/Prototypes/_CMU14/Reagents/toxins.yml
+++ b/Resources/Prototypes/_CMU14/Reagents/toxins.yml
@@ -1,0 +1,16 @@
+- type: reagent
+  parent: CMReagent
+  id: CMUBlackSludge
+  name: reagent-name-rmcblackgoo
+  desc: reagent-desc-rmcblackgoo
+  physicalDesc: reagent-physical-desc-unidentifiable
+  flavor: bitter
+  color: "#0a0b0d"
+  unknown: true
+  toxin: true
+  metabolisms:
+    Poison:
+      metabolismRate: 4
+      effects:
+      - !type:ChemVomit
+        probability: 0

--- a/Resources/Prototypes/_CMU14/Recipes/Reactions/other.yml
+++ b/Resources/Prototypes/_CMU14/Recipes/Reactions/other.yml
@@ -1,0 +1,14 @@
+- type: reaction
+  id: CMUCreateSludgeGC
+  quantized: true
+  reactants:
+    CMBicaridine:
+      amount: 16
+    CMMeralyne:
+      amount: 16
+    CMKelotane:
+      amount: 16
+    CMDermaline:
+      amount: 16
+  products:
+    CMUBlackSludge: 64


### PR DESCRIPTION
## About the PR
GC Reaction + Chem

## Why / Balance
Requested change for LRP.

## Technical details
Converts every (quantized) 16u of Bicaridine, Meralyne, Kelotane, and Dermaline into 64u Black Sludge. This works in beakers, bodies, and chemmasters, ect. No poison effects.