### PR TITLE
Crusher rework: charge bowling, directional stomp, shield reflect, soak ability, stats rebalancing

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -13,7 +13,9 @@ using Content.Shared._RMC14.Xenonids.Burrow;
 using Content.Shared._RMC14.Xenonids.DeployTraps;
 using Content.Shared._RMC14.Xenonids.Spray;
 using Content.Shared._RMC14.Xenonids.Abduct;
+using Content.Shared._RMC14.Xenonids.Charge;
 using Content.Shared._RMC14.Xenonids.Pierce;
+using Content.Shared._RMC14.Xenonids.Stomp;
 using Content.Shared.Actions.Components;
 using Content.Shared.Maps;
 using Content.Shared.Physics;
@@ -74,6 +76,8 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     private readonly EntityQuery<XenoDeployTrapsComponent> _deployTrapsQ;
     private readonly EntityQuery<XenoAbductComponent> _abductQ;
     private readonly EntityQuery<XenoPierceComponent> _pierceQ;
+    private readonly EntityQuery<XenoChargeComponent> _chargeQ;
+    private readonly EntityQuery<XenoStompComponent> _stompQ;
     private readonly EntityQuery<TransformComponent> _xformQ;
 
     public XenoAbilityPreviewOverlay(IEntityManager ents)
@@ -100,6 +104,8 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         _deployTrapsQ = ents.GetEntityQuery<XenoDeployTrapsComponent>();
         _abductQ = ents.GetEntityQuery<XenoAbductComponent>();
         _pierceQ = ents.GetEntityQuery<XenoPierceComponent>();
+        _chargeQ = ents.GetEntityQuery<XenoChargeComponent>();
+        _stompQ = ents.GetEntityQuery<XenoStompComponent>();
         _xformQ = ents.GetEntityQuery<TransformComponent>();
     }
 
@@ -181,6 +187,18 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
                 if (!_pierceQ.TryComp(player.Value, out var pierce))
                     return;
                 DrawPierce(args, player.Value, xform, originMap, mousePos, pierce);
+                break;
+
+            case XenoChargeActionEvent:
+                if (!_chargeQ.TryComp(player.Value, out var charge))
+                    return;
+                DrawCharge(args, player.Value, xform, originMap, mousePos, charge);
+                break;
+
+            case XenoDirectionalStompActionEvent:
+                if (!_stompQ.TryComp(player.Value, out var stomp) || !stomp.Directional)
+                    return;
+                DrawDirectionalStomp(args, originMap, mousePos, stomp);
                 break;
         }
     }
@@ -294,6 +312,61 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
 
         var color = PierceOutlineColor.WithAlpha(OutlineAlpha);
         DrawLinePreview(args, player, xform.Coordinates, mousePos, (int)pierce.Range, color);
+    }
+
+    private void DrawCharge(
+        in OverlayDrawArgs args,
+        EntityUid player,
+        TransformComponent xform,
+        MapCoordinates originMap,
+        MapCoordinates mousePos,
+        XenoChargeComponent charge)
+    {
+        var direction = mousePos.Position - originMap.Position;
+        var distance = Math.Min(direction.Length(), charge.Range);
+        mousePos = originMap.Offset(direction.Normalized() * distance);
+
+        var color = new Color(0.85f, 0.2f, 0.2f).WithAlpha(OutlineAlpha);
+        DrawLinePreview(args, player, xform.Coordinates, mousePos, distance, color);
+    }
+
+    private void DrawDirectionalStomp(
+        in OverlayDrawArgs args,
+        MapCoordinates originMap,
+        MapCoordinates mousePos,
+        XenoStompComponent stomp)
+    {
+        var direction = (mousePos.Position - originMap.Position).ToWorldAngle();
+        var halfAngle = new Angle(stomp.DirectionalAngle.Theta / 2);
+        var range = stomp.DirectionalRange;
+        var color = new Color(0.85f, 0.2f, 0.2f).WithAlpha(OutlineAlpha);
+
+        if (!_mapManager.TryFindGridAt(originMap, out var gridUid, out var grid))
+            return;
+
+        var center = _mapSystem.CoordinatesToTile(gridUid, grid, originMap);
+        var tileRange = (int) MathF.Ceiling(range);
+        var tiles = new HashSet<Vector2i>();
+
+        for (var x = -tileRange; x <= tileRange; x++)
+        {
+            for (var y = -tileRange; y <= tileRange; y++)
+            {
+                var tilePos = center + new Vector2i(x, y);
+                var worldPos = _mapSystem.GridTileToWorld(gridUid, grid, tilePos).Position;
+                var diff = worldPos - originMap.Position;
+                if (diff.Length() > range || diff.Length() < 0.1f)
+                    continue;
+
+                var angleDiff = Angle.ShortestDistance(direction, diff.ToWorldAngle());
+                if (Math.Abs(angleDiff.Theta) > halfAngle.Theta)
+                    continue;
+
+                tiles.Add(tilePos);
+            }
+        }
+
+        DrawTileBorder(args.WorldHandle, gridUid, grid, tiles, color);
     }
 
     private void DrawBombard(

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -106,6 +106,13 @@ public sealed partial class MeleeWeaponComponent : Component
     [DataField, AutoNetworkedField]
     public Angle Angle = Angle.FromDegrees(60);
 
+    /// <summary>
+    /// Per-weapon override for maximum wide attack targets.
+    /// If null, uses the global CVar value.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int? MaxTargets;
+
     [DataField, AutoNetworkedField]
     public EntProtoId Animation = "WeaponArcPunch";
 

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -703,9 +703,10 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
         }
 
         // Naughty input
