### PR TITLE
M34-T crate feedback changes

### DIFF
--- a/Resources/Prototypes/_AU14/Catalog/Fills/Crates/weapons.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Fills/Crates/weapons.yml
@@ -15,17 +15,17 @@
 - type: entity
   id: AU14CrateFlamerSpec
   parent: RMCCrateWeapons
-  name: M34-T Incinerator Crate (1x M34-t Incinerator, 1x Broiler-T, 1x Fuel Tank Pouch, 1x Large Incinerator Tank, 2x Large Custom Incinerator Tanks)
+  name: M34-T Incinerator Crate (1x M34-t Incinerator, 1x Broiler-T, 1x Fuel Tank Pouch, 1x Large Incinerator Tank, 1x Large Custom Incinerator Tanks)
   components:
   - type: StorageFill
     contents:
     - id: RMCWeaponFlamerSpec
       amount: 1
-    - id: RMCBackpackBroilerEmpty
+    - id: RMCBackpackBroiler
       amount: 1
     - id: RMCPouchFuelTank
       amount: 1
     - id: RMCTankFlamerLarge
       amount: 1
     - id: RMCTankFlamerLargeCustom
-      amount: 2
+      amount: 1


### PR DESCRIPTION
## About the PR
Applies feedback changes requested by people who bought the crate.

This makes the broiler come pre-filled with one normal tank, one Napalm-B tank, and one that blue fire tank that i forgot the name of.
## Why / Balance
the kit is 6k, it makes buying the kit for the first time earn you an exclusive tank that should be used scarcely as it’s a one of a kind item that comes with every crate. also feedback
For compensation, removes one custom tank for the filled broiler.

## Technical details
Removes one tank + removes broilerempty for broiler

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: The requisitions M34-T kit now has a filled broiler at the compensation of one less custom tank.