### PR TITLE
More Job Normalization & AddComponentSpecial Inheritance (bool)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
 
   required-checks:
     name: Required Checks
-    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    if: (failure() || success()) && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     needs:
       - source-guards
       - build

--- a/Content.Server/_RMC14/Humanoid/RMCHumanoidSystem.cs
+++ b/Content.Server/_RMC14/Humanoid/RMCHumanoidSystem.cs
@@ -1,6 +1,8 @@
+using System.Linq;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Jobs;
 using Content.Shared.Clothing.Components;
+using Content.Shared.Roles;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server._RMC14.Humanoid;
@@ -36,10 +38,33 @@ public sealed partial class RMCHumanoidSystem : EntitySystem
             AddComp(ent, loadout);
         }
 
+        var addComponents = job.InheritAddComponentSpecials     // prototype Boolean
+            ? GetAllAddComponentSpecials(job)                   // merged inheritance chain
+            : [.. job.Special.OfType<AddComponentSpecial>()];   // original behavior
+
+        foreach (var add in addComponents)
+            EntityManager.AddComponents(ent, add.Components, add.RemoveExisting);
+    }
+
+    private List<AddComponentSpecial> GetAllAddComponentSpecials(JobPrototype job)
+    {
+        var results = new List<AddComponentSpecial>();
+
+        if (job.Parents is { Length: > 0 })
+        {
+            foreach (var parentId in job.Parents)
+            {
+                if (_prototype.TryIndex<JobPrototype>(parentId, out var parentJob))
+                    results.AddRange(GetAllAddComponentSpecials(parentJob));
+            }
+        }
+
         foreach (var special in job.Special)
         {
-            if (special is AddComponentSpecial add)
-                EntityManager.AddComponents(ent, add.Components, add.RemoveExisting);
+            if (special is AddComponentSpecial addComp)
+                results.Add(addComp);
         }
+
+        return results;
     }
 }

--- a/Content.Shared/AU14/Util/PlatoonJobClass.cs
+++ b/Content.Shared/AU14/Util/PlatoonJobClass.cs
@@ -2,18 +2,17 @@ namespace Content.Shared.AU14.util
 {
     public enum PlatoonJobClass
     {
-        SquadAutomaticRifleman,
-        PlatoonCorpsman,
-        DCC,
+        SquadRifleman,
         PlatCo,
-        RadioTelephoneOperator,
+        PlatOp,
         SectionSergeant,
         SquadSergeant,
-        PlatOp,
-        SquadRifleman,
+        RadioTelephoneOperator,
+        SquadCombatTech,
+        SquadAutomaticRifleman,
+        PlatoonCorpsman,
         DSPilot,
-        SupportSynth,
-        CombatTech
+        DCC,
+        SupportSynth
     }
 }
-

--- a/Content.Shared/AU14/Util/PlatoonPrototype.cs
+++ b/Content.Shared/AU14/Util/PlatoonPrototype.cs
@@ -9,65 +9,61 @@ using Content.Shared.Roles;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.AU14.util;
-    [Prototype]
-    public sealed partial class PlatoonPrototype : IPrototype
-    {
-        [IdDataField]
-        public string ID { get; private set; } = default!;
 
-        [DataField("factions", required: false)]
-        public List<string> Factions { get; private set; } = new();
+[Prototype]
+public sealed partial class PlatoonPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = default!;
 
-        /// <summary>
-        /// The primary NPC faction assigned to members of this platoon when they spawn.
-        /// Overrides the generic GOVFOR/OPFOR faction for more specific platoon identity.
-        /// </summary>
-        [DataField("npcFaction")]
-        public ProtoId<NpcFactionPrototype>? NpcFaction { get; private set; }
+    [DataField("factions", required: false)]
+    public List<string> Factions { get; private set; } = new();
 
-        /// <summary>
-        /// The allegiance associated with this platoon.
-        /// Characters with a matching allegiance will preferentially spawn here.
-        /// </summary>
-        [DataField("Allegiance")]
-        public ProtoId<AllegiancePrototype>? Allegiance { get; private set; }
+    /// <summary>
+    /// The primary NPC faction assigned to members of this platoon when they spawn.
+    /// Overrides the generic GOVFOR/OPFOR faction for more specific platoon identity.
+    /// </summary>
+    [DataField("npcFaction")]
+    public ProtoId<NpcFactionPrototype>? NpcFaction { get; private set; }
 
-        [DataField("language", required: false)]
-        public string Language { get; private set; } = string.Empty;
-        [DataField("name", required: true)]
-        public string Name { get; private set; } = string.Empty;
+    /// <summary>
+    /// The allegiance associated with this platoon.
+    /// Characters with a matching allegiance will preferentially spawn here.
+    /// </summary>
+    [DataField("Allegiance")]
+    public ProtoId<AllegiancePrototype>? Allegiance { get; private set; }
 
-        [DataField("lorePrimer")]
-        public ProtoId<LorePrimerPrototype>? LorePrimer { get; private set; }
+    [DataField("language", required: false)]
+    public string Language { get; private set; } = string.Empty;
+    [DataField("name", required: true)]
+    public string Name { get; private set; } = string.Empty;
 
+    [DataField("lorePrimer")]
+    public ProtoId<LorePrimerPrototype>? LorePrimer { get; private set; }
 
-        [DataField("reqlist", required: false)]
-        public string Reqlist { get; private set; } = string.Empty;
+    [DataField("reqlist", required: false)]
+    public string Reqlist { get; private set; } = string.Empty;
 
-        [DataField("VendorToMarker")]
-        public Dictionary<PlatoonMarkerClass, EntProtoId> VendorMarkersByClass { get; private set; } = new();
+    [DataField("VendorToMarker")]
+    public Dictionary<PlatoonMarkerClass, EntProtoId> VendorMarkersByClass { get; private set; } = new();
 
+    [DataField("possibleships")]
+    public List<string> PossibleShips { get; private set; } = new();
 
-        [DataField("possibleships")]
-        public List<string> PossibleShips { get; private set; } = new();
+    [DataField("jobClassOverride")]
+    public Dictionary<PlatoonJobClass, string> JobClassOverride { get; private set; } = new();
+    [DataField("PlatoonFlag")]
+    public string PlatoonFlag { get; private set; } = string.Empty;
+    //used for capture objectives and deco, spritestate
+    [DataField("jobSlotOverride")]
+    public Dictionary<PlatoonJobClass, int> JobSlotOverride { get; private set; } = new();
 
-        [DataField("jobClassOverride")]
-        public Dictionary<PlatoonJobClass, string> JobClassOverride { get; private set; } = new();
-            [DataField("PlatoonFlag")]
-        public string PlatoonFlag { get; private set; } = string.Empty;
-        //used for capture objectives and deco, spritestate
-        [DataField("jobSlotOverride")]
-        public Dictionary<PlatoonJobClass, int> JobSlotOverride { get; private set; } = new();
+    [DataField("CompatibleDropships")]
+    public List<ResPath> CompatibleDropships { get; private set; } = new();
 
-        [DataField("CompatibleDropships")]
-        public List<ResPath> CompatibleDropships { get; private set; } = new();
+    [DataField("compatibleFighters")]
+    public List<ResPath> CompatibleFighters { get; private set; } = new();
 
-        [DataField("compatibleFighters")]
-        public List<ResPath> CompatibleFighters { get; private set; } = new();
-
-
-        [DataField("techTree", required: false)]
-        public string TechTree { get; private set; } = string.Empty;
-
-
-    }
+    [DataField("techTree", required: false)]
+    public string TechTree { get; private set; } = string.Empty;
+}

--- a/Content.Shared/_RMC14/Marines/Roles/JobPrototype.cs
+++ b/Content.Shared/_RMC14/Marines/Roles/JobPrototype.cs
@@ -95,4 +95,11 @@ public sealed partial class JobPrototype : IInheritingPrototype, ICMSpecific
     /// </summary>
     [DataField]
     public bool UsePlayerProfile = true;
+
+    /// <summary>
+    /// If we would like to grab the AddComponentSpecials from the parent prototypes.
+    /// Used for military job/factions to reduce bloat.
+    /// </summary>
+    [DataField]
+    public bool InheritAddComponentSpecials = false;
 }

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/dropshipcrewchiefBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/dropshipcrewchiefBase.yml
@@ -9,7 +9,7 @@
   startingGear: AU14GearGOVFORDCC
   dummyStartingGear: AU14GearGOVFORDCCDummy
   playTimeTracker: AU14JobGOVFORDCC
-  setPreference: false
+  requireAdminNotify: true
   canBeAntag: false
   accessGroups:
   - AU14GovforPilot

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/militaryjobBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/militaryjobBase.yml
@@ -5,6 +5,7 @@
   supervisors: au14-job-supervisors-govfor
   hidden: true          # abstract hides by default, but for children/factions to remain hidden
   setPreference: false  # all faction variants are hidden in the loadout menu