-        if (entities.Count > MaxTargets)
+        var maxTargets = component.MaxTargets ?? MaxTargets;
+        if (entities.Count > maxTargets)
         {
-            entities.RemoveRange(MaxTargets, entities.Count - MaxTargets);
+            entities.RemoveRange(maxTargets, entities.Count - maxTargets);
         }
 
         // Validate client

--- a/Content.Shared/_RMC14/Shields/CrusherShieldComponent.cs
+++ b/Content.Shared/_RMC14/Shields/CrusherShieldComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class CrusherShieldComponent : Component
     public int ExplosionResistance = 1000;
 
     [DataField, AutoNetworkedField]
-    public int DamageReduction = 10;
+    public int DamageReduction = 8;
 
     [DataField, AutoNetworkedField]
     public TimeSpan ExplosionResistanceDuration = TimeSpan.FromSeconds(2.5);
@@ -32,8 +32,17 @@ public sealed partial class CrusherShieldComponent : Component
     public FixedPoint2 PlasmaCost = FixedPoint2.New(50);
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 Amount = FixedPoint2.New(200);
+    public FixedPoint2 Amount = FixedPoint2.New(100);
 
     [DataField, AutoNetworkedField]
     public EntProtoId Effect = "RMCEffectEmpowerBrown";
+
+    [DataField, AutoNetworkedField]
+    public float ReflectChanceFront = 0.4f;
+
+    [DataField, AutoNetworkedField]
+    public float ReflectChanceSide = 0.3f;
+
+    [DataField, AutoNetworkedField]
+    public float ReflectChanceBack = 0.25f;
 }

--- a/Content.Shared/_RMC14/Shields/CrusherShieldSystem.cs
+++ b/Content.Shared/_RMC14/Shields/CrusherShieldSystem.cs
@@ -1,13 +1,20 @@
 using Content.Shared._RMC14.Actions;
+using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Armor;
 using Content.Shared._RMC14.Damage;
+using Content.Shared._RMC14.Weapons.Ranged.Prediction;
 using Content.Shared._RMC14.Xenonids.Plasma;
+using Content.Shared._RMC14.Xenonids.Projectile;
 using Content.Shared.Actions;
 using Content.Shared.Coordinates;
 using Content.Shared.Explosion;
 using Content.Shared.Popups;
+using Content.Shared.Projectiles;
 using Robust.Shared.Network;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
+using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Shields;
@@ -21,6 +28,9 @@ public sealed partial class CrusherShieldSystem : EntitySystem
     [Dependency] private XenoShieldSystem _shield = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private XenoPlasmaSystem _xenoPlasma = default!;
+    [Dependency] private SharedPhysicsSystem _physics = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private IRobustRandom _random = default!;
 
     public override void Initialize()
     {
@@ -30,6 +40,7 @@ public sealed partial class CrusherShieldSystem : EntitySystem
         SubscribeLocalEvent<CrusherShieldComponent, GetExplosionResistanceEvent>(OnGetExplosionResistance);
         SubscribeLocalEvent<CrusherShieldComponent, RemovedShieldEvent>(OnShieldRemove);
         SubscribeLocalEvent<CrusherShieldComponent, XenoDefensiveShieldActionEvent>(OnXenoDefensiveShieldAction);
+        SubscribeLocalEvent<CrusherShieldComponent, ProjectileReflectAttemptEvent>(OnReflectAttempt);
     }
 
     private void OnXenoDefensiveShieldAction(Entity<CrusherShieldComponent> xeno, ref XenoDefensiveShieldActionEvent args)
@@ -80,6 +91,69 @@ public sealed partial class CrusherShieldSystem : EntitySystem
                 _actions.SetToggled(action.Owner, false);
             }
         }
+    }
+
+    private void OnReflectAttempt(Entity<CrusherShieldComponent> xeno, ref ProjectileReflectAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        // Only reflect while shield is active.
+        if (!TryComp<XenoShieldComponent>(xeno, out var shield) ||
+            !shield.Active ||
+            shield.Shield != XenoShieldSystem.ShieldType.Crusher)
+            return;
+
+        // Don't reflect xeno projectiles.
+        if (HasComp<XenoProjectileComponent>(args.ProjUid))
+            return;
+
+        var chance = GetDirectionalReflectChance(xeno, args.ProjUid);
+        if (!_random.Prob(chance))
+            return;
+
+        args.Cancelled = true;
+        if (TryComp(args.ProjUid, out PhysicsComponent? physics))
+        {
+            var velocity = _physics.GetMapLinearVelocity(args.ProjUid, component: physics);
+            var rotation = _random.NextAngle(-Angle.FromDegrees(90), Angle.FromDegrees(90)).Opposite();
+            var reflected = rotation.RotateVec(velocity);
+            _physics.SetLinearVelocity(args.ProjUid, reflected, body: physics);
+            _transform.SetWorldRotationNoLerp(args.ProjUid, reflected.ToWorldAngle() + args.Component.Angle);
+        }
+
+        if (_net.IsServer)
+        {
+            RemComp<PredictedProjectileServerComponent>(args.ProjUid);
+        }
+        else if (TryComp(args.ProjUid, out PredictedProjectileClientComponent? predicted))
+        {
+            predicted.Hit = false;
+        }
+
+        args.Component.Shooter = xeno.Owner;
+        args.Component.Weapon = xeno.Owner;
+        Dirty(args.ProjUid, args.Component);
+    }
+
+    private float GetDirectionalReflectChance(Entity<CrusherShieldComponent> xeno, EntityUid projectile)
+    {
+        var projectileCoords = _transform.GetMapCoordinates(projectile);
+        var defenderCoords = _transform.GetMapCoordinates(xeno);
+        if (projectileCoords.MapId != defenderCoords.MapId)
+            return xeno.Comp.ReflectChanceBack;
+
+        var diff = (projectileCoords.Position - defenderCoords.Position).ToWorldAngle().GetCardinalDir();
+        var dir = _transform.GetWorldRotation(xeno).GetCardinalDir();
+
+        if (dir == diff)
+            return xeno.Comp.ReflectChanceFront;
+
+        var perpendiculars = diff.GetPerpendiculars();
+        if (dir == perpendiculars.First || dir == perpendiculars.Second)
+            return xeno.Comp.ReflectChanceSide;
+
+        return xeno.Comp.ReflectChanceBack;
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_RMC14/Xenonids/Brutalize/XenoBrutalizeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Brutalize/XenoBrutalizeComponent.cs
@@ -22,6 +22,9 @@ public sealed partial class XenoBrutalizeComponent : Component
     public float Range = 1.5f;
 
     [DataField, AutoNetworkedField]
+    public int ArmorPiercing = 0;
+
+    [DataField, AutoNetworkedField]
     public TimeSpan BaseCooldownReduction = TimeSpan.FromSeconds(1.5);
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Brutalize/XenoBrutalizeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Brutalize/XenoBrutalizeSystem.cs
@@ -63,7 +63,7 @@ public sealed partial class XenoBrutalizeSystem : EntitySystem
 
             currHits++;
 
-            var myDamage = _damageable.TryChangeDamage(extra, _xeno.TryApplyXenoSlashDamageMultiplier(extra, damage), origin: xeno, tool: xeno);
+            var myDamage = _damageable.TryChangeDamage(extra, _xeno.TryApplyXenoSlashDamageMultiplier(extra, damage), armorPiercing: xeno.Comp.ArmorPiercing, origin: xeno, tool: xeno);
             if (myDamage?.GetTotal() > FixedPoint2.Zero)
             {
                 var filter = Filter.Pvs(extra, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/Charge/ChargeFlungComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/ChargeFlungComponent.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Damage;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Charge;
+
+/// <summary>
+///     Added to a mob flung by crusher charge. When this mob collides with
+///     another mob during the throw, both take damage and get knocked down.
+///     Removed when the throw ends.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(XenoChargeSystem))]
+public sealed partial class ChargeFlungComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier CollisionDamage = new()
+    {
+        DamageDict = { ["Blunt"] = 30 }
+    };
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan KnockdownTime = TimeSpan.FromSeconds(1.5);
+}

--- a/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeComponent.cs
@@ -30,7 +30,7 @@ public sealed partial class XenoChargeComponent : Component
     public TimeSpan StunTime = TimeSpan.FromSeconds(2);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan ChargeDelay = TimeSpan.FromSeconds(1.2);
+    public TimeSpan ChargeDelay = TimeSpan.FromSeconds(0.6);
 
     // TODO RMC14 extra sound on impact
     [DataField, AutoNetworkedField]
@@ -40,8 +40,32 @@ public sealed partial class XenoChargeComponent : Component
     public Vector2? Charge;
 
     [DataField, AutoNetworkedField]
-    public float Strength = 20;
+    public float Strength = 30;
 
     [DataField]
     public HashSet<EntityUid> AlreadyHit = new();
+
+    /// <summary>
+    ///     The intended target of the charge. Intermediate mobs get knocked aside.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? PrimaryTarget;
+
+    /// <summary>
+    ///     Damage multiplier for intermediate targets knocked aside during charge.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float IntermediateDamageMult = 0.7f;
+
+    /// <summary>
+    ///     Where the charge started. Used to calculate distance traveled.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Vector2? ChargeOrigin;
+
+    [DataField, AutoNetworkedField]
+    public float MinKnockback = 5f;
+
+    [DataField, AutoNetworkedField]
+    public float MaxKnockback = 10f;
 }

--- a/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
@@ -31,6 +31,7 @@ using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
+using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
@@ -106,6 +107,9 @@ public sealed partial class XenoChargeSystem : EntitySystem
         SubscribeLocalEvent<XenoChargeComponent, XenoChargeDoAfterEvent>(OnXenoChargeDoAfterEvent);
         SubscribeLocalEvent<XenoChargeComponent, StopThrowEvent>(OnXenoChargeStop);
         SubscribeLocalEvent<XenoChargeComponent, PreventCollideEvent>(OnXenoChargePreventCollide);
+
+        SubscribeLocalEvent<ChargeFlungComponent, ThrowDoHitEvent>(OnChargeFlungHit);
+        SubscribeLocalEvent<ChargeFlungComponent, StopThrowEvent>(OnChargeFlungStop);
 
         SubscribeLocalEvent<XenoToggleChargingComponent, XenoToggleChargingActionEvent>(OnXenoToggleChargingAction);
 
@@ -343,7 +347,7 @@ public sealed partial class XenoChargeSystem : EntitySystem
             Hidden = true,
         };
 
-        _stun.TrySlowdown(xeno, TimeSpan.FromSeconds(1.75f), false, 0f, 0f);
+        _stun.TrySlowdown(xeno, TimeSpan.FromSeconds(0.6f), false, 0f, 0f);
         _doAfter.TryStartDoAfter(doAfter);
     }
 
@@ -367,8 +371,6 @@ public sealed partial class XenoChargeSystem : EntitySystem
 
     private void OnXenoChargeHit(Entity<XenoChargeComponent> xeno, ref ThrowDoHitEvent args)
     {
-        // TODO RMC14 lag compensation
-        // TODO RMC14 allow charge to continue if pass is true
         var targetId = args.Target;
         if (_mobState.IsDead(targetId))
             return;
@@ -424,8 +426,54 @@ public sealed partial class XenoChargeSystem : EntitySystem
 
         var origin = _transform.GetMapCoordinates(xeno);
 
+        var distanceTraveled = xeno.Comp.ChargeOrigin != null
+            ? (origin.Position - xeno.Comp.ChargeOrigin.Value).Length()
+            : 0f;
+        var ratio = Math.Clamp(distanceTraveled / xeno.Comp.Range, 0f, 1f);
+        var knockback = xeno.Comp.MinKnockback + ratio * (xeno.Comp.MaxKnockback - xeno.Comp.MinKnockback);
+
         _stun.TryParalyze(targetId, xeno.Comp.StunTime, true);
-        _sizeStun.KnockBack(targetId, origin, 3, 3, knockBackSpeed: 15);
+        _rmcObstacleSlamming.ApplyBonuses(targetId, TimeSpan.FromSeconds(1.5), TimeSpan.FromSeconds(3));
+        EnsureComp<ChargeFlungComponent>(targetId);
+        _sizeStun.KnockBack(targetId, origin, knockback, knockback, knockBackSpeed: 15);
+    }
+
+    private void OnChargeFlungHit(Entity<ChargeFlungComponent> ent, ref ThrowDoHitEvent args)
+    {
+        var target = args.Target;
+
+        if (!HasComp<MobStateComponent>(target))
+            return;
+
+        if (_mobState.IsDead(target))
+            return;
+
+        // Don't collide with the crusher that flung us.
+        if (HasComp<XenoChargeComponent>(target))
+            return;
+
+        // Don't collide with same-hive xenos.
+        if (_xenoHive.FromSameHive(ent.Owner, target))
+            return;
+
+        // Damage and knockdown the marine in the path.
+        _damageable.TryChangeDamage(target, ent.Comp.CollisionDamage, origin: ent);
+
+        var filter = Filter.Pvs(target, entityManager: EntityManager);
+        _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { target }, filter);
+
+        _stun.TryParalyze(target, ent.Comp.KnockdownTime, true);
+        _slow.TrySlowdown(target, TimeSpan.FromSeconds(1.5));
+
+        if (_net.IsServer)
+            _audio.PlayPvs(new SoundCollectionSpecifier("Punch"), target);
+
+        // Don't stop. Keep going through mobs until hitting a wall or end of range.
+    }
+
+    private void OnChargeFlungStop(Entity<ChargeFlungComponent> ent, ref StopThrowEvent args)
+    {
+        RemCompDeferred<ChargeFlungComponent>(ent);
     }
 
     private void OnXenoChargePreventCollide(Entity<XenoChargeComponent> xeno, ref PreventCollideEvent args)
@@ -459,7 +507,28 @@ public sealed partial class XenoChargeSystem : EntitySystem
 
         var coordinates = GetCoordinates(args.Coordinates);
         var origin = _transform.GetMapCoordinates(xeno);
-        var diff = _transform.ToMapCoordinates(coordinates).Position - origin.Position;
+        var targetMap = _transform.ToMapCoordinates(coordinates);
+        var diff = targetMap.Position - origin.Position;
+
+        // Find the closest valid mob target near the click position.
+        xeno.Comp.PrimaryTarget = null;
+        float closestDist = float.MaxValue;
+        foreach (var mob in _lookup.GetEntitiesInRange<MobStateComponent>(targetMap, 2f))
+        {
+            if (!_xeno.CanAbilityAttackTarget(xeno, mob))
+                continue;
+
+            if (_mobState.IsDead(mob))
+                continue;
+
+            var mobMap = _transform.GetMapCoordinates(mob);
+            var dist = (mobMap.Position - targetMap.Position).Length();
+            if (dist < closestDist)
+            {
+                closestDist = dist;
+                xeno.Comp.PrimaryTarget = mob;
+            }
+        }
         var length = diff.Length();
         if (length > xeno.Comp.Range)
             diff = diff.Normalized() * xeno.Comp.Range;
@@ -504,6 +573,7 @@ public sealed partial class XenoChargeSystem : EntitySystem
         }
 
         xeno.Comp.Charge = diff;
+        xeno.Comp.ChargeOrigin = origin.Position;
         Dirty(xeno);
 
         EnsureComp<XenoChargingComponent>(xeno);

--- a/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakComponent.cs
@@ -11,4 +11,16 @@ public sealed partial class XenoSoakComponent : Component
 
     [DataField, AutoNetworkedField]
     public FixedPoint2 PlasmaCost = FixedPoint2.New(20);
+
+    /// <summary>
+    ///     Override for the damage goal. If null, uses the default from XenoSoakingDamageComponent.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int? DamageGoal;
+
+    /// <summary>
+    ///     Override for the heal amount. If null, uses the default from XenoSoakingDamageComponent.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2? Heal;
 }

--- a/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakSystem.cs
@@ -44,6 +44,13 @@ public sealed partial class XenoSoakSystem : EntitySystem
         var soak = EnsureComp<XenoSoakingDamageComponent>(xeno);
         soak.EffectExpiresAt = _timing.CurTime + xeno.Comp.Duration;
         soak.DamageAccumulated = 0;
+
+        if (xeno.Comp.DamageGoal is { } damageGoal)
+            soak.DamageGoal = damageGoal;
+
+        if (xeno.Comp.Heal is { } heal)
+            soak.Heal = heal;
+
         Dirty(xeno.Owner, soak);
 
         _popup.PopupPredicted(Loc.GetString("rmc-xeno-soak-self"), Loc.GetString("rmc-xeno-soak-others", ("xeno", xeno)), xeno, xeno, PopupType.MediumCaution);

--- a/Content.Shared/_RMC14/Xenonids/Stomp/SharedXenoStompSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stomp/SharedXenoStompSystem.cs
@@ -1,4 +1,8 @@
+using System.Numerics;
 using Content.Shared._RMC14.Actions;
+using Content.Shared._RMC14.CameraShake;
+using Content.Shared._RMC14.Damage.ObstacleSlamming;
+using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Slow;
 using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Xenonids.Plasma;
@@ -9,8 +13,12 @@ using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Effects;
 using Content.Shared.FixedPoint;
+using Content.Shared.Interaction;
+using Content.Shared.Maps;
 using Content.Shared.Mobs.Components;
+using Robust.Shared.Map.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Physics;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Robust.Shared.Audio.Systems;
@@ -37,6 +45,13 @@ public sealed partial class XenoStompSystem : EntitySystem
     [Dependency] private RMCSizeStunSystem _size = default!;
     [Dependency] private SharedRMCActionsSystem _rmcActions = default!;
     [Dependency] private SharedHitLocationSystem _hitLocation = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private SharedInteractionSystem _interact = default!;
+    [Dependency] private RMCPullingSystem _rmcPulling = default!;
+    [Dependency] private RMCObstacleSlammingSystem _obstacleSlamming = default!;
+    [Dependency] private RMCCameraShakeSystem _cameraShake = default!;
+    [Dependency] private SharedMapSystem _map = default!;
+    [Dependency] private TurfSystem _turf = default!;
 
     public override void Initialize()
     {
@@ -44,6 +59,7 @@ public sealed partial class XenoStompSystem : EntitySystem
 
         SubscribeLocalEvent<XenoStompComponent, XenoStompActionEvent>(OnXenoStompAction);
         SubscribeLocalEvent<XenoStompComponent, XenoStompDoAfterEvent>(OnXenoStompDoAfter);
+        SubscribeLocalEvent<XenoStompComponent, XenoDirectionalStompActionEvent>(OnXenoDirectionalStompAction);
     }
 
     private readonly HashSet<Entity<MobStateComponent>> _receivers = new();
@@ -93,11 +109,63 @@ public sealed partial class XenoStompSystem : EntitySystem
         if (!TryComp(xeno, out TransformComponent? xform))
             return;
 
-        _receivers.Clear();
-        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.Range, _receivers);
+        if (_net.IsServer)
+            _audio.PlayPvs(xeno.Comp.Sound, xeno);
+
+        if (xeno.Comp.Directional)
+        {
+            var facing = _transform.GetWorldRotation(xform);
+            DoDirectionalStomp(xeno, xform, facing);
+        }
+        else
+            DoCircularStomp(xeno, xform);
+
+        if (_net.IsServer && xeno.Comp.SelfEffect is not null)
+            SpawnAttachedTo(xeno.Comp.SelfEffect, xeno.Owner.ToCoordinates());
+    }
+
+    private void OnXenoDirectionalStompAction(Entity<XenoStompComponent> xeno, ref XenoDirectionalStompActionEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!xeno.Comp.Directional)
+            return;
+
+        var attemptEv = new XenoStompAttemptEvent();
+        RaiseLocalEvent(xeno, ref attemptEv);
+
+        if (attemptEv.Cancelled)
+            return;
+
+        if (_mobState.IsDead(xeno))
+            return;
+
+        if (!_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, xeno.Comp.PlasmaCost))
+            return;
+
+        if (!TryComp(xeno, out TransformComponent? xform))
+            return;
+
+        args.Handled = true;
 
         if (_net.IsServer)
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
+
+        var origin = _transform.GetMapCoordinates(xeno);
+        var targetMap = _transform.ToMapCoordinates(args.Target);
+        var direction = (targetMap.Position - origin.Position).ToWorldAngle();
+
+        DoDirectionalStomp(xeno, xform, direction);
+
+        if (_net.IsServer && xeno.Comp.SelfEffect is not null)
+            SpawnAttachedTo(xeno.Comp.SelfEffect, xeno.Owner.ToCoordinates());
+    }
+
+    private void DoCircularStomp(Entity<XenoStompComponent> xeno, TransformComponent xform)
+    {
+        _receivers.Clear();
+        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.Range, _receivers);
 
         using var targetingSuppression = _hitLocation.SuppressBodyZoneTargeting(xeno.Owner);
         foreach (var receiver in _receivers)
@@ -132,8 +200,87 @@ public sealed partial class XenoStompSystem : EntitySystem
                     : xeno.Comp.ParalyzeTime, true);
             }
         }
+    }
 
-        if (_net.IsServer && xeno.Comp.SelfEffect is not null)
-            SpawnAttachedTo(xeno.Comp.SelfEffect, xeno.Owner.ToCoordinates());
+    private void DoDirectionalStomp(Entity<XenoStompComponent> xeno, TransformComponent xform, Angle direction)
+    {
+        var origin = _transform.GetMapCoordinates(xeno);
+        var halfAngle = new Angle(xeno.Comp.DirectionalAngle.Theta / 2);
+        var range = xeno.Comp.DirectionalRange;
+
+        if (_net.IsClient)
+            return;
+
+        // Spawn tile effects in the cone area.
+        if (xeno.Comp.DirectionalTileEffect is { } tileEffect &&
+            _transform.GetGrid(xeno.Owner) is { } gridId &&
+            TryComp<MapGridComponent>(gridId, out var grid))
+        {
+            var tileRange = (int) MathF.Ceiling(range);
+            var center = _map.CoordinatesToTile(gridId, grid, origin);
+
+            for (var x = -tileRange; x <= tileRange; x++)
+            {
+                for (var y = -tileRange; y <= tileRange; y++)
+                {
+                    var tilePos = center + new Vector2i(x, y);
+                    var worldPos = _map.GridTileToWorld(gridId, grid, tilePos).Position;
+                    var diff = worldPos - origin.Position;
+                    if (diff.Length() > range || diff.Length() < 0.1f)
+                        continue;
+
+                    var angleDiff = Angle.ShortestDistance(direction, diff.ToWorldAngle());
+                    if (Math.Abs(angleDiff.Theta) > halfAngle.Theta)
+                        continue;
+
+                    var tileCenter = _map.GridTileToLocal(gridId, grid, tilePos);
+                    SpawnAtPosition(tileEffect, tileCenter);
+                }
+            }
+        }
+
+        _receivers.Clear();
+        _entityLookup.GetEntitiesInRange(origin, range, _receivers);
+
+        using var targetingSuppression = _hitLocation.SuppressBodyZoneTargeting(xeno.Owner);
+        foreach (var ent in _receivers)
+        {
+            if (!_xeno.CanAbilityAttackTarget(xeno, ent))
+                continue;
+
+            // Cone check: is the entity within the arc?
+            var entMap = _transform.GetMapCoordinates(ent);
+            var toEnt = entMap.Position - origin.Position;
+            if (toEnt.Length() < 0.1f)
+                continue;
+
+            var angleDiff = Angle.ShortestDistance(direction, toEnt.ToWorldAngle());
+            if (Math.Abs(angleDiff.Theta) > halfAngle.Theta)
+                continue;
+
+            var damage = _damageable.TryChangeDamage(ent, _xeno.TryApplyXenoSlashDamageMultiplier(ent, xeno.Comp.Damage), origin: xeno, tool: xeno);
+            if (damage?.GetTotal() > FixedPoint2.Zero)
+            {
+                var filter = Filter.Pvs(ent, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);
+                _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { ent }, filter);
+            }
+
+            _stun.TryParalyze(ent, xeno.Comp.DebuffsHurtXenosMore
+                ? _xeno.TryApplyXenoDebuffMultiplier(ent, xeno.Comp.ParalyzeTime)
+                : xeno.Comp.ParalyzeTime, true);
+
+            if (xeno.Comp.Slows)
+                _slow.TrySuperSlowdown(ent, xeno.Comp.SlowTime, true);
+
+            if (xeno.Comp.KnockBackDistance > 0)
+            {
+                _rmcPulling.TryStopAllPullsFromAndOn(ent);
+                _obstacleSlamming.MakeImmune(ent);
+                _size.KnockBack(ent, origin, xeno.Comp.KnockBackDistance, xeno.Comp.KnockBackDistance, 10);
+            }
+
+            if (xeno.Comp.ScreenShakeStrength > 0)
+                _cameraShake.ShakeCamera(ent, 6, xeno.Comp.ScreenShakeStrength);
+        }
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Stomp/XenoDirectionalStompActionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stomp/XenoDirectionalStompActionEvent.cs
@@ -1,0 +1,5 @@
+using Content.Shared.Actions;
+
+namespace Content.Shared._RMC14.Xenonids.Stomp;
+
+public sealed partial class XenoDirectionalStompActionEvent : WorldTargetActionEvent;

--- a/Content.Shared/_RMC14/Xenonids/Stomp/XenoStompComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stomp/XenoStompComponent.cs
@@ -49,4 +49,40 @@ public sealed partial class XenoStompComponent : Component
     // TODO RMC14 bang.ogg
     [DataField, AutoNetworkedField]
     public SoundSpecifier Sound = new SoundPathSpecifier("/Audio/_RMC14/Xeno/alien_footstep_charge1.ogg");
+
+    /// <summary>
+    ///     If true, stomp is a cone aimed at the mouse instead of a circle.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Directional = false;
+
+    /// <summary>
+    ///     Range (radius) of the directional stomp cone.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float DirectionalRange = 4f;
+
+    /// <summary>
+    ///     Total arc width of the directional stomp cone.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Angle DirectionalAngle = Angle.FromDegrees(90);
+
+    /// <summary>
+    ///     Knockback distance for directional stomp.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float KnockBackDistance = 0f;
+
+    /// <summary>
+    ///     Screen shake strength for directional stomp.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int ScreenShakeStrength = 0;
+
+    /// <summary>
+    ///     Effect to spawn on each tile when directional stomp lands.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntProtoId? DirectionalTileEffect;
 }

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -719,6 +719,25 @@
     event: !type:XenoStompActionEvent
 
 - type: entity
+  id: ActionXenoDirectionalStomp
+  parent: ActionXenoBase
+  name: Stomp (30)
+  description: Slam the ground in a cone in front of you, dealing heavy damage and knocking back all enemies caught in the blast.
+  components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _RMC14/Actions/xeno_actions.rsi
+      state: stomp
+    useDelay: 18
+  - type: TargetAction
+    range: 15
+    checkCanAccess: false
+  - type: WorldTargetAction
+    event: !type:XenoDirectionalStompActionEvent
+  - type: ActionBlockIfResting
+
+- type: entity
   parent: CMGuidebookActionXenoBase
   id: RMCGuidebookActionXenoStomp
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -258,7 +258,7 @@
   id: ActionXenoDefensiveShield
   parent: ActionXenoBase
   name: Defensive Shield (50)
-  description: Gain a temporary shield that blocks the next 200 damage (and is immune to explosive damage) that lasts 7 seconds. Any damage that impacts the shield is reduced by 10 before processing. [color=green]Cooldown is partially refunded upon attacking an enemy.[/color]
+  description: Encase yourself in a protective shield that absorbs 100 damage for 7 seconds. Reduces incoming damage by 8 per hit. Reflects enemy projectiles while active. [color=red]Grants brief explosion immunity on activation.[/color]
   components:
   - type: Action
     itemIconStyle: NoItem
@@ -430,6 +430,12 @@
   - type: InstantAction
     event: !type:XenoSoakActionEvent
   - type: ActionBlockIfResting
+
+- type: entity
+  parent: ActionXenoSoak
+  id: ActionXenoCrusherSoak
+  name: Soak (20)
+  description: Brace yourself for incoming damage. If you absorb 240 damage within 6 seconds, heal 120 health and reset your tail stab cooldown. [color=red]If the threshold is not reached, the effect expires with no reward.[/color]
 
 - type: entity
   parent: ActionXenoBase

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
@@ -26,8 +26,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      700: Critical
-      800: Dead
+      800: Critical
+      900: Dead
   - type: Xeno
     role: CMXenoCrusher
     actionIds:
@@ -35,7 +35,7 @@
     - ActionXenoRegurgitate
     - ActionXenoWatch
     - ActionXenoTailStab
-    - ActionXenoStomp
+    - ActionXenoDirectionalStomp
     - ActionXenoDevolve
     tier: 3
     hudOffset: -0.15,0.1
@@ -48,9 +48,17 @@
     - CMXenoWarrior
   - type: XenoDevour
   - type: XenoStomp
+    directional: true
+    directionalRange: 4
+    directionalAngle: 90
+    paralyzeTime: 1
+    slowTime: 2.5
+    knockBackDistance: 2
+    screenShakeStrength: 4
+    directionalTileEffect: RMCEffectXenoTelegraphRed
     damage:
       types:
-        Blunt: 65
+        Blunt: 80
     selfEffect: CMEffectSelfStomp
   - type: XenoAnimateMovement
   - type: XenoPlasma
@@ -58,11 +66,15 @@
     maxPlasma: 400
     plasmaRegenOnWeeds: 4
   - type: CMArmor
-    xenoArmor: 30
+    xenoArmor: 25
+    frontalArmor: 20
+    sideArmor: 5
     explosionArmor: 100
   - type: XenoClaws
     clawType: VerySharp
   - type: MeleeWeapon
+    angle: 60
+    maxTargets: 2
     damage:
       groups:
         Brute: 40
@@ -94,7 +106,8 @@
   - type: XenoBrutalize
     damage:
       types:
-        Blunt: 16
+        Blunt: 20
+    armorPiercing: 10
   - type: RMCSize
     size: Immobile
   - type: RMCXenoDamageVisuals
@@ -124,14 +137,18 @@
     - ActionXenoWatch
     - ActionXenoTailStab
     - ActionXenoCharge
-    - ActionXenoStomp
+    - ActionXenoDirectionalStomp
+    - ActionXenoCrusherSoak
     - ActionXenoDefensiveShield
     - ActionXenoDevolve
+  - type: XenoSoak
+    damageGoal: 240
+    heal: 120
   - type: CrusherShield
   - type: XenoCharge
     damage:
       types:
-        Blunt: 60
+        Blunt: 90
         Structural: 750
   - type: XenoShield
   - type: XenoEvolution


### PR DESCRIPTION
## About the PR

Complete rework of the Crusher xenomorph to fulfill its role as the hive's tier 3 frontline battering ram. Reworks charge, stomp, and defensive shield. Adds directional armor, wide swing, and the Soak ability.

## Why / Balance

The crusher's fantasy is being the first xeno to smash through marine lines, create openings for the rest of the hive and shield others with their body. In practice, it fell short and the result was a tier 3 xeno that didn't feel like a tank or a breacher, but a front-line fighter that gets overshadowed by most others.

**Charge** now has a faster wind-up (0.6s), deals 90 Blunt, and flings the target with distance-scaled knockback (5-10 tiles based on how far the crusher charged). Flung marines bowl through other marines in the path, dealing 30 Blunt + 1.5s knockdown + 1.5s slow to each, only stopping at walls or max distance. Marines flung into walls take slam damage + 1.5s stun + 3s slow. A charge path preview overlay shows the trajectory.

**Stomp** is replaced with a targeted 90° cone aimed at the mouse. 4 tile range, 80 Blunt, 1s paralyze, 2.5s slow (1.5s effective after knockdown), 2 tile knockback, screen shake. Red tile effect on impact and a cone preview overlay while targeting.

**Defensive Shield** has been modified. Shield HP reduced from 200 to 100, damage reduction from 10 to 8, but now reflects enemy projectiles while active (40% front, 30% sides, 25% back).

HP increased to 800/900. Armor is now directional: 45 front, 30 sides, 25 back. This encourages aggressive face-forward positioning but punishes getting flanked or caught from behind. Wide swing restored (60° arc, 2 targets) and brutalize splash increased to 20 Blunt with 10 AP.

**Soak** (new ability) provides sustain for extended engagements. Absorb 240 damage within 6 seconds to heal 120 HP and reset tail stab cooldown. No reward if threshold not reached.

## Technical details

- Added nullable `MaxTargets` field to `MeleeWeaponComponent` for per-weapon override of the global CVar (only crusher uses it)
- New `ChargeFlungComponent`: handles mob-on-mob bowling collision via `ThrowDoHitEvent`, self-cleans on `StopThrowEvent`
- New `XenoDirectionalStompActionEvent` (`WorldTargetActionEvent`): separate from the existing instant `XenoStompActionEvent` so other xenos are unaffected
- Directional stomp uses radial cone check (angle filtering on `GetEntitiesInRange`) rather than `Box2Rotated`
- Shield reflect reuses the same `ProjectileReflectAttemptEvent` pattern as the Bulwark strain
- Soak overrides via nullable fields on `XenoSoakComponent`, null = use defaults (Steelcrest unaffected)
- All new fields default to no-op values; no existing entities affected
- Charger strain fully overrides its action list and keeps circular stomp

## Media
N/A 
## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- add: Crusher charge now bowls flung marines through other marines in the path, damaging and knocking down each one
- add: Crusher stomp is now a targeted 90° cone aimed at your mouse with a preview overlay
- add: Crusher defensive shield now reflects enemy projectiles (40% front, 30% sides, 25% back)
- add: Crusher gains Soak ability: absorb 240 damage in 6 seconds to heal 120 HP
- add: Crusher charge has a path preview overlay
- tweak: Crusher HP increased to 800/900
- tweak: Crusher armor is now directional: 45 front, 30 sides, 25 back
- tweak: Crusher wide swing restored: 60° arc, 2 max targets
- tweak: Crusher charge: faster wind-up, 90 damage, distance-scaled knockback (5-10 tiles)
- tweak: Crusher stomp: 80 damage, 1s paralyze, 2 tile knockback, screen shake
- tweak: Crusher brutalize splash: 20 Blunt with 10 armor piercing
- tweak: Crusher defensive shield: 100 HP (was 200), 8 damage reduction (was 10)
- code: Added per-weapon MaxTargets override to MeleeWeaponComponent
