### PR TITLE
Buffs Dancer and Base Praetorian

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Dodge/XenoActiveDodgeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Dodge/XenoActiveDodgeComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared._RMC14.Xenonids.Dodge;
 public sealed partial class XenoActiveDodgeComponent : Component
 {
     [DataField]
-    public FixedPoint2 SpeedMult = FixedPoint2.New(0.25);
+    public FixedPoint2 SpeedMult = FixedPoint2.New(0.35);
 
     [DataField]
     public FixedPoint2 CrowdSpeedAddMult = FixedPoint2.New(0.25);

--- a/Content.Shared/_RMC14/Xenonids/Dodge/XenoDodgeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Dodge/XenoDodgeComponent.cs
@@ -10,5 +10,5 @@ public sealed partial class XenoDodgeComponent : Component
     public int PlasmaCost = 200;
 
     [DataField, AutoNetworkedField]
-    public TimeSpan Duration = TimeSpan.FromSeconds(7);
+    public TimeSpan Duration = TimeSpan.FromSeconds(15);
 }

--- a/Content.Shared/_RMC14/Xenonids/Impale/XenoImpaleComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Impale/XenoImpaleComponent.cs
@@ -23,7 +23,7 @@ public sealed partial class XenoImpaleComponent : Component
     public SoundSpecifier Sound = new SoundPathSpecifier("/Audio/_RMC14/Xeno/alien_tail_attack.ogg");
 
     [DataField, AutoNetworkedField]
-    public int AP = 10;
+    public int AP = 30;
 
     [DataField, AutoNetworkedField]
     public ProtoId<EmotePrototype>? Emote = "XenoRoar";

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
@@ -341,7 +341,7 @@ public sealed partial class XenoSpitSystem : EntitySystem
             return;
 
         var ev = new XenoAcidBallDoAfterEvent(GetNetCoordinates(args.Target));
-        var doAfter = new DoAfterArgs(EntityManager, ent, ent.Comp.Delay, ev, ent) { BreakOnMove = true, RootEntity = true };
+        var doAfter = new DoAfterArgs(EntityManager, ent, ent.Comp.Delay, ev, ent) { BreakOnMove = false, RootEntity = true };
         _doAfter.TryStartDoAfter(doAfter);
     }
 

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -926,14 +926,14 @@
   parent: ActionXenoBase
   id: ActionXenoImpale
   name: Impale (80)
-  description: Impales an adjacent enemy with your tail. Hits twice on a marked target and removes the mark. Pierces some armor.
+  description: Impales an adjacent enemy with your tail. Hits twice on a marked target and removes the mark. Pierces armor.
   components:
   - type: Action
     itemIconStyle: NoItem
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
       state: prae_impale
-    useDelay: 13
+    useDelay: 8
   - type: TargetAction
     range: 1.5
     deselectOnMiss: false

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -373,7 +373,7 @@
   id: ActionXenoDodge
   parent: ActionXenoBase
   name: Dodge (200)
-  description: Gain a speed boost for 7 seconds and move through allies and enemies unimpeded. Your speed is doubled near standing enemies.
+  description: Gain a speed boost for 15 seconds and move through allies and enemies unimpeded. Your speed is doubled near standing enemies.
   components:
   - type: Action
     itemIconStyle: NoItem

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -256,7 +256,7 @@
   - type: XenoImpale
     damage:
       groups:
-        Brute: 40
+        Brute: 60
   - type: XenoTailTrip
   - type: XenoHidden
   - type: RMCActionOrder


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Dancer:
Base damage increased by 20 
Dodge now lasts 15 seconds and is 10% faster. (this is a movement increase and phase through entities only, not an actual dodge)
Impale now ignores 30 armor and has a 7 second cooldown.
Base Praetorian:
Acid ball do-after no longer cancels when moving.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Dancer is extremely underpowered - it doesnt really benefit at all over anything compared to other castes like vanguard and ravager (even being outclassed by vampire) So this is a buff that should help it.

Base Praetorian gets heavily nerfed due to the fact it cant use it's acid ball on the move - forcing it to sit infront of enemies to use the ball (usually limiting its acid stacking by an extreme amount) 
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Dancer Impale, base damage and dodge has been buffed!
- tweak: Base Praetorian can now use acid ball while moving!