+  inheritAddComponentSpecials: true
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/militaryjobBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/militaryjobBase.yml
@@ -3,7 +3,8 @@
   parent: CMJobBase
   id: AU14JobMilitaryBase
   supervisors: au14-job-supervisors-govfor
-  setPreference: false
+  hidden: true          # abstract hides by default, but for children/factions to remain hidden
+  setPreference: false  # all faction variants are hidden in the loadout menu
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/radiotelephoneoperatorBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/radiotelephoneoperatorBase.yml
@@ -4,7 +4,7 @@
   id: AU14JobRadioTelephoneOperatorBaseAbstract
   name: au14-job-name-radiotelephoneoperator
   description: au14-job-description-radiotelephoneoperator
-  icon: "AU14JobIconSarge"
+  icon: "AU14JobIconRTO"
   spawnMenuRoleName: Fireteam Leader (GOVFOR)
   startingGear: AU14GearGOVFORRadioTelephoneOperator
   dummyStartingGear: AU14GearGOVFORRadioTelephoneOperatorDummy

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/sectionsergeantBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/sectionsergeantBase.yml
@@ -15,8 +15,6 @@
   overwatchShowName: true
   accessGroups:
   - AU14GovforCommand
-  setPreference: false  # don't show in loadout menu
-  hidden: true          # plt sgt is disabled
 
 - type: job
   abstract: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/auxiliarysupportsynth.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/auxiliarysupportsynth.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobAuxSupportSynthBase
   id: AU14JobGOVFORAuxSupportSynth
+  hidden: false
   setPreference: true
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/militaryauxtech.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/militaryauxtech.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobAuxTechBase
   id: AU14JobGOVFORAuxTech
+  hidden: false
   setPreference: true
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/militarydoctor.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/militarydoctor.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobMilitaryDoctorBase
   id: AU14JobGOVFORMilitaryDoctor
+  hidden: false
   setPreference: true
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/militarypoliceofficer.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/militarypoliceofficer.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobMilitaryPoliceBase
   id: AU14JobGOVFORMilitaryPoliceMan
+  hidden: false
   setPreference: true
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonadvisor.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonadvisor.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobadvisorBase
   id: AU14JobGOVFORadvisor
+  hidden: false
   setPreference: true
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platooncommander.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platooncommander.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobPlatCoBase
   id: AU14JobGOVFORPlatCo
+  hidden: false
   setPreference: true
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platooncorpsman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platooncorpsman.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobPlatoonCorpsmanBase
   id: AU14JobGOVFORPlatoonCorpsman
+  hidden: false
   setPreference: true
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoondropshipcrewchief.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoondropshipcrewchief.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobDCCBase
   id: AU14JobGOVFORDCC
+  hidden: false
   setPreference: true
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonoperationsofficer.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonoperationsofficer.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobPlatOpBase
   id: AU14JobGOVFORPlatOp
+  hidden: false
   setPreference: true
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonpilotofficer.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonpilotofficer.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobDSPilotBase
   id: AU14JobGOVFORDSPilot
+  hidden: false
   setPreference: true
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonradiotelephoneoperator.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonradiotelephoneoperator.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobRadioTelephoneOperatorBase
   id: AU14JobGOVFORRadioTelephoneOperator
+  hidden: false
   setPreference: true
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonsectionsergeant.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonsectionsergeant.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobSectionSergeantBase
   id: AU14JobGOVFORSectionSergeant
-  # setPreference: true
+  # hidden: false # plt. sgt. is disabled
+  # setPreference: true # don't show in loadout menu
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonsquadautomaticrifleman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonsquadautomaticrifleman.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobSquadAutomaticRiflemanBase
   id: AU14JobGOVFORSquadAutomaticRifleman
+  hidden: false
   setPreference: true
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonsquadcombattech.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonsquadcombattech.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobSquadCombatTechBase
   id: AU14JobGOVFORSquadCombatTech
+  hidden: false
   setPreference: true
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonsquadrifleman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonsquadrifleman.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobSquadRiflemanBase
   id: AU14JobGOVFORSquadRifleman
+  hidden: false
   setPreference: true
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonsquadsergeant.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonsquadsergeant.yml
@@ -1,5 +1,6 @@
 - type: job
   parent: AU14JobSquadSergeantBase # parent does the heavy lifting
   id: AU14JobGOVFORSquadSergeant # Default Squad Leader
+  hidden: false
   setPreference: true
   basePlaytimeTracker: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCauxiliarysupportsynth.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCauxiliarysupportsynth.yml
@@ -2,9 +2,8 @@
   parent: AU14JobAuxSupportSynthBase
   id: AU14JobGOVFORAuxSupportSynthRMC
   name: au14-job-name-govforauxsupportsynthRMC
-  description: au14-job-description-govforauxsupportsynth
-  setPreference: true
-  canBeAntag: false
+  spawnMenuRoleName: Support Synth (TWE RMC)
+  dummyStartingGear: AU14GearGOVFORAuxSupportSynthDummyRMC
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 7200 # 2 hours
@@ -21,25 +20,9 @@
       role: AU14JobGOVFORAuxSupportSynth
       time: 180000 # 50 hours
     RMC_WarrantOfficer2: []
