### PR TITLE
Add an additional check regarding role loadouts. (EXPLOIT FIX)

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -1150,7 +1150,8 @@ namespace Content.Shared.Preferences
                     toRemove.Add(roleName);
                     continue;
                 }
-
+                
+                loadouts.Role = roleName;
                 loadouts.EnsureValid(this, session, collection);
             }
 


### PR DESCRIPTION
## About the PR
It was possible to modify game files to allow yourself to spawn in with ANY of the currently selectable loadouts from the roundstart list, even those that were hidden worked, actually. The server never validated that you are the role that the loadout belongs to. This fixes that.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
No player facing changes.