### PR TITLE
Ranks and govfor segments Loc

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1460,11 +1460,11 @@ namespace Content.Client.Lobby.UI
                 yield return (InsurgencyGovernmentJobList,
                     GamemodeInsurgency,
                     $"insurgency-govfor-{segmentKey}",
-                    $"Government Forces / {segmentTitle}");
+                    Loc.GetString("humanoid-profile-editor-government-forces-label", ("segmentTitle", segmentTitle)));
                 yield return (DistressGovernmentJobList,
                     GamemodeDistressSignal,
                     $"distress-govfor-{segmentKey}",
-                    $"Government Forces / {segmentTitle}");
+                    Loc.GetString("humanoid-profile-editor-government-forces-label", ("segmentTitle", segmentTitle)));
                 yield break;
             }
 
@@ -1562,16 +1562,16 @@ namespace Content.Client.Lobby.UI
             if (job.MarineAuthorityLevel > 0 ||
                 ContainsAny(id, name, "PlatCo", "PlatOp", "Commander", "Command", "Officer", "Leader", "Sergeant", "Advisor"))
             {
-                return ("command", "Command");
+                return ("command", Loc.GetString("humanoid-profile-editor-segment-command"));
             }
 
             if (ContainsAny(id, name, "Pilot", "Dropship", "Crew Chief", "DCC"))
-                return ("flight", "Flight");
+                return ("flight", Loc.GetString("humanoid-profile-editor-segment-flight"));
 
             if (ContainsAny(id, name, "Doctor", "Corpsman", "Medic", "Technician", "Tech", "Police", "Synth", "Working Joe", "Auxiliary"))
-                return ("support", "Support");
+                return ("support", Loc.GetString("humanoid-profile-editor-segment-support"));
 
-            return ("line", "Line Infantry");
+            return ("line", Loc.GetString("humanoid-profile-editor-segment-line"));
         }
 
         private static int GetJobSortGroup(DepartmentPrototype department, JobPrototype job)

--- a/Content.Client/_RMC14/Overwatch/OverwatchConsoleBui.cs
+++ b/Content.Client/_RMC14/Overwatch/OverwatchConsoleBui.cs
@@ -377,7 +377,7 @@ public sealed partial class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleW
                 if (marine.Rank != null)
                 {
                     if (_prototypes.TryIndex(marine.Rank, out var rank))
-                        rankName = rank.Prefix;
+                        rankName = _localization.TryGetString($"rank-{rank.ID}.prefix", out var lp) ? lp : rank.Prefix;
                 }
 
                 var name = rankName != null ? $"{rankName} {marine.Name}" : marine.Name;

--- a/Content.Shared/_RMC14/Marines/Roles/Ranks/SharedRankSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Roles/Ranks/SharedRankSystem.cs
@@ -90,17 +90,19 @@ public abstract partial class SharedRankSystem : EntitySystem
 
         if (isShort)
         {
+            var localizedPrefix = Loc.TryGetString($"rank-{rank.ID}.prefix", out var lp) ? lp : rank.Prefix;
+
             if (rank.FemalePrefix == null || rank.MalePrefix == null)
-                return rank.Prefix;
+                return localizedPrefix;
 
             if (!TryComp<HumanoidAppearanceComponent>(uid, out var humanoidAppearance))
-                return rank.Prefix;
+                return localizedPrefix;
 
             var genderPrefix = humanoidAppearance.Gender switch
             {
-                Gender.Female => rank.FemalePrefix,
-                Gender.Male => rank.MalePrefix,
-                _ => rank.Prefix,
+                Gender.Female => Loc.TryGetString($"rank-{rank.ID}.prefix-female", out var fp) ? fp : rank.FemalePrefix,
+                Gender.Male   => Loc.TryGetString($"rank-{rank.ID}.prefix-male",   out var mp) ? mp : rank.MalePrefix,
+                _             => localizedPrefix,
             };
 
             return genderPrefix;

--- a/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
@@ -84,3 +84,11 @@ humanoid-profile-editor-trait-count-hint = Points available: [{$current}/{$max}]
 trait-category-disabilities = Disabilities
 trait-category-speech = Speech traits
 trait-category-quirks = Quirks
+
+
+humanoid-profile-editor-government-forces-label = Government Forces / { $segmentTitle }
+
+humanoid-profile-editor-segment-command = Command
+humanoid-profile-editor-segment-flight = Flight
+humanoid-profile-editor-segment-support = Support
+humanoid-profile-editor-segment-line = Line Infantry


### PR DESCRIPTION
## About the PR
Add localisation support for hardcoded strings in HumanoidProfileEditor and rank display systems.

## Why / Balance
These strings are currently hardcoded in English and cannot be translated via the fluent localization system. This is required for russian localisation (RussianCM fork).

## Technical details
Loc.GetString is used for humanoid-profile-editor-government-forces-label (en-US key is required and provided).

Loc.TryGetString is used for rank keys - safe fallback to rank.Prefix / rank.FemalePrefix / rank.MalePrefix from prototype if key is absent

## Media
Not required.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- code: Add localisation support for GOVFOR job segments label and rank prefixes/names.