-  startingGear: AU14GearGOVFORAuxSupportSynth
-  dummyStartingGear: AU14GearGOVFORAuxSupportSynthDummyRMC
-  icon: "AU14JobIconGovSynth"
-  requireAdminNotify: false
-  spawnMenuRoleName: Support Synth (TWE RMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govforplatco
-  accessGroups:
-  - AU14GovforCommand
-  - CMCargoTech
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
-    - type: NpcFactionMember
-      factions:
-      - GOVFOR
-    - type: Marine
-      Faction: govfor
     - type: Skills
       skills:
         RMCSkillCqc: 5
@@ -61,26 +44,6 @@
         RMCSkillIntel: 2
         RMCSkillDomestics: 2
         RMCSkillNavigations: 1
-    - type: JobPrefix
-      prefix: au14-job-prefix-govforauxsupportsynth
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-    - type: MeleeWeapon
-      soundHit:
-        path: /Audio/_RMC14/Weapons/synthpunch1.ogg
-        params:
-          variation: 0.15
-          volume: -1
-      angle: 30
-      animation: WeaponArcFist
-      attackRate: 1
-      damage:
-        types:
-          Blunt: 35
-    - type: Synth
-  hidden: true
 
 - type: startingGear
   id: AU14GearGOVFORAuxSupportSynthDummyRMC

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoonadvisor.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoonadvisor.yml
@@ -1,64 +1,10 @@
 - type: job
   parent: AU14JobadvisorBase
   id: AU14JobGOVFORadvisorRMC
-  name: au14-job-name-govforadvisor
-  description: au14-job-description-govforadvisor
-  setPreference: true
-  canBeAntag: false
-  requirements:
-  - !type:OverallPlaytimeRequirement
-    time: 3600 # Set to 72000 once we are fully launched AU14 todo
-  - !type:AgeRequirement
-    requiredAge: 21
-  - !type:TraitsRequirement
-    inverted: true
-    traits:
-    - Epilepsy
+  spawnMenuRoleName: Platoon Advisor (TWE RMC)
   ranks:
     RMC_WarrantOfficer1:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORadvisor
       time: 360000 # 100 hours
     RMC_WarrantOfficer2: []
-  startingGear: AU14GearGOVFORadvisor
-  dummyStartingGear: AU14GearGOVFORadvisorDummy
-  icon: "AU14JobIconGovAdvisor"
-  requireAdminNotify: true
-  spawnMenuRoleName: Platoon Advisor (TWE RMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  whitelisted: true
-  accessGroups:
-  - AU14GovforCommand
-  roleWeight: 0.25
-  special:
-  - !type:AddComponentSpecial
-    components:
-    - type: NpcFactionMember
-      factions:
-      - GOVFOR
-    - type: Marine
-      Faction: govfor
-    - type: Skills
-      preset: AU14SkillPresetPlatoonAdvisor
-    - type: JobPrefix
-      prefix: au14-job-prefix-govforadvisor
-    - type: SeeNewPlayers
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-    - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatooncorpsman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatooncorpsman.yml
@@ -2,41 +2,16 @@
   parent: AU14JobPlatoonCorpsmanBase
   id: AU14JobGOVFORPlatoonCorpsmanRMC
   name: au14-job-name-govforplatooncorpsmanRMC
-  description: au14-job-description-govforplatooncorpsman
-  setPreference: true
-  requirements:
-  - !type:TraitsRequirement
-    inverted: true
-    traits:
-    - Epilepsy
-    - NonResuscitable
+  spawnMenuRoleName: Hospital Corpsman (TWE RMC)
   ranks:
     RMC_Corporal:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORPlatoonCorpsman
       time: 72000 # 20 hours
     RMC_LanceCorporal: []
-  startingGear: AU14GearGOVFORPlatoonCorpsman
-  dummyStartingGear: AU14GearGOVFORCorpsmanDummy
-  icon: "AU14JobIconCorpsman"
-  requireAdminNotify: false
-  spawnMenuRoleName: Hospital Corpsman (TWE RMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforCorpsman
-  - AU14GovforSquad
-  overwatchSortPriority: -2
-  overwatchRoleName: au14-job-name-govforplatooncorpsman-plural
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
-    - type: NpcFactionMember
-      factions:
-      - GOVFOR
-    - type: Marine
-      Faction: govfor
     - type: Skills
       skills:
         RMCSkillFirearms: 2
@@ -47,10 +22,3 @@
         RMCSkillConstruction: 2
         RMCSkillEngineer: 3
         RMCSkillPolice: 1
-    - type: JobPrefix
-      prefix: au14-job-prefix-govforplatooncorpsman
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoondropshipcrewchief.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoondropshipcrewchief.yml
@@ -2,15 +2,7 @@
   parent: AU14JobDCCBase
   id: AU14JobGOVFORDCCRMC
   name: au14-job-name-govfordccRMC
-  description: au14-job-description-govfordcc
-  setPreference: true
-  canBeAntag: false
-  requirements:
-  - !type:TraitsRequirement
-    inverted: true
-    traits:
-    - Epilepsy
-    - NonResuscitable
+  spawnMenuRoleName: Dropship Crew Chief (TWE RMC)
   ranks:
     RMC_WarrantOfficer1:
     - !type:RoleTimeRequirement
@@ -25,26 +17,9 @@
       role: AU14JobGOVFORDCC
       time: 43200 # 12 hours
     RMC_Sergeant: []
-  startingGear: AU14GearGOVFORDCC
-  dummyStartingGear: AU14GearGOVFORDCCDummy
-  icon: "AU14JobIconDCC"
-  requireAdminNotify: true
-  spawnMenuRoleName: Dropship Crew Chief (TWE RMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforPilot
-  - AU14GovforCorpsman
-  - AU14GovforSquad
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
-    - type: NpcFactionMember
-      factions:
-      - GOVFOR
-    - type: Marine
-      Faction: govfor
     - type: Skills
       skills:
         RMCSkillFirearms: 2
@@ -58,10 +33,3 @@
         RMCSkillPowerLoader: 2
         RMCSkillSurgery: 1
         RMCSkillPolice: 1
-    - type: JobPrefix
-      prefix: au14-job-prefix-govfordcc
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoonpilotofficer.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoonpilotofficer.yml
@@ -2,19 +2,7 @@
   parent: AU14JobDSPilotBase
   id: AU14JobGOVFORDSPilotRMC
   name: RMC Pilot Officer
-  description: au14-job-description-govfordspilot
-  setPreference: true
-  canBeAntag: false
-  requirements:
-  - !type:AgeRequirement
-    requiredAge: 25
-  - !type:TraitsRequirement
-    inverted: true
-    traits:
-    - SocialAnxietyHeavy
-    - FrontalLisp
-    - NonResuscitable
-    - Epilepsy
+  spawnMenuRoleName: Pilot Officer (TWE RMC)
   ranks:
     RMC_Lieutenant:
     - !type:RoleTimeRequirement
@@ -29,26 +17,9 @@
       role: AU14JobGOVFORDSPilot
       time: 108000 # 30 hours
     RMC_WarrantOfficer2: []
-  startingGear: AU14GearGOVFORDSPilot
-  dummyStartingGear: AU14GearGOVFORDSPilotDummy
-  icon: "AU14JobIconPilotOfficer"
-  requireAdminNotify: true
-  spawnMenuRoleName: Pilot Officer (TWE RMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforPilot
-  - AU14GovforCorpsman
-  - AU14GovforSquad
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
-    - type: NpcFactionMember
-      factions:
-      - GOVFOR
-    - type: Marine
-      Faction: govfor
     - type: Skills
       skills:
         RMCSkillFirearms: 2
@@ -64,21 +35,3 @@
         RMCSkillPolice: 1
     - type: JobPrefix
       prefix: au14-job-prefix-govfordspilotRMC
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-    - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoonradiotelephoneoperator.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoonradiotelephoneoperator.yml
@@ -2,14 +2,8 @@
   parent: AU14JobRadioTelephoneOperatorBase
   id: AU14JobGOVFORRadioTelephoneOperatorRMC
   name: au14-job-name-radiotelephoneoperatorRMC
-  description: au14-job-description-radiotelephoneoperator
-  setPreference: true
-  requirements:
-  - !type:TraitsRequirement
-    inverted: true
-    traits:
-    - Epilepsy
-    - NonResuscitable
+  spawnMenuRoleName: Fireteam Leader (TWE RMC)
+  overwatchRoleName: au14-job-name-radiotelephoneoperator-alt
   ranks:
     RMC_Corporal:
     - !type:RoleTimeRequirement
@@ -20,26 +14,9 @@
       role: AU14JobGOVFORSquadAutomaticRifleman
       time: 108000 # 30 hours
     RMC_Marine: []
-  startingGear: AU14GearGOVFORRadioTelephoneOperator
-  dummyStartingGear: AU14GearGOVFORRadioTelephoneOperatorDummy
-  icon: "AU14JobIconRTO"
-  requireAdminNotify: false
-  spawnMenuRoleName: Fireteam Leader (TWE RMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforFTL
-  overwatchSortPriority: -5
-  overwatchRoleName: au14-job-name-radiotelephoneoperator-alt
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
-    - type: NpcFactionMember
-      factions:
-      - GOVFOR
-    - type: Marine
-      Faction: govfor
     - type: Skills
       skills:
         RMCSkillConstruction: 2
@@ -48,23 +25,3 @@
         RMCSkillFireman: 1
         RMCSkillJtac: 3
         RMCSkillPolice: 1
-    - type: JobPrefix
-      prefix: au14-job-prefix-radiotelephoneoperator
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-    - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoonsectionsergeant.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoonsectionsergeant.yml
@@ -2,45 +2,16 @@
   parent: AU14JobSectionSergeantBase
   id: AU14JobGOVFORSectionSergeantRMC
   name: au14-job-name-govforSSGRMC
-  description: au14-job-description-govforSSG
-  setPreference: true
-  requirements:
-  - !type:AgeRequirement
-    requiredAge: 25
-  - !type:TraitsRequirement
-    inverted: true
-    traits:
-    - SocialAnxietyHeavy
-    - FrontalLisp
-    - NonResuscitable
-    - Epilepsy
+  spawnMenuRoleName: Platoon Sergeant (TWE RMC)
   ranks:
     RMC_ColourSergeant:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORSectionSergeant
       time: 216000 # 60 hours
     RMC_Sergeant: []
-  startingGear: AU14GearGOVFORSectionSergeant
-  dummyStartingGear: AU14GearGOVFORPlatoonSergeantDummy
-  icon: "AU14JobIconPlatoonSarge"
-  requireAdminNotify: true
-  spawnMenuRoleName: Platoon Sergeant (TWE RMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforCommand
-  overwatchSortPriority: -6
-  overwatchShowName: true
-  overwatchRoleName: Platoon Sergeant
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
-    - type: NpcFactionMember
-      factions:
-      - GOVFOR
-    - type: Marine
-      Faction: govfor
     - type: Skills
       skills:
         RMCSkillConstruction: 2
@@ -57,21 +28,3 @@
         RMCSkillPolice: 1
     - type: JobPrefix
       prefix: au14-job-prefix-govforSSGRMC
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-    - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoonsquadautomaticrifleman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoonsquadautomaticrifleman.yml
@@ -2,14 +2,7 @@
   parent: AU14JobSquadAutomaticRiflemanBase
   id: AU14JobGOVFORSquadAutomaticRiflemanRMC
   name: au14-job-name-govforsquadautomaticriflemanRMC
-  description: au14-job-description-govforsquadautomaticrifleman
-  setPreference: true
-  requirements:
-  - !type:TraitsRequirement
-    inverted: true
-    traits:
-    - Epilepsy
-    - NonResuscitable
+  spawnMenuRoleName: Automatic Rifleman (TWE RMC)
   ranks:
     RMC_Corporal:
     - !type:RoleTimeRequirement
@@ -20,34 +13,3 @@
       role: AU14JobGOVFORSquadAutomaticRifleman
       time: 54000 # 15 hours
     RMC_Marine: []
-  startingGear: AU14GearGOVFORSquadAutomaticRifleman
-  dummyStartingGear: AU14GearGOVFORAutoRiflemanDummy
-  icon: "AU14JobIconAFN"
-  requireAdminNotify: false
-  spawnMenuRoleName: Automatic Rifleman (TWE RMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforGunner
-  overwatchSortPriority: -3
-  overwatchShowName: true
-  overwatchRoleName: au14-job-name-govforsquadautomaticrifleman-plural
-  roleWeight: 0.25
-  special:
-  - !type:AddComponentSpecial
-    components:
-    - type: NpcFactionMember
-      factions:
-      - GOVFOR
-    - type: Marine
-      Faction: govfor
-    - type: Skills
-      preset: AU14SkillPresetPlatoonAutomaticRifleman
-    - type: SquadArmorWearer
-    - type: JobPrefix
-      prefix: au14-job-prefix-govforsquadautomaticrifleman
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: smartgunner
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoonsquadcombattech.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoonsquadcombattech.yml
@@ -2,14 +2,7 @@
   parent: AU14JobSquadCombatTechBase
   id: AU14JobGOVFORSquadCombatTechRMC
   name: au14-job-name-govforsquadcombattechRMC
-  description: au14-job-description-govforsquadcombattech
-  setPreference: true
-  requirements:
-  - !type:TraitsRequirement
-    inverted: true
-    traits:
-    - Epilepsy
-    - NonResuscitable
+  spawnMenuRoleName: Combat Tech (TWE RMC)
   ranks:
     RMC_Corporal:
     - !type:RoleTimeRequirement
@@ -20,34 +13,8 @@
       role: AU14JobGOVFORSquadAutomaticRifleman
       time: 108000 # 30 hours
     RMC_Marine: []
-  startingGear: AU14GearGOVFORSquadCombatTech
-  dummyStartingGear: AU14GearGOVFORCTDummy
-  icon: "AU14JobIconGovCT"
-  requireAdminNotify: false
-  spawnMenuRoleName: Combat Tech (TWE RMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforEngineer
-  hasIcon: true
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
-    - type: NpcFactionMember
-      factions:
-      - GOVFOR
-    - type: Marine
-      Faction: govfor
-    - type: Skills
-      preset: AU14SkillPresetPlatoonCombatTechnician
     - type: JobPrefix
       prefix: au14-job-prefix-govforsquadcombattechRMC
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-    - type: CMVendorUser
-      id: AU14JobGOVFORSquadCombatTech
-      points: 50
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoonsquadrifleman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/RMC/RMCplatoonsquadrifleman.yml
@@ -2,38 +2,16 @@
   parent: AU14JobSquadRiflemanBase
   id: AU14JobGOVFORSquadRiflemanRMC
   name: au14-job-name-govforsquadriflemanRMC
-  description: au14-job-description-govforsquadrifleman
-  setPreference: true
-  requirements:
-  - !type:TraitsRequirement
-    inverted: true
-    traits:
-    - Epilepsy
+  spawnMenuRoleName: Rifleman (TWE RMC)
   ranks:
     RMC_LanceCorporal:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORSquadRifleman
       time: 54000 # 15 hours
     RMC_Marine: []
-  startingGear: AU14GearGOVFORSquadRifleman
-  dummyStartingGear: AU14GearGOVFORRiflemanDummy
-  icon: "CMJobIconEmpty"
-  requireAdminNotify: false
-  spawnMenuRoleName: Rifleman (TWE RMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforSquad
-  hasIcon: false
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
-    - type: NpcFactionMember
-      factions:
-      - GOVFOR
-    - type: Marine
-      Faction: govfor
     - type: Skills
       skills:
         RMCSkillEndurance: 1
@@ -43,10 +21,3 @@
         RMCSkillFireman: 1
         RMCSkillVehicles: 1
         RMCSkillPolice: 1
-    - type: JobPrefix
-      prefix: au14-job-prefix-govforsquadrifleman
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPauxiliarysupportsynth.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPauxiliarysupportsynth.yml
@@ -1,10 +1,7 @@
 - type: job
   parent: AU14JobAuxSupportSynthBase
   id: AU14JobGOVFORAuxSupportSynthUPP
-  name: au14-job-name-govforauxsupportsynth
-  description: au14-job-description-govforauxsupportsynth
-  setPreference: true
-  canBeAntag: false
+  spawnMenuRoleName: Support Synth (UPP)
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 7200 # 2 hours
@@ -21,25 +18,9 @@
       role: AU14JobGOVFORAuxSupportSynth
       time: 180000 # 50 hours
     UPP_WarrantOfficer: []
-  startingGear: AU14GearGOVFORAuxSupportSynth
-  dummyStartingGear: AU14GearGOVFORAuxSupportSynthDummy
-  icon: "AU14JobIconGovSynth"
-  requireAdminNotify: false
-  spawnMenuRoleName: Support Synth (UPP)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govforplatco
-  accessGroups:
-  - AU14GovforCommand
-  - CMCargoTech
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
-    - type: NpcFactionMember
-      factions:
-      - GOVFOR
-    - type: Marine
-      Faction: govfor
     - type: Skills
       skills:
         RMCSkillCqc: 5
@@ -61,23 +42,3 @@
         RMCSkillIntel: 2
         RMCSkillDomestics: 2
         RMCSkillNavigations: 1
-    - type: JobPrefix
-      prefix: au14-job-prefix-govforauxsupportsynth
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-    - type: MeleeWeapon
-      soundHit:
-        path: /Audio/_RMC14/Weapons/synthpunch1.ogg
-        params:
-          variation: 0.15
-          volume: -1
-      angle: 30
-      animation: WeaponArcFist
-      attackRate: 1
-      damage:
-        types:
-          Blunt: 35
-    - type: Synth
-  hidden: false

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoonadvisor.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoonadvisor.yml
@@ -1,63 +1,10 @@
 - type: job
   parent: AU14JobadvisorBase
   id: AU14JobGOVFORadvisorUPP
-  name: au14-job-name-govforadvisor
-  description: au14-job-description-govforadvisor
-  setPreference: true
-  canBeAntag: false
-  requirements:
-  - !type:OverallPlaytimeRequirement
-    time: 3600 # Set to 72000 once we are fully launched AU14 todo
-  - !type:AgeRequirement
-    requiredAge: 21
-  - !type:TraitsRequirement
-    inverted: true
-    traits:
-    - Epilepsy
+  spawnMenuRoleName: Platoon Advisor (UPP)
   ranks:
     UPP_FirstSergeant:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORadvisor
       time: 360000 # 100 hours
     UPP_Chotar: []
-  startingGear: AU14GearGOVFORadvisor
-  dummyStartingGear: AU14GearGOVFORadvisorDummy
-  icon: "AU14JobIconGovAdvisor"
-  requireAdminNotify: true
-  spawnMenuRoleName: Platoon Advisor (UPP)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  whitelisted: true
-  accessGroups:
-  - AU14GovforCommand
-  roleWeight: 0.25
-  special:
-  - !type:AddComponentSpecial
-    components:
-    - type: NpcFactionMember
-      factions:
-      - GOVFOR
-    - type: Marine
-      Faction: govfor
-    - type: Skills
-      preset: AU14SkillPresetPlatoonAdvisor
-    - type: JobPrefix
-      prefix: au14-job-prefix-govforadvisor
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-    - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatooncorpsman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatooncorpsman.yml
@@ -2,27 +2,13 @@
   parent: AU14JobPlatoonCorpsmanBase
   id: AU14JobGOVFORPlatoonCorpsmanUPP
   name: Field Medic
-  description: au14-job-description-govforplatooncorpsman
-  setPreference: false
+  spawnMenuRoleName: Hospital Corpsman (UPP)
   ranks:
     UPP_Corporal:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORPlatoonCorpsman
       time: 108000 # 30 hours
     UPP_SeniorGefreiter: []
-  startingGear: AU14GearGOVFORPlatoonCorpsman
-  dummyStartingGear: AU14GearGOVFORCorpsmanDummy
-  icon: "AU14JobIconCorpsman"
-  requireAdminNotify: false
-  spawnMenuRoleName: Hospital Corpsman (UPP)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforCorpsman
-  - AU14GovforSquad
-  overwatchSortPriority: -2
-  overwatchRoleName: au14-job-name-govforplatooncorpsman-plural
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
@@ -38,8 +24,3 @@
         RMCSkillPolice: 1
     - type: JobPrefix
       prefix: au14-job-prefix-AU14JobGOVFORPlatoonCorpsmanUPP
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoondropshipcrewchief.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoondropshipcrewchief.yml
@@ -2,9 +2,7 @@
   parent: AU14JobDCCBase
   id: AU14JobGOVFORDCCUPP
   name: Dropship Crew Chief
-  description: au14-job-description-govfordcc
-  setPreference: false
-  canBeAntag: false
+  spawnMenuRoleName: Dropship Crew Chief (UPP)
   ranks:
     UPP_Chotar:
     - !type:RoleTimeRequirement
@@ -15,18 +13,6 @@
       role: AU14JobGOVFORDCC
       time: 108000 # 30 hours
     UPP_Sergeant: []
-  startingGear: AU14GearGOVFORDCC
-  dummyStartingGear: AU14GearGOVFORDCCDummy
-  icon: "AU14JobIconDCC"
-  requireAdminNotify: false
-  spawnMenuRoleName: Dropship Crew Chief (UPP)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforPilot
-  - AU14GovforCorpsman
-  - AU14GovforSquad
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
@@ -45,8 +31,3 @@
         RMCSkillPolice: 1
     - type: JobPrefix
       prefix: au14-job-prefix-AU14JobGOVFORDCCUPP
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoonpilotofficer.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoonpilotofficer.yml
@@ -2,9 +2,7 @@
   parent: AU14JobDSPilotBase
   id: AU14JobGOVFORDSPilotUPP
   name: Dropship Pilot
-  description: au14-job-description-govfordspilot
-  setPreference: false
-  canBeAntag: false
+  spawnMenuRoleName: Pilot Officer (UPP)
   ranks:
     UPP_Lieutenant:
     - !type:RoleTimeRequirement
@@ -19,18 +17,6 @@
       role: AU14JobGOVFORDSPilot
       time: 108000 # 30 hours
     UPP_WarrantOfficer: []
-  startingGear: AU14GearGOVFORDSPilot
-  dummyStartingGear: AU14GearGOVFORDSPilotDummy
-  icon: "AU14JobIconPilotOfficer"
-  requireAdminNotify: false
-  spawnMenuRoleName: Pilot Officer (UPP)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforPilot
-  - AU14GovforCorpsman
-  - AU14GovforSquad
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
@@ -49,21 +35,3 @@
         RMCSkillPolice: 1
     - type: JobPrefix
       prefix: au14-job-prefix-AU14JobGOVFORDSPilotUPP
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-    - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoonradiotelephoneoperator.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoonradiotelephoneoperator.yml
@@ -1,27 +1,15 @@
 - type: job
   parent: AU14JobRadioTelephoneOperatorBase
   id: AU14JobGOVFORRadioTelephoneOperatorUPP
-  name: Radio Telephone Operator
-  description: au14-job-description-radiotelephoneoperator
-  setPreference: false
+  name: au14-job-name-radiotelephoneoperator-alt
+  spawnMenuRoleName: Fireteam Leader (UPP)
+  overwatchRoleName: au14-job-name-radiotelephoneoperator-alt
   ranks:
     UPP_SeniorGefreiter:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORRadioTelephoneOperator
       time: 108000 # 30 hours
     UPP_Gefreiter: []
-  startingGear: AU14GearGOVFORRadioTelephoneOperator
-  dummyStartingGear: AU14GearGOVFORRadioTelephoneOperatorDummy
-  icon: "AU14JobIconRTO"
-  requireAdminNotify: false
-  spawnMenuRoleName: Fireteam Leader (UPP)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforFTL
-  overwatchSortPriority: -5
-  overwatchRoleName: au14-job-name-radiotelephoneoperator-alt
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
@@ -35,21 +23,3 @@
         RMCSkillPolice: 1
     - type: JobPrefix
       prefix: au14-job-prefix-AU14JobGOVFORRadioTelephoneOperatorUPP
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-    - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoonsectionsergeant.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoonsectionsergeant.yml
@@ -2,31 +2,17 @@
   parent: AU14JobSectionSergeantBase
   id: AU14JobGOVFORSectionSergeantUPP
   name: Platoon Leader
-  description: au14-job-description-govforSSG
-  setPreference: false
+  spawnMenuRoleName: Platoon Sergeant (UPP)
   ranks:
     UPP_Chotar:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORSectionSergeant
-      time: 216000 # 30 hours
+      time: 216000 # 60 hours
     UPP_StaffSergeant:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORSectionSergeant
       time: 108000 # 30 hours
     UPP_Sergeant: []
-  startingGear: AU14GearGOVFORSectionSergeant
-  dummyStartingGear: AU14GearGOVFORPlatoonSergeantDummy
-  icon: "AU14JobIconPlatoonSarge"
-  requireAdminNotify: true
-  spawnMenuRoleName: Platoon Sergeant (UPP)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforCommand
-  overwatchSortPriority: -6
-  overwatchShowName: true
-  overwatchRoleName: Platoon Sergeant
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
@@ -46,21 +32,3 @@
         RMCSkillPolice: 1
     - type: JobPrefix
       prefix: au14-job-prefix-AU14JobGOVFORSectionSergeantUPP
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-    - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder # No Russian/UPP voicelines yet, its gonna have to use normal english accent
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoonsquadautomaticrifleman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoonsquadautomaticrifleman.yml
@@ -2,27 +2,13 @@
   parent: AU14JobSquadAutomaticRiflemanBase
   id: AU14JobGOVFORSquadAutomaticRiflemanUPP
   name: Machine Gunner
-  description: au14-job-description-govforsquadautomaticrifleman
-  setPreference: false
+  spawnMenuRoleName: Automatic Rifleman (UPP)
   ranks:
     UPP_Gefreiter:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORSquadAutomaticRifleman
       time: 108000 # 30 hours
     UPP_Private: []
-  startingGear: AU14GearGOVFORSquadAutomaticRifleman
-  dummyStartingGear: AU14GearGOVFORAutoRiflemanDummy
-  icon: "AU14JobIconAFN"
-  requireAdminNotify: false
-  spawnMenuRoleName: Automatic Rifleman (UPP)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforGunner
-  overwatchSortPriority: -3
-  overwatchShowName: true
-  overwatchRoleName: au14-job-name-govforsquadautomaticrifleman-plural
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
@@ -35,11 +21,5 @@
         RMCSkillConstruction: 2
         RMCSkillEngineer: 3
         RMCSkillPolice: 1
-    - type: SquadArmorWearer
     - type: JobPrefix
       prefix: au14-job-prefix-AU14JobGOVFORSquadAutomaticRiflemanUPP
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: smartgunner
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoonsquadcombattech.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoonsquadcombattech.yml
@@ -1,15 +1,7 @@
 - type: job
   parent: AU14JobSquadCombatTechBase
   id: AU14JobGOVFORSquadCombatTechUPP
-  name: au14-job-name-govforsquadcombattech
-  description: au14-job-description-govforsquadcombattech
-  setPreference: true
-  requirements:
-  - !type:TraitsRequirement
-    inverted: true
-    traits:
-    - Epilepsy
-    - NonResuscitable
+  spawnMenuRoleName: Combat Tech (UPP)
   ranks:
     UPP_Corporal:
     - !type:RoleTimeRequirement
@@ -24,34 +16,3 @@
       role: AU14JobGOVFORSquadCombatTech
       time: 54000 # 15 hours
     UPP_Private: []
-  startingGear: AU14GearGOVFORSquadCombatTech
-  dummyStartingGear: AU14GearGOVFORCTDummy
-  icon: "AU14JobIconGovCT"
-  requireAdminNotify: false
-  spawnMenuRoleName: Combat Tech (UPP)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforEngineer
-  hasIcon: true
-  roleWeight: 0.25
-  special:
-  - !type:AddComponentSpecial
-    components:
-    - type: NpcFactionMember
-      factions:
-      - GOVFOR
-    - type: Marine
-      Faction: govfor
-    - type: Skills
-      preset: AU14SkillPresetPlatoonCombatTechnician
-    - type: JobPrefix
-      prefix: au14-job-prefix-govforsquadcombattech
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-    - type: CMVendorUser
-      id: AU14JobGOVFORSquadCombatTech
-      points: 50
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoonsquadrifleman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/UPP/UPPplatoonsquadrifleman.yml
@@ -2,25 +2,13 @@
   parent: AU14JobSquadRiflemanBase
   id: AU14JobGOVFORSquadRiflemanUPP
   name: Rifleman
-  description: au14-job-description-govforsquadrifleman
-  setPreference: false
+  spawnMenuRoleName: Rifleman (UPP)
   ranks:
     UPP_Gefreiter:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORSquadRifleman
       time: 108000 # 30 hours
     UPP_Private: []
-  startingGear: AU14GearGOVFORSquadRifleman
-  dummyStartingGear: AU14GearGOVFORRiflemanDummy
-  icon: "AU14JobIconGovRifleman"
-  requireAdminNotify: false
-  spawnMenuRoleName: Rifleman (UPP)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforSquad
-  hasIcon: false
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
@@ -35,8 +23,3 @@
         RMCSkillPolice: 1
     - type: JobPrefix
       prefix: au14-job-prefix-AU14JobGOVFORSquadRiflemanUPP
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/WY_PMC/WYplatooncorpsman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/WY_PMC/WYplatooncorpsman.yml
@@ -2,27 +2,13 @@
   parent: AU14JobPlatoonCorpsmanBase
   id: AU14JobGOVFORPlatoonCorpsmanWYPMC
   name: PMC Combat Lifesaver
-  description: au14-job-description-govforplatooncorpsman
-  setPreference: false
+  spawnMenuRoleName: Hospital Corpsman (WYPMC)
   ranks:
     AU14RankWeYuSeniorOperator:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORPlatoonCorpsman
       time: 108000 # 30 hours
     AU14RankWeYuOperator: []
-  startingGear: AU14GearGOVFORPlatoonCorpsman
-  dummyStartingGear: AU14GearGOVFORCorpsmanDummy
-  icon: "AU14JobIconCorpsman"
-  requireAdminNotify: false
-  spawnMenuRoleName: Hospital Corpsman (WYPMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforCorpsman
-  - AU14GovforSquad
-  overwatchSortPriority: -2
-  overwatchRoleName: au14-job-name-govforplatooncorpsman-plural
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
@@ -38,8 +24,3 @@
         RMCSkillPolice: 1
     - type: JobPrefix
       prefix: au14-job-prefix-AU14JobGOVFORPlatoonCorpsmanWYPMC
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/WY_PMC/WYplatoondropshipcrewchief.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/WY_PMC/WYplatoondropshipcrewchief.yml
@@ -2,27 +2,13 @@
   parent: AU14JobDCCBase
   id: AU14JobGOVFORDCCWYPMC
   name: PMC Crew Chief
-  description: au14-job-description-govfordcc
-  setPreference: false
-  canBeAntag: false
+  spawnMenuRoleName: Dropship Crew Chief (WYPMC)
   ranks:
     AU14RankWeYuSeniorCrewChief:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORDCC
       time: 108000 # 30 hours
     AU14RankWeYuCrewChief: []
-  startingGear: AU14GearGOVFORDCC
-  dummyStartingGear: AU14GearGOVFORDCCDummy
-  icon: "AU14JobIconDCC"
-  requireAdminNotify: false
-  spawnMenuRoleName: Dropship Crew Chief (WYPMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforPilot
-  - AU14GovforCorpsman
-  - AU14GovforSquad
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
@@ -41,8 +27,3 @@
         RMCSkillPolice: 1
     - type: JobPrefix
       prefix: au14-job-prefix-AU14JobGOVFORDCCWYPMC
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/WY_PMC/WYplatoonpilotofficer.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/WY_PMC/WYplatoonpilotofficer.yml
@@ -2,27 +2,13 @@
   parent: AU14JobDSPilotBase
   id: AU14JobGOVFORDSPilotWYPMC
   name: PMC Pilot Officer
-  description: au14-job-description-govfordspilot
-  setPreference: false
-  canBeAntag: false
+  spawnMenuRoleName: Pilot Officer (WYPMC)
   ranks:
     AU14RankWeYuSeniorCrewChief:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORDSPilot
       time: 108000 # 30 hours
     AU14RankWeYuCrewChief: []
-  startingGear: AU14GearGOVFORDSPilot
-  dummyStartingGear: AU14GearGOVFORDSPilotDummy
-  icon: "AU14JobIconPilotOfficer"
-  requireAdminNotify: false
-  spawnMenuRoleName: Pilot Officer (WYPMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforPilot
-  - AU14GovforCorpsman
-  - AU14GovforSquad
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
@@ -41,21 +27,3 @@
         RMCSkillPolice: 1
     - type: JobPrefix
       prefix: au14-job-prefix-AU14JobGOVFORDSPilotWYPMC
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-    - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/WY_PMC/WYplatoonradiotelephoneoperator.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/WY_PMC/WYplatoonradiotelephoneoperator.yml
@@ -2,26 +2,14 @@
   parent: AU14JobRadioTelephoneOperatorBase
   id: AU14JobGOVFORRadioTelephoneOperatorWYPMC
   name: PMC Communications Specialist
-  description: au14-job-description-radiotelephoneoperator
-  setPreference: false
+  spawnMenuRoleName: Fireteam Leader (WYPMC)
+  overwatchRoleName: au14-job-name-radiotelephoneoperator-alt
   ranks:
     AU14RankWeYuSeniorOperator:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORRadioTelephoneOperator
       time: 108000 # 30 hours
     AU14RankWeYuOperator: []
-  startingGear: AU14GearGOVFORRadioTelephoneOperator
-  dummyStartingGear: AU14GearGOVFORRadioTelephoneOperatorDummy
-  icon: "AU14JobIconRTO"
-  requireAdminNotify: false
-  spawnMenuRoleName: Fireteam Leader (WYPMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforFTL
-  overwatchSortPriority: -5
-  overwatchRoleName: au14-job-name-radiotelephoneoperator-alt
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
@@ -35,21 +23,3 @@
         RMCSkillPolice: 1
     - type: JobPrefix
       prefix: au14-job-prefix-AU14JobGOVFORRadioTelephoneOperatorWYPMC
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-    - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/WY_PMC/WYplatoonsectionsergeant.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/WY_PMC/WYplatoonsectionsergeant.yml
@@ -2,23 +2,9 @@
   parent: AU14JobSectionSergeantBase
   id: AU14JobGOVFORSectionSergeantWYPMC
   name: PMC Platoon Leader
-  description: au14-job-description-govforSSG
-  setPreference: false
+  spawnMenuRoleName: Platoon Sergeant (WYPMC)
   ranks:
     AU14RankWeYuEnforcerLead: []
-  startingGear: AU14GearGOVFORSectionSergeant
-  dummyStartingGear: AU14GearGOVFORPlatoonSergeantDummy
-  icon: "AU14JobIconPlatoonSarge"
-  requireAdminNotify: true
-  spawnMenuRoleName: Platoon Sergeant (WYPMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforCommand
-  overwatchSortPriority: -6
-  overwatchShowName: true
-  overwatchRoleName: Platoon Sergeant
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
@@ -38,21 +24,3 @@
         RMCSkillPolice: 1
     - type: JobPrefix
       prefix: au14-job-prefix-AU14JobGOVFORSectionSergeantWYPMC
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-    - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/WY_PMC/WYplatoonsquadautomaticrifleman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/WY_PMC/WYplatoonsquadautomaticrifleman.yml
@@ -2,27 +2,13 @@
   parent: AU14JobSquadAutomaticRiflemanBase
   id: AU14JobGOVFORSquadAutomaticRiflemanWYPMC
   name: PMC Smartgun Operator
-  description: au14-job-description-govforsquadautomaticrifleman
-  setPreference: false
+  spawnMenuRoleName: Automatic Rifleman (WYPMC)
   ranks:
     AU14RankWeYuSeniorOperator:
     - !type:RoleTimeRequirement
       role: AU14JobGOVFORSquadAutomaticRifleman
       time: 108000 # 30 hours
     AU14RankWeYuOperator: []
-  startingGear: AU14GearGOVFORSquadAutomaticRifleman
-  dummyStartingGear: AU14GearGOVFORAutoRiflemanDummy
-  icon: "AU14JobIconAFN"
-  requireAdminNotify: false
-  spawnMenuRoleName: Automatic Rifleman (WYPMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforGunner
-  overwatchSortPriority: -3
-  overwatchShowName: true
-  overwatchRoleName: au14-job-name-govforsquadautomaticrifleman-plural
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
@@ -35,11 +21,5 @@
         RMCSkillConstruction: 2
         RMCSkillEngineer: 3
         RMCSkillPolice: 1
-    - type: SquadArmorWearer
     - type: JobPrefix
       prefix: au14-job-prefix-AU14JobGOVFORSquadAutomaticRiflemanWYPMC
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: smartgunner
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/WY_PMC/WYplatoonsquadrifleman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/WY_PMC/WYplatoonsquadrifleman.yml
@@ -2,8 +2,7 @@
   parent: AU14JobSquadRiflemanBase
   id: AU14JobGOVFORSquadRiflemanWYPMC
   name: PMC Contractor
-  description: au14-job-description-govforsquadrifleman
-  setPreference: false
+  spawnMenuRoleName: Rifleman (WYPMC)
   ranks:
     AU14RankWeYuSeniorOperator:
     - !type:RoleTimeRequirement
@@ -14,17 +13,6 @@
       role: AU14JobGOVFORSquadRifleman
       time: 1200 # 2 hours
     AU14RankWeYuRecruit: []
-  startingGear: AU14GearGOVFORSquadRifleman
-  dummyStartingGear: AU14GearGOVFORRiflemanDummy
-  icon: "AU14JobIconGovRifleman"
-  requireAdminNotify: false
-  spawnMenuRoleName: Rifleman (WYPMC)
-  joinNotifyCrew: false
-  supervisors: au14-job-supervisors-govfor
-  accessGroups:
-  - AU14GovforSquad
-  hasIcon: false
-  roleWeight: 0.25
   special:
   - !type:AddComponentSpecial
     components:
@@ -39,8 +27,3 @@
         RMCSkillPolice: 1
     - type: JobPrefix
       prefix: au14-job-prefix-AU14JobGOVFORSquadRiflemanWYPMC
-    - type: TacticalMapIcon
-      icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: true

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Util/threatLeader.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Util/threatLeader.yml
@@ -18,10 +18,10 @@
   description: au-job-description-threat-leader
   setPreference: true
   playTimeTracker: AUJobThreatLeader
-  requirements:
-  - !type:RoleTimeRequirement
-    role: AUJobThreatMember
-    time: 7200 # 2 hours
+  # requirements:
+  # - !type:RoleTimeRequirement
+  #   role: AUJobThreatMember
+  #   time: 7200 # 2 hours
   hidden: false
   supervisors: nobody
   icon: "AU14JobIconThreatLeader"

--- a/Resources/Prototypes/_AU14/gamemode/platoons.yml
+++ b/Resources/Prototypes/_AU14/gamemode/platoons.yml
@@ -1,4 +1,31 @@
 - type: platoon
+  id: exampleplatoon
+  name: exampleplatoon
+  lorePrimer: AU14PrimerPlatoonHAZOPS
+  reqlist: USCMCargoCatalog
+  VendorToMarker:
+    Rifleman: AU14USCMequipmentvendor
+    Corpsman: AU14USCMcorpsmanvendor
+    Arifleman: AU14USCMequipmentvendor
+    Dcc: AU14AircrewWeaponsVendor
+    OperationsOfficer: AU14USCMsectionleaderequipmentvendor
+    Rto: AU14RTOVendor
+    SectionSergeant: AU14USCMsectionleaderequipmentvendor
+    Pilot: AU14AircrewWeaponsVendor
+    combattech: AU14ComtechGearVendor
+    JuniorOfficer: AU14JOGenericVendor
+    MilitaryPolice: AU14MilitaryPolicemanGenericVendor
+    MilitaryDoctor: AU14MilitaryDoctorGenericVendor
+  possibleships:
+      - USSBush
+  jobSlotOverride:
+    SquadRifleman: 12
+    PlatoonCorpsman: 1
+    PlatCo: 1
+    DSPilot: 1
+  techTree: RMCIntelTechTree_ua
+
+- type: platoon
   id: USCM
   name: US Colonial Marines
   lorePrimer: AU14PrimerPlatoonUSCM
@@ -88,17 +115,19 @@
     ReqVend: AU14UPPRequisitionVendor
   possibleships:
       - USSBush
-#  jobClassOverride:
-#    SquadRifleman: AU14JobGOVFORSquadRiflemanUPP
-#    SectionSergeant: AU14JobGOVFORSectionSergeantUPP
-#    PlatoonCorpsman: AU14JobGOVFORPlatoonCorpsmanUPP
-#    PlatCo: AU14JobGOVFORPlatCoUPP
-#    SquadSergeant: AU14JobGOVFORSquadSergeantUPP
-#    DSPilot: AU14JobGOVFORDSPilotUPP
-#    SquadAutomaticRifleman: AU14JobGOVFORSquadAutomaticRiflemanUPP
-#    RadioTelephoneOperator: AU14JobGOVFORRadioTelephoneOperatorUPP
-#    PlatOp: AU14JobGOVFORPlatOpUPP
-#    DCC: AU14JobGOVFORDCCUPP
+  jobClassOverride:
+    SquadRifleman: AU14JobGOVFORSquadRiflemanUPP
+    PlatCo: AU14JobGOVFORPlatCoUPP
+    PlatOp: AU14JobGOVFORPlatOpUPP
+    # SectionSergeant: AU14JobGOVFORSectionSergeantUPP
+    SquadSergeant: AU14JobGOVFORSquadSergeantUPP
+    RadioTelephoneOperator: AU14JobGOVFORRadioTelephoneOperatorUPP
+    SquadCombatTech: AU14JobGOVFORSquadCombatTechUPP
+    SquadAutomaticRifleman: AU14JobGOVFORSquadAutomaticRiflemanUPP
+    PlatoonCorpsman: AU14JobGOVFORPlatoonCorpsmanUPP
+    DSPilot: AU14JobGOVFORDSPilotUPP
+    DCC: AU14JobGOVFORDCCUPP
+    SupportSynth: AU14JobGOVFORAuxSupportSynthUPP
   CompatibleDropships:
   - /Maps/_CMU14/Shuttles/alamo.yml
   - /Maps/_CMU14/Shuttles/lexingtonsmall.yml
@@ -126,17 +155,19 @@
     MilitaryPolice: AU14MilitaryPolicemanGenericVendor
     MilitaryDoctor: AU14MilitaryDoctorGenericVendor
     ReqVend: AU14WYPMCRequisitionVendor
-#  jobClassOverride:
-#    SquadRifleman: AU14JobGOVFORSquadRiflemanWYPMC
-#    SectionSergeant: AU14JobGOVFORSectionSergeantWYPMC
-#    PlatoonCorpsman: AU14JobGOVFORPlatoonCorpsmanWYPMC
-#    PlatCo: AU14JobGOVFORPlatCoWYPMC
-#    SquadSergeant: AU14JobGOVFORSquadSergeantWYPMC
-#    DSPilot: AU14JobGOVFORDSPilotWYPMC
-#    SquadAutomaticRifleman: AU14JobGOVFORSquadAutomaticRiflemanWYPMC
-#    RadioTelephoneOperator: AU14JobGOVFORRadioTelephoneOperatorWYPMC
-#    PlatOp: AU14JobGOVFORPlatOpWYPMC
-#    DCC: AU14JobGOVFORDCCWYPMC
+    jobClassOverride:
+      SquadRifleman: AU14JobGOVFORSquadRiflemanWYPMC
+      PlatCo: AU14JobGOVFORPlatCoWYPMC
+      PlatOp: AU14JobGOVFORPlatOpWYPMC
+      # SectionSergeant: AU14JobGOVFORSectionSergeantWYPMC
+      SquadSergeant: AU14JobGOVFORSquadSergeantWYPMC
+      RadioTelephoneOperator: AU14JobGOVFORRadioTelephoneOperatorWYPMC
+      SquadCombatTech: AU14JobGOVFORSquadCombatTechWYPMC
+      SquadAutomaticRifleman: AU14JobGOVFORSquadAutomaticRiflemanWYPMC
+      PlatoonCorpsman: AU14JobGOVFORPlatoonCorpsmanWYPMC
+      DSPilot: AU14JobGOVFORDSPilotWYPMC
+      DCC: AU14JobGOVFORDCCWYPMC
+      # Synth
   CompatibleDropships:
   - /Maps/_CMU14/Shuttles/alamo.yml
   - /Maps/_CMU14/Shuttles/lexingtonsmall.yml
@@ -170,12 +201,12 @@
     MilitaryPolice: AU14MilitaryPolicemanGenericVendorCIU
     MilitaryDoctor: AU14MilitaryDoctorGenericVendor
     ReqVend: AU14CMBCIURequisitionVendor
-#  jobClassOverride:
-#    PlatCo: AU14JobGOVFORPlatCoCMBCIU
-#    SquadRifleman: AU14JobGOVFORSquadRiflemanCMBCIU
-#    PlatoonCorpsman: AU14JobGOVFORPlatoonCorpsmanCMBCIU
-#    SquadSergeant: AU14JobGOVFORSectionSergeantCMBCIU
-#    SectionSergeant: AU14JobGOVFORSectionSergeantCMBCIU
+  jobClassOverride:
+    SquadRifleman: AU14JobGOVFORSquadRiflemanCMBCIU
+    PlatCo: AU14JobGOVFORPlatCoCMBCIU
+    SectionSergeant: AU14JobGOVFORSectionSergeantCMBCIU
+    SquadSergeant: AU14JobGOVFORSectionSergeantCMBCIU
+    PlatoonCorpsman: AU14JobGOVFORPlatoonCorpsmanCMBCIU
 #  jobSlotOverride:
 #    SquadRifleman: 14
 #    PlatoonCorpsman: 2
@@ -190,33 +221,6 @@
   - /Maps/_CMU14/Shuttles/lexingtonsmall.yml
   compatibleFighters:
     - /Maps/_AU14/ShuttlesDropships/cmbsquadcar.yml
-  techTree: RMCIntelTechTree_ua
-
-- type: platoon
-  id: exampleplatoon
-  name: exampleplatoon
-  lorePrimer: AU14PrimerPlatoonHAZOPS
-  reqlist: USCMCargoCatalog
-  VendorToMarker:
-    Rifleman: AU14USCMequipmentvendor
-    Corpsman: AU14USCMcorpsmanvendor
-    Arifleman: AU14USCMequipmentvendor
-    Dcc: AU14AircrewWeaponsVendor
-    OperationsOfficer: AU14USCMsectionleaderequipmentvendor
-    Rto: AU14RTOVendor
-    SectionSergeant: AU14USCMsectionleaderequipmentvendor
-    Pilot: AU14AircrewWeaponsVendor
-    combattech: AU14ComtechGearVendor
-    JuniorOfficer: AU14JOGenericVendor
-    MilitaryPolice: AU14MilitaryPolicemanGenericVendor
-    MilitaryDoctor: AU14MilitaryDoctorGenericVendor
-  possibleships:
-      - USSBush
-  jobSlotOverride:
-    SquadRifleman: 12
-    PlatoonCorpsman: 1
-    PlatCo: 1
-    DSPilot: 1
   techTree: RMCIntelTechTree_ua
 
 - type: platoon
@@ -346,18 +350,19 @@
     MilitaryPolice: AU14MilitaryPolicemanGenericVendor
     MilitaryDoctor: AU14MilitaryDoctorGenericVendor
     ReqVend: AU14RMCRequisitionVendor
-  #jobClassOverride:
-   # SquadRifleman: AU14JobGOVFORSquadRiflemanRMC
-   # SectionSergeant: AU14JobGOVFORSectionSergeantRMC
-   # PlatoonCorpsman: AU14JobGOVFORPlatoonCorpsmanRMC
-   # PlatCo: AU14JobGOVFORPlatCoRMC
-   # SquadSergeant: AU14JobGOVFORSquadSergeantRMC
-   # DSPilot: AU14JobGOVFORDSPilotRMC
-   # SquadAutomaticRifleman: AU14JobGOVFORSquadAutomaticRiflemanRMC
-   # RadioTelephoneOperator: AU14JobGOVFORRadioTelephoneOperatorRMC
-   # PlatOp: AU14JobGOVFORPlatOpRMC
-   # DCC: AU14JobGOVFORDCCRMC
-   # SupportSynth: AU14JobGOVFORAuxSupportSynthRMC
+    jobClassOverride:
+      SquadRifleman: AU14JobGOVFORSquadRiflemanRMC
+      PlatCo: AU14JobGOVFORPlatCoRMC
+      PlatOp: AU14JobGOVFORPlatOpRMC
+      SectionSergeant: AU14JobGOVFORSectionSergeantRMC
+      SquadSergeant: AU14JobGOVFORSquadSergeantRMC
+      RadioTelephoneOperator: AU14JobGOVFORRadioTelephoneOperatorRMC
+      SquadCombatTech: AU14JobGOVFORSquadCombatTechRMC
+      SquadAutomaticRifleman: AU14JobGOVFORSquadAutomaticRiflemanRMC
+      PlatoonCorpsman: AU14JobGOVFORPlatoonCorpsmanRMC
+      DSPilot: AU14JobGOVFORDSPilotRMC
+      DCC: AU14JobGOVFORDCCRMC
+      SupportSynth: AU14JobGOVFORAuxSupportSynthRMC
   CompatibleDropships:
   - /Maps/_CMU14/Shuttles/alamo.yml
   - /Maps/_CMU14/Shuttles/lexingtonsmall.yml

--- a/Resources/Prototypes/_AU14/gamemode/platoons.yml
+++ b/Resources/Prototypes/_AU14/gamemode/platoons.yml
@@ -155,19 +155,19 @@
     MilitaryPolice: AU14MilitaryPolicemanGenericVendor
     MilitaryDoctor: AU14MilitaryDoctorGenericVendor
     ReqVend: AU14WYPMCRequisitionVendor
-    jobClassOverride:
-      SquadRifleman: AU14JobGOVFORSquadRiflemanWYPMC
-      PlatCo: AU14JobGOVFORPlatCoWYPMC
-      PlatOp: AU14JobGOVFORPlatOpWYPMC
-      # SectionSergeant: AU14JobGOVFORSectionSergeantWYPMC
-      SquadSergeant: AU14JobGOVFORSquadSergeantWYPMC
-      RadioTelephoneOperator: AU14JobGOVFORRadioTelephoneOperatorWYPMC
-      SquadCombatTech: AU14JobGOVFORSquadCombatTechWYPMC
-      SquadAutomaticRifleman: AU14JobGOVFORSquadAutomaticRiflemanWYPMC
-      PlatoonCorpsman: AU14JobGOVFORPlatoonCorpsmanWYPMC
-      DSPilot: AU14JobGOVFORDSPilotWYPMC
-      DCC: AU14JobGOVFORDCCWYPMC
-      # Synth
+  jobClassOverride:
+    SquadRifleman: AU14JobGOVFORSquadRiflemanWYPMC
+    PlatCo: AU14JobGOVFORPlatCoWYPMC
+    PlatOp: AU14JobGOVFORPlatOpWYPMC
+    # SectionSergeant: AU14JobGOVFORSectionSergeantWYPMC
+    SquadSergeant: AU14JobGOVFORSquadSergeantWYPMC
+    RadioTelephoneOperator: AU14JobGOVFORRadioTelephoneOperatorWYPMC
+    SquadCombatTech: AU14JobGOVFORSquadCombatTechWYPMC
+    SquadAutomaticRifleman: AU14JobGOVFORSquadAutomaticRiflemanWYPMC
+    PlatoonCorpsman: AU14JobGOVFORPlatoonCorpsmanWYPMC
+    DSPilot: AU14JobGOVFORDSPilotWYPMC
+    DCC: AU14JobGOVFORDCCWYPMC
+    # Synth
   CompatibleDropships:
   - /Maps/_CMU14/Shuttles/alamo.yml
   - /Maps/_CMU14/Shuttles/lexingtonsmall.yml
@@ -204,7 +204,7 @@
   jobClassOverride:
     SquadRifleman: AU14JobGOVFORSquadRiflemanCMBCIU
     PlatCo: AU14JobGOVFORPlatCoCMBCIU
-    SectionSergeant: AU14JobGOVFORSectionSergeantCMBCIU
+    # SectionSergeant: AU14JobGOVFORSectionSergeantCMBCIU
     SquadSergeant: AU14JobGOVFORSectionSergeantCMBCIU
     PlatoonCorpsman: AU14JobGOVFORPlatoonCorpsmanCMBCIU
 #  jobSlotOverride:
@@ -350,19 +350,19 @@
     MilitaryPolice: AU14MilitaryPolicemanGenericVendor
     MilitaryDoctor: AU14MilitaryDoctorGenericVendor
     ReqVend: AU14RMCRequisitionVendor
-    jobClassOverride:
-      SquadRifleman: AU14JobGOVFORSquadRiflemanRMC
-      PlatCo: AU14JobGOVFORPlatCoRMC
-      PlatOp: AU14JobGOVFORPlatOpRMC
-      SectionSergeant: AU14JobGOVFORSectionSergeantRMC
-      SquadSergeant: AU14JobGOVFORSquadSergeantRMC
-      RadioTelephoneOperator: AU14JobGOVFORRadioTelephoneOperatorRMC
-      SquadCombatTech: AU14JobGOVFORSquadCombatTechRMC
-      SquadAutomaticRifleman: AU14JobGOVFORSquadAutomaticRiflemanRMC
-      PlatoonCorpsman: AU14JobGOVFORPlatoonCorpsmanRMC
-      DSPilot: AU14JobGOVFORDSPilotRMC
-      DCC: AU14JobGOVFORDCCRMC
-      SupportSynth: AU14JobGOVFORAuxSupportSynthRMC
+  jobClassOverride:
+    SquadRifleman: AU14JobGOVFORSquadRiflemanRMC
+    PlatCo: AU14JobGOVFORPlatCoRMC
+    PlatOp: AU14JobGOVFORPlatOpRMC
+    SectionSergeant: AU14JobGOVFORSectionSergeantRMC
+    SquadSergeant: AU14JobGOVFORSquadSergeantRMC
+    RadioTelephoneOperator: AU14JobGOVFORRadioTelephoneOperatorRMC
+    SquadCombatTech: AU14JobGOVFORSquadCombatTechRMC
+    SquadAutomaticRifleman: AU14JobGOVFORSquadAutomaticRiflemanRMC
+    PlatoonCorpsman: AU14JobGOVFORPlatoonCorpsmanRMC
+    DSPilot: AU14JobGOVFORDSPilotRMC
+    DCC: AU14JobGOVFORDCCRMC
+    SupportSynth: AU14JobGOVFORAuxSupportSynthRMC
   CompatibleDropships:
   - /Maps/_CMU14/Shuttles/alamo.yml
   - /Maps/_CMU14/Shuttles/lexingtonsmall.yml


### PR DESCRIPTION
- **📋 Role loadout & visibility**
- **📋 corpsman & rifleman role cleanup**
- **✨ AddComponentSpecial inheritance - required to reduce bloat**
- **📋 rifleman & AR role cleanup**

## About the PR
- AddComponentSpecial didn't actually allow inheritance, probably why it's special

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- code: AddComponentSpecial can be inherited by jobs using the inheritAddComponentSpecials boolean to reduce bloat
- add: Job class overrides for WYPMC - UPP - RMC - CMBCIU