### PR TITLE
Basira minor buff

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/BoltAction/hunting_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/BoltAction/hunting_rifle.yml
@@ -139,9 +139,16 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 37
+        Piercing: 35
   - type: CMArmorPiercing
-    amount: 10
+    amount: 15
+  - type: RMCProjectileDamageFalloff
+    thresholds:
+    - range: 15
+      falloff: 3
+      ignoreModifiers: true
+    - range: 7
+      falloff: 0
   - type: RMCStunOnHit
     stuns:
     - whitelist:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/BoltAction/hunting_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/BoltAction/hunting_rifle.yml
@@ -139,13 +139,13 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 35
+        Piercing: 37
   - type: CMArmorPiercing
-    amount: 15
+    amount: 10
   - type: RMCProjectileDamageFalloff
     thresholds:
     - range: 15
-      falloff: 3
+      falloff: 1
       ignoreModifiers: true
     - range: 7
       falloff: 0

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/BoltAction/hunting_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/BoltAction/hunting_rifle.yml
@@ -139,12 +139,12 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 32
+        Piercing: 29
   - type: CMArmorPiercing
-    amount: 15
+    amount: 18
   - type: RMCProjectileDamageFalloff
     thresholds:
-    - range: 20
+    - range: 30
       falloff: 1
       ignoreModifiers: true
     - range: 7

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/BoltAction/hunting_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/BoltAction/hunting_rifle.yml
@@ -139,12 +139,12 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 37
+        Piercing: 32
   - type: CMArmorPiercing
-    amount: 10
+    amount: 15
   - type: RMCProjectileDamageFalloff
     thresholds:
-    - range: 15
+    - range: 20
       falloff: 1
       ignoreModifiers: true
     - range: 7


### PR DESCRIPTION
## About the PR
Increases basira AP and range. 

## Why / Balance
Basira was buns. Now it is buns (appropriate to the 2 point spend, I think)

## Technical details
its like 2 notepad files man

## Media
Trust me..still can't kill shit on 4x long range like real snipers.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Basira AP increase, Damage falloff reduced
