### PR TITLE
Charger rework follow-up adjustments

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -19,6 +19,7 @@ using Content.Shared._RMC14.Xenonids.Stomp;
 using Content.Shared.Actions.Components;
 using Content.Shared.Maps;
 using Content.Shared.Physics;
+using Robust.Shared.Physics;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
@@ -198,7 +199,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
             case XenoDirectionalStompActionEvent:
                 if (!_stompQ.TryComp(player.Value, out var stomp) || !stomp.Directional)
                     return;
-                DrawDirectionalStomp(args, originMap, mousePos, stomp);
+                DrawDirectionalStomp(args, player.Value, originMap, mousePos, stomp);
                 break;
         }
     }
@@ -332,6 +333,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
 
     private void DrawDirectionalStomp(
         in OverlayDrawArgs args,
+        EntityUid player,
         MapCoordinates originMap,
         MapCoordinates mousePos,
         XenoStompComponent stomp)
@@ -360,6 +362,18 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
 
                 var angleDiff = Angle.ShortestDistance(direction, diff.ToWorldAngle());
                 if (Math.Abs(angleDiff.Theta) > halfAngle.Theta)
+                    continue;
+
+                // Raycast for barricade blocking.
+                var ray = new CollisionRay(originMap.Position, diff.Normalized(), (int) CollisionGroup.BarricadeImpassable);
+                var blocked = false;
+                foreach (var _ in _physics.IntersectRay(originMap.MapId, ray, diff.Length(), player, returnOnFirstHit: true))
+                {
+                    blocked = true;
+                    break;
+                }
+
+                if (blocked)
                     continue;
 
                 tiles.Add(tilePos);

--- a/Content.Shared/_RMC14/Xenonids/Stomp/SharedXenoStompSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stomp/SharedXenoStompSystem.cs
@@ -19,6 +19,9 @@ using Content.Shared.Mobs.Components;
 using Robust.Shared.Map.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Physics;
+using Robust.Shared.Map;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Robust.Shared.Audio.Systems;
@@ -50,6 +53,7 @@ public sealed partial class XenoStompSystem : EntitySystem
     [Dependency] private RMCPullingSystem _rmcPulling = default!;
     [Dependency] private RMCObstacleSlammingSystem _obstacleSlamming = default!;
     [Dependency] private RMCCameraShakeSystem _cameraShake = default!;
+    [Dependency] private SharedPhysicsSystem _physics = default!;
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private TurfSystem _turf = default!;
 
@@ -233,6 +237,10 @@ public sealed partial class XenoStompSystem : EntitySystem
                     if (Math.Abs(angleDiff.Theta) > halfAngle.Theta)
                         continue;
 
+                    // Raycast to check for barricades blocking the tile.
+                    if (IsBlockedByBarricade(origin, new MapCoordinates(worldPos, origin.MapId), xeno.Owner))
+                        continue;
+
                     var tileCenter = _map.GridTileToLocal(gridId, grid, tilePos);
                     SpawnAtPosition(tileEffect, tileCenter);
                 }
@@ -258,7 +266,23 @@ public sealed partial class XenoStompSystem : EntitySystem
             if (Math.Abs(angleDiff.Theta) > halfAngle.Theta)
                 continue;
 
-            var damage = _damageable.TryChangeDamage(ent, _xeno.TryApplyXenoSlashDamageMultiplier(ent, xeno.Comp.Damage), origin: xeno, tool: xeno);
+            // Barricade line-of-sight check.
+            if (IsBlockedByBarricade(origin, entMap, xeno.Owner))
+                continue;
+
+            var stompDamage = xeno.Comp.Damage;
+            if (xeno.Comp.DirectionalMinDamage is { } minDmg)
+            {
+                var distRatio = Math.Clamp(toEnt.Length() / range, 0f, 1f);
+                stompDamage = new DamageSpecifier();
+                foreach (var (type, amount) in xeno.Comp.Damage.DamageDict)
+                {
+                    var minAmount = minDmg.DamageDict.GetValueOrDefault(type);
+                    stompDamage.DamageDict[type] = amount + (minAmount - amount) * distRatio;
+                }
+            }
+
+            var damage = _damageable.TryChangeDamage(ent, _xeno.TryApplyXenoSlashDamageMultiplier(ent, stompDamage), origin: xeno, tool: xeno);
             if (damage?.GetTotal() > FixedPoint2.Zero)
             {
                 var filter = Filter.Pvs(ent, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);
@@ -282,5 +306,24 @@ public sealed partial class XenoStompSystem : EntitySystem
             if (xeno.Comp.ScreenShakeStrength > 0)
                 _cameraShake.ShakeCamera(ent, 6, xeno.Comp.ScreenShakeStrength);
         }
+    }
+
+    private bool IsBlockedByBarricade(MapCoordinates origin, MapCoordinates target, EntityUid ignore)
+    {
+        if (origin.MapId != target.MapId)
+            return true;
+
+        var diff = target.Position - origin.Position;
+        var distance = diff.Length();
+        if (distance < 0.1f)
+            return false;
+
+        var ray = new CollisionRay(origin.Position, diff.Normalized(), (int) CollisionGroup.BarricadeImpassable);
+        foreach (var _ in _physics.IntersectRay(origin.MapId, ray, distance, ignore, returnOnFirstHit: true))
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Stomp/XenoStompComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stomp/XenoStompComponent.cs
@@ -85,4 +85,11 @@ public sealed partial class XenoStompComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public EntProtoId? DirectionalTileEffect;
+
+    /// <summary>
+    ///     If set, directional stomp damage falls off with distance.
+    ///     Full Damage at close range, this value at max range.
+    /// </summary>
+    [DataField]
+    public DamageSpecifier? DirectionalMinDamage;
 }

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
@@ -59,6 +59,9 @@
     damage:
       types:
         Blunt: 80
+    directionalMinDamage:
+      types:
+        Blunt: 65
     selfEffect: CMEffectSelfStomp
   - type: XenoAnimateMovement
   - type: XenoPlasma
@@ -67,7 +70,7 @@
     plasmaRegenOnWeeds: 4
   - type: CMArmor
     xenoArmor: 25
-    frontalArmor: 20
+    frontalArmor: 10
     sideArmor: 5
     explosionArmor: 100
   - type: XenoClaws


### PR DESCRIPTION
## About the PR

Follow-up to crusher rework. Stomp damage falloff, barricade blocking, armor adjustment.

## Why / Balance

- Stomp damage now falls off with distance: 80 Blunt at close range, 65 at max range
- Barricades block the stomp cone (tiles, effects, and entities behind barricades are not hit)
- Armor adjusted from 45/30/25 to 35/30/25 (front/sides/back)

## Technical details

- Added `DirectionalMinDamage` field to `XenoStompComponent` for distance-based damage lerp
- Added barricade raycast (`CollisionGroup.BarricadeImpassable`) to both the stomp system and the client preview overlay
- Changed `frontalArmor` from 20 to 10 on crusher prototype

## Media

N/A

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Crusher stomp damage now falls off with distance (80 close, 65 at max range)
- tweak: Crusher stomp cone is now blocked by barricades
- tweak: Crusher frontal armor reduced from 45 to 35