### PR TITLE
XenoQueen hijack AccessReader bypass

### DIFF
--- a/Content.Shared/_RMC14/Dropship/SharedDropshipSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/SharedDropshipSystem.cs
@@ -61,6 +61,11 @@ public abstract partial class SharedDropshipSystem : EntitySystem
         SubscribeLocalEvent<DropshipComponent, MapInitEvent>(OnDropshipMapInit);
 
         SubscribeLocalEvent<DropshipNavigationComputerComponent, MapInitEvent>(OnMapInit);
+        
+        //fix queenxeno ignore AccessReaderComponent
+        SubscribeLocalEvent<DropshipNavigationComputerComponent, ActivateInWorldEvent>(OnNavigationActivateInWorld, before: [typeof(ActivatableUISystem), typeof(ActivatableUIRequiresAccessSystem)]);
+        //
+        
         SubscribeLocalEvent<DropshipNavigationComputerComponent, ActivatableUIOpenAttemptEvent>(OnUIOpenAttempt);
         SubscribeLocalEvent<DropshipNavigationComputerComponent, AfterActivatableUIOpenEvent>(OnNavigationOpen);
         SubscribeLocalEvent<DropshipNavigationComputerComponent, DropshipLockoutOverrideDoAfterEvent>(OnNavigationLockoutOverride);
@@ -249,6 +254,31 @@ public abstract partial class SharedDropshipSystem : EntitySystem
 
         // Xeno hijacker: open destination menu immediately
         OpenHijackDestinationMenu(ent, args.User);
+    }
+    
+    // Fix to queenxeno ignore AccessReaderComponent
+    private void OnNavigationActivateInWorld(Entity<DropshipNavigationComputerComponent> ent,
+        ref ActivateInWorldEvent args)
+    {
+        var user = args.User;
+        var isXeno = HasComp<XenoComponent>(user);
+        var isHijacker = HasComp<DropshipHijackerComponent>(user);
+        
+        //for non xeno pass normal AccessReader and skill checks still apply.
+        if (!isXeno && !isHijacker)
+        {
+            return;
+        }
+        
+        args.Handled = true;
+        if (_net.IsClient)
+        {
+            return;
+        }
+
+        var ev = new ActivatableUIOpenAttemptEvent(user);
+        
+        OnUIOpenAttempt(ent, ref ev);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fix XenoQueen now can use both shuttles and can bypass `ActivatableUIRequiresAccessSystem` (but in fact just ignore it) to access `DropshipNavigationComputerComponent` even if they have access list.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
Add handler `OnNavigationActivateInWorld` before `ActivatableUISystem` and `ActivatableUIRequiresAccessSystem`

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [ ] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: now Xeno Queen can use both marine shuttles to hijack.
