### PR TITLE
Burrower buff

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
@@ -9,7 +9,7 @@
   - RMCXenoVentCrawler
   id: CMXenoBurrower
   name: Burrower
-  description: A beefy alien with sharp claws.
+  description: A hefty alien with sharp claws.
   components:
   - type: CanBuildThickFromConstructNode
   - type: GuideHelp
@@ -55,6 +55,8 @@
   - type: XenoDevolve
     devolvesTo:
     - CMXenoDrone
+  - type: XenoPheromones
+    pheromonesMultiplier: 2
   - type: XenoPlasma
     plasma: 600
     maxPlasma: 600


### PR DESCRIPTION
## About the PR
Burrower buffed, gave it base drone pheros.

## Why / Balance
Burrower, as is, weak in combat, weak at captures (3-5 shoves, traps are one shot, grenades exist), slow to build their lair (2 filled traps / 3 empty traps per FULL PLASMA RESERVE) and has slow movement speed. Plasma trees, which were originally designed for helping in this case, are hogged by queens at the hive core for remote heals which cost a ton of plasma. Do i even need to mention the odds of getting a leader during tax when drones and hivelords exist?
Hopefully, drone pheros will elevate the burrower suffering, probably can be toned down to lesser pheros if it turns out to be too OP.

## Technical details
One yml line.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added fun to burrower!
- remove: Removed suffering!