### PR TITLE
Fix the M34-T Flamer restriction

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34t_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34t_flamer.yml
@@ -6,10 +6,6 @@
   components:
   - type: Corrodible
     isCorrodible: false
-  - type: GunUserWhitelist
-    whitelist:
-      components:
-      - PyroWhitelist
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Guns/Flamethrower/m34t.rsi
   - type: Item


### PR DESCRIPTION
## About the PR
Didnt let anyone who wasnt a JO, RFN or other officers use it, funny.

## Why / Balance
bugfix

## Technical details
1 comp removed
## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: GOVFOR roles and others should now be able to use the M34-T flamer properly.