### PR TITLE
🩹 synth blood white impact&effect markers

### DIFF
--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -42,20 +42,27 @@ namespace Content.Shared.Projectiles;
 public abstract partial class SharedProjectileSystem : EntitySystem
 {
     public const string ProjectileFixture = "projectile";
-    private static readonly ProtoId<ReagentPrototype> BloodReagent = "Blood";
-    private static readonly ProtoId<ReagentPrototype> YautjaBloodReagent = "CMUYautjaBlood";
     private static readonly FixedPoint2 BloodImpactPiercingThreshold = FixedPoint2.New(45);
+    private static readonly ProtoId<ReagentPrototype> BloodReagent = "Blood";
     private static readonly string[] BloodImpactEffects =
     {
         "CMUBloodImpactEffect",
         "CMUBloodImpactEffect1",
         "CMUBloodImpactEffect2",
     };
+    private static readonly ProtoId<ReagentPrototype> YautjaBloodReagent = "CMUYautjaBlood";
     private static readonly string[] YautjaBloodImpactEffects =
     {
         "CMUYautjaBloodImpactEffect",
         "CMUYautjaBloodImpactEffect1",
         "CMUYautjaBloodImpactEffect2",
+    };
+    private static readonly ProtoId<ReagentPrototype> SynthBloodReagent = "RMCSynthBlood";
+    private static readonly string[] SynthBloodImpactEffects =
+    {
+        "CMUSynthBloodImpactEffect",
+        "CMUSynthBloodImpactEffect1",
+        "CMUSynthBloodImpactEffect2",
     };
 
     [Dependency] private INetManager _net = default!;
@@ -291,17 +298,18 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         if (bloodstream.BloodReagent == YautjaBloodReagent)
             return _random.Pick(YautjaBloodImpactEffects);
 
+        if (bloodstream.BloodReagent == SynthBloodReagent)
+            return _random.Pick(SynthBloodImpactEffects);
+
         return fallback;
     }
 
     private Color GetDamageEffectColor(EntityUid target)
     {
-        if (TryComp(target, out BloodstreamComponent? bloodstream) &&
-            bloodstream.BloodReagent == YautjaBloodReagent &&
-            _reagent.TryIndex(bloodstream.BloodReagent, out var reagent))
-        {
+        if (TryComp(target, out BloodstreamComponent? bloodstream)
+            && bloodstream.BloodReagent != BloodReagent
+            && _reagent.TryIndex(bloodstream.BloodReagent, out var reagent))
             return reagent.SubstanceColor;
-        }
 
         return Color.Red;
     }

--- a/Resources/Prototypes/_CMU14/Effects/blood_impact.yml
+++ b/Resources/Prototypes/_CMU14/Effects/blood_impact.yml
@@ -1,3 +1,4 @@
+# ├──[ DEFAULT BLOOD ]───────────────────────────────────────────────┤
 - type: entity
   id: CMUBloodImpactEffect
   categories: [ HideSpawnMenu ]
@@ -50,6 +51,7 @@
       sprite: _CMU14/Effects/blood_impact.rsi
       state: cmubloodsplatter2
 
+# ├──[ YAUTJA BLOOD ]────────────────────────────────────────────────┤
 - type: entity
   parent: CMUBloodImpactEffect
   id: CMUYautjaBloodImpactEffect
@@ -91,6 +93,54 @@
     drawdepth: Effects
     scale: 0.75, 0.75
     color: "#2cf274"
+    layers:
+    - shader: unshaded
+      map: ["enum.EffectLayers.Unshaded"]
+      sprite: _CMU14/Effects/blood_impact.rsi
+      state: cmubloodsplatter2
+
+# ├──[ SYNTH BLOOD ]─────────────────────────────────────────────────┤
+- type: entity
+  parent: CMUBloodImpactEffect
+  id: CMUSynthBloodImpactEffect
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    drawdepth: Effects
+    scale: 0.75, 0.75
+    color: "#EEEEEE"
+    layers:
+    - shader: unshaded
+      map: ["enum.EffectLayers.Unshaded"]
+      sprite: _CMU14/Effects/blood_impact.rsi
+      state: cm_bloodsplatter
+  - type: SpriteColor
+    color: "#EEEEEE"
+
+- type: entity
+  parent: CMUSynthBloodImpactEffect
+  id: CMUSynthBloodImpactEffect1
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    drawdepth: Effects
+    scale: 0.75, 0.75
+    color: "#EEEEEE"
+    layers:
+    - shader: unshaded
+      map: ["enum.EffectLayers.Unshaded"]
+      sprite: _CMU14/Effects/blood_impact.rsi
+      state: cmubloodsplatter1
+
+- type: entity
+  parent: CMUSynthBloodImpactEffect
+  id: CMUSynthBloodImpactEffect2
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    drawdepth: Effects
+    scale: 0.75, 0.75
+    color: "#EEEEEE"
     layers:
     - shader: unshaded
       map: ["enum.EffectLayers.Unshaded"]


### PR DESCRIPTION
## About the PR
- Fixed the synth blood impact markers being default red

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
