### PR TITLE
CLF Changes

### DIFF
--- a/Content.Client/_RMC14/UniformAccessories/UniformAccessoryBui.cs
+++ b/Content.Client/_RMC14/UniformAccessories/UniformAccessoryBui.cs
@@ -4,6 +4,7 @@ using Content.Shared._RMC14.UniformAccessories;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
+using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Containers;
@@ -15,9 +16,11 @@ public sealed class UniformAccessoryBui : BoundUserInterface
 {
     [Dependency] private readonly IClyde _displayManager = default!;
     [Dependency] private readonly IEyeManager _eye = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
 
     private readonly TransformSystem _transform;
     private readonly SharedContainerSystem _container;
+    private readonly UniformAccessorySystem _uniformAccessories;
 
     private UniformAccessoryMenu? _menu;
 
@@ -27,6 +30,7 @@ public sealed class UniformAccessoryBui : BoundUserInterface
 
         _transform = EntMan.System<TransformSystem>();
         _container = EntMan.System<SharedContainerSystem>();
+        _uniformAccessories = EntMan.System<UniformAccessorySystem>();
     }
 
     protected override void Open()
@@ -55,8 +59,15 @@ public sealed class UniformAccessoryBui : BoundUserInterface
 
         foreach (var accessory in container.ContainedEntities)
         {
-            if (!EntMan.TryGetComponent(accessory, out MetaDataComponent? metaData))
+            if (!EntMan.TryGetComponent(accessory, out MetaDataComponent? metaData) ||
+                !EntMan.TryGetComponent(accessory, out UniformAccessoryComponent? accessoryComp))
                 continue;
+
+            if (_player.LocalEntity is not { } viewer ||
+                !_uniformAccessories.CanViewAccessory(accessory, viewer, accessoryComp))
+            {
+                continue;
+            }
 
             var button = new RadialMenuTextureButton
             {

--- a/Content.Shared/_RMC14/UniformAccessories/SharedUniformAccessorySystem.cs
+++ b/Content.Shared/_RMC14/UniformAccessories/SharedUniformAccessorySystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Item;
 using Content.Shared.Popups;
 using Content.Shared.Roles;
 using Content.Shared.Verbs;
+using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Utility;
@@ -26,6 +27,7 @@ public abstract class SharedUniformAccessorySystem : EntitySystem
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedWebbingSystem _webbing = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
 
     public override void Initialize()
     {
@@ -99,11 +101,18 @@ public abstract class SharedUniformAccessorySystem : EntitySystem
         if (!args.CanAccess || !args.CanInteract || HasComp<XenoComponent>(args.User))
             return;
 
-        if (!_container.TryGetContainer(ent, ent.Comp.ContainerId, out var container) ||
-            !container.ContainedEntities.TryFirstOrNull(out var firstAccessory))
-        {
+        if (!_container.TryGetContainer(ent, ent.Comp.ContainerId, out var container))
             return;
+
+        var visibleAccessories = new List<EntityUid>();
+        foreach (var accessory in container.ContainedEntities)
+        {
+            if (CanViewAccessory(accessory, args.User))
+                visibleAccessories.Add(accessory);
         }
+
+        if (!visibleAccessories.TryFirstOrNull(out var firstAccessory))
+            return;
 
         var user = args.User;
         args.Verbs.Add(new EquipmentVerb
@@ -112,7 +121,7 @@ public abstract class SharedUniformAccessorySystem : EntitySystem
             Act = () =>
             {
                 // only one accessory, don't bother with the UI
-                if (container.ContainedEntities.Count == 1 && firstAccessory != null)
+                if (visibleAccessories.Count == 1 && firstAccessory != null)
                 {
                     _container.Remove(firstAccessory.Value, container);
                     _hands.TryPickupAnyHand(user, firstAccessory.Value);
@@ -133,6 +142,9 @@ public abstract class SharedUniformAccessorySystem : EntitySystem
         var toRemove = GetEntity(args.ToRemove);
 
         if (!_container.TryGetContainer(ent, ent.Comp.ContainerId, out var container))
+            return;
+
+        if (!CanViewAccessory(toRemove, user))
             return;
 
         if (_container.Remove(toRemove, container))
@@ -260,6 +272,15 @@ public abstract class SharedUniformAccessorySystem : EntitySystem
     public bool BelongsToUser(NetEntity user, EntityUid target)
     {
         return user == GetNetEntity(target);
+    }
+
+    public bool CanViewAccessory(EntityUid accessory, EntityUid viewer, UniformAccessoryComponent? accessoryComp = null)
+    {
+        if (!Resolve(accessory, ref accessoryComp, false))
+            return false;
+
+        return accessoryComp.ViewerWhitelist == null ||
+               _whitelist.IsValid(accessoryComp.ViewerWhitelist, viewer);
     }
 
     public void SetAccessoriesHidden(EntityUid accessoryHolder, bool hideAccessories)

--- a/Content.Shared/_RMC14/UniformAccessories/UniformAccessoryComponent.cs
+++ b/Content.Shared/_RMC14/UniformAccessories/UniformAccessoryComponent.cs
@@ -1,5 +1,6 @@
 using Robust.Shared.GameStates;
 using Robust.Shared.Utility;
+using Content.Shared.Whitelist;
 using static Robust.Shared.Utility.SpriteSpecifier;
 
 namespace Content.Shared._RMC14.UniformAccessories;
@@ -21,6 +22,9 @@ public sealed partial class UniformAccessoryComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool Hidden = false;
+
+    [DataField, AutoNetworkedField]
+    public EntityWhitelist? ViewerWhitelist;
 
     [DataField, AutoNetworkedField]
     public bool HiddenByJacketRolling = false;

--- a/Resources/Prototypes/_AU14/Entities/Clothing/Headset/clfheadsets.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Headset/clfheadsets.yml
@@ -24,6 +24,9 @@
     state: cmb_headset
   - type: UniformAccessory
     hidden: true
+    viewerWhitelist:
+      components:
+      - CLFMember
     category: Utility
     limit: 1
     playerSprite:

--- a/Resources/Prototypes/_AU14/Entities/clf/clfstuff.yml
+++ b/Resources/Prototypes/_AU14/Entities/clf/clfstuff.yml
@@ -278,20 +278,56 @@
 
 - type: clfSpawnConfig
   id: CLFSpawnConfig
-  # Additional entity prototypes that CLF can spawn at during round start
-  # These will be used alongside any entities with SafehouseMarkerComponent
-  additionalItems:
-  - AU14CrateCivilianClothingRandom
-  - AU14CLFObjectiveWeaponsVendor
-  - AU14CrateCivilianClothingRandom
-  - AU14CrateCLFinitalTools
-  - RMCCrateMedicalFirstAid
-  - RMCComputerIntelCLF
-  - ComputerObjectivesCLF
-  - AU14AnalyzerMachineCLF
-  - RMCLampTripod
-  - RMCTechTreeConsoleCLF
-  - CMFaxCLF
+  # Safehouse markers are fallback CLF spawn points; operational gear is deployed from the Cell Leader's kit.
+  additionalItems: []
+
+- type: entity
+  parent: RMCBaseEquipmentCase
+  id: AU14CLFCellKit
+  name: heavy CLF cell kit
+  description: A heavy, low-profile field case used to establish a CLF cell hideout.
+  components:
+  - type: Sprite
+    layers:
+    - state: closed
+      map: [ base ]
+    - state: mortar
+      map: [ label ]
+  - type: RMCDeployable
+    deployTime: 12
+    deployArea:
+      !type:PhysShapeAabb
+      bounds: "-2.4,-2.4,2.4,2.4"
+    areaBlockedCheck: false
+    failIfNotSurface: false
+    deploySetups:
+    - prototype: RMCComputerIntelCLF
+      mode: ReactiveParental
+      offset: -1.5, 2
+    - prototype: ComputerObjectivesCLF
+      offset: -0.5, 2
+    - prototype: RMCTechTreeConsoleCLF
+      offset: 0.5, 2
+    - prototype: CMFaxCLF
+      offset: 1.5, 2
+    - prototype: AU14AnalyzerMachineCLF
+      offset: -1.5, 0
+    - prototype: AU14CLFObjectiveWeaponsVendor
+      anchor: false
+      offset: -0.5, 0
+    - prototype: RMCLampTripod
+      offset: 0.5, 0
+    - prototype: RMCCrateMedicalFirstAid
+      offset: 1.5, 0
+    - prototype: AU14CrateCivilianClothingRandom
+      offset: -1.5, -2
+    - prototype: AU14CrateCivilianClothingRandom
+      offset: -0.5, -2
+    - prototype: AU14CrateCLFinitalTools
+      offset: 0.5, -2
+    - prototype: AU14CrateCLFRecruitmentKit
+      offset: 1.5, -2
+
 - type: entity
   name: Generic Safhouse Marker
   parent: MarkerBase
@@ -305,8 +341,8 @@
 - type: entity
   parent: RMCCrateBase
   id: AU14CrateCLFinitalTools
-  name: Crate
-  description: Contains several tools
+  name: CLF tool cache
+  description: A field cache of weapons, utilities, and repair tools for a newly established CLF cell.
   components:
   - type: Sprite
     state: crate
@@ -332,13 +368,25 @@
       amount: 2
     - id: RMCBoxFlashlights
       amount: 2
+
+- type: entity
+  parent: RMCCrateBase
+  id: AU14CrateCLFRecruitmentKit
+  name: CLF recruitment cache
+  description: A compact cache for inducting new CLF members and handing out covert cell comms.
+  components:
+  - type: Sprite
+    state: crate
+  - type: StorageFill
+    contents:
     - id: AU14CLFHeadset
       amount: 5
-    - id:  AU14TattooInkCartridge
-      amount: 2
+    - id: RMCCLFArmband
+      amount: 5
+    - id: AU14TattooInkCartridge
+      amount: 6
     - id: AU14TattooGun
       amount: 1
-
 
 - type: entity
   parent: CMFax

--- a/Resources/Prototypes/_AU14/Roles/Jobs/CLF/clfcellleader.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/CLF/clfcellleader.yml
@@ -74,7 +74,7 @@
     id: AU14IDCardCLFCellLeader
     eyes: RMCGlassesAviators
   inhand:
-  - RMCWeaponRifleType71
+  - AU14CLFCellKit
   - AU14CLFHeadset
 
 - type: entity


### PR DESCRIPTION
Reworked CLF safehouse loot into a deployable heavy CLF Cell Kit for the Cell Leader.

Cell Leader now starts with the Cell Kit

Cell Kit deploys the full old Insurgency/CLF safehouse:

Added a CLF recruitment cache comes with
CLF headsets
CLF armbands
tattoo gun
tattoo ink

Requisitions rack deployed from the Cell Kit is now movable.

CLF earpieces are now hidden from non-CLF stripping/interaction views, while CLF members can still see them.
Validation

https://cdn.discordapp.com/attachments/1405935562971418714/1504452881124818944/image.png?ex=6a070a6e&is=6a05b8ee&hm=c14320e06c3b6cd6b623a8ec98724d2066632d512915c5ed5391f6d031abc4cc&
https://cdn.discordapp.com/attachments/1405935562971418714/1504452898115813439/image.png?ex=6a070a72&is=6a05b8f2&hm=ecbbcd270e8d3fa0cb5d55c8c8f86b62bc9d67c4a620b0e50abe74c6a38d755a&