### PR TITLE
More crusher adjustments

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -208,7 +208,8 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         // Server will validate it with InRangeUnobstructed.
         var entities = GetNetEntityList(ArcRayCast(userPos, direction.ToWorldAngle(), component.Angle, distance, userXform.MapID, user).ToList());
         _rmcLagCompensation.SendLastRealTick(); // RMC14
-        RaisePredictiveEvent(new HeavyAttackEvent(GetNetEntity(meleeUid), entities.GetRange(0, Math.Min(MaxTargets, entities.Count)), GetNetCoordinates(coordinates)));
+        var maxTargets = component.MaxTargets ?? MaxTargets;
+        RaisePredictiveEvent(new HeavyAttackEvent(GetNetEntity(meleeUid), entities.GetRange(0, Math.Min(maxTargets, entities.Count)), GetNetCoordinates(coordinates)));
     }
 
     private void ClientDisarm(EntityUid attacker, MapCoordinates mousePos, EntityCoordinates coordinates, MeleeWeaponComponent meleeComponent)

--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -325,10 +325,27 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     {
         var direction = mousePos.Position - originMap.Position;
         var distance = Math.Min(direction.Length(), charge.Range);
+
+        // Raycast for walls, doors, and barricades to find where the charge would actually stop.
+        if (direction.Length() > 0.1f)
+        {
+            var mask = (int) (CollisionGroup.Impassable | CollisionGroup.InteractImpassable | CollisionGroup.BarricadeImpassable);
+            var ray = new CollisionRay(originMap.Position, direction.Normalized(), mask);
+            foreach (var result in _physics.IntersectRay(originMap.MapId, ray, distance, player, returnOnFirstHit: true))
+            {
+                distance = Math.Max(0, result.Distance - 0.5f);
+            }
+        }
+
         mousePos = originMap.Offset(direction.Normalized() * distance);
 
         var color = new Color(0.85f, 0.2f, 0.2f).WithAlpha(OutlineAlpha);
-        DrawLinePreview(args, player, xform.Coordinates, mousePos, distance, color);
+        var toCoordinates = _transform.ToCoordinates(player, mousePos);
+        var tiles = _line.DrawLine(xform.Coordinates, toCoordinates, TimeSpan.Zero, distance, out _, hitBlocker: false);
+        if (tiles.Count == 0)
+            return;
+
+        DrawTileBorderFromLineTiles(args, tiles, color);
     }
 
     private void DrawDirectionalStomp(
@@ -364,8 +381,8 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
                 if (Math.Abs(angleDiff.Theta) > halfAngle.Theta)
                     continue;
 
-                // Raycast for barricade blocking.
-                var ray = new CollisionRay(originMap.Position, diff.Normalized(), (int) CollisionGroup.BarricadeImpassable);
+                // Raycast for obstacle blocking (walls, windows, doors, barricades).
+                var ray = new CollisionRay(originMap.Position, diff.Normalized(), (int) (CollisionGroup.Impassable | CollisionGroup.InteractImpassable | CollisionGroup.BarricadeImpassable));
                 var blocked = false;
                 foreach (var _ in _physics.IntersectRay(originMap.MapId, ray, diff.Length(), player, returnOnFirstHit: true))
                 {

--- a/Content.Shared/_RMC14/Shields/CrusherShieldComponent.cs
+++ b/Content.Shared/_RMC14/Shields/CrusherShieldComponent.cs
@@ -38,11 +38,11 @@ public sealed partial class CrusherShieldComponent : Component
     public EntProtoId Effect = "RMCEffectEmpowerBrown";
 
     [DataField, AutoNetworkedField]
-    public float ReflectChanceFront = 0.4f;
+    public float ReflectChanceFront = 0.1f;
 
     [DataField, AutoNetworkedField]
-    public float ReflectChanceSide = 0.3f;
+    public float ReflectChanceSide = 0f;
 
     [DataField, AutoNetworkedField]
-    public float ReflectChanceBack = 0.25f;
+    public float ReflectChanceBack = 0f;
 }

--- a/Content.Shared/_RMC14/Shields/CrusherShieldSystem.cs
+++ b/Content.Shared/_RMC14/Shields/CrusherShieldSystem.cs
@@ -54,7 +54,7 @@ public sealed partial class CrusherShieldSystem : EntitySystem
         args.Handled = true;
 
         EnsureComp<XenoShieldComponent>(xeno);
-        _shield.ApplyShield(xeno, XenoShieldSystem.ShieldType.Crusher, xeno.Comp.Amount);
+        _shield.ApplyShield(xeno, XenoShieldSystem.ShieldType.Crusher, xeno.Comp.Amount, visualState: "king-shield", maxShield: xeno.Comp.Amount.Double());
         ApplyEffects(xeno);
 
         if (_net.IsClient)

--- a/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class XenoChargeComponent : Component
     public DamageSpecifier Damage = new();
 
     [DataField, AutoNetworkedField]
-    public float Range = 8;
+    public float Range = 9;
 
     [DataField, AutoNetworkedField]
     public float SlowRange = 1.5f;

--- a/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
@@ -33,6 +33,7 @@ using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Map;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
@@ -387,6 +388,10 @@ public sealed partial class XenoChargeSystem : EntitySystem
             return;
         }
 
+        // Capture charge direction before StopCrusherCharge nulls it.
+        var savedChargeDir = xeno.Comp.Charge?.Normalized();
+        var origin = _transform.GetMapCoordinates(xeno);
+
         StopCrusherCharge(xeno);
 
         if (_net.IsServer)
@@ -424,8 +429,6 @@ public sealed partial class XenoChargeSystem : EntitySystem
 
         _rmcPulling.TryStopAllPullsFromAndOn(targetId);
 
-        var origin = _transform.GetMapCoordinates(xeno);
-
         var distanceTraveled = xeno.Comp.ChargeOrigin != null
             ? (origin.Position - xeno.Comp.ChargeOrigin.Value).Length()
             : 0f;
@@ -435,7 +438,19 @@ public sealed partial class XenoChargeSystem : EntitySystem
         _stun.TryParalyze(targetId, xeno.Comp.StunTime, true);
         _rmcObstacleSlamming.ApplyBonuses(targetId, TimeSpan.FromSeconds(1.5), TimeSpan.FromSeconds(3));
         EnsureComp<ChargeFlungComponent>(targetId);
-        _sizeStun.KnockBack(targetId, origin, knockback, knockback, knockBackSpeed: 15);
+
+        // Fling the target along the saved charge direction.
+        var targetPos = _transform.GetMapCoordinates(targetId);
+        var chargeDir = savedChargeDir ?? (targetPos.Position - origin.Position).Normalized();
+        var flingVec = chargeDir * knockback;
+
+        if (TryComp(targetId, out PhysicsComponent? targetPhysics))
+        {
+            _physics.SetLinearVelocity(targetId, Vector2.Zero, body: targetPhysics);
+            _physics.SetAngularVelocity(targetId, 0f, body: targetPhysics);
+        }
+
+        _throwing.TryThrow(targetId, flingVec, 15, animated: false, playSound: false, compensateFriction: true);
     }
 
     private void OnChargeFlungHit(Entity<ChargeFlungComponent> ent, ref ThrowDoHitEvent args)
@@ -484,17 +499,27 @@ public sealed partial class XenoChargeSystem : EntitySystem
         if (TerminatingOrDeleted(args.OtherEntity))
             return;
 
-        if (!TryComp(args.OtherEntity, out XenoCrusherChargableComponent? crush))
+        // Chargable entities with instant destroy and pass-through: destroy and pass.
+        if (TryComp(args.OtherEntity, out XenoCrusherChargableComponent? crush))
+        {
+            if (crush.InstantDestroy && crush.PassOnDestroy)
+            {
+                if (_net.IsServer)
+                    _destruct.DestroyEntity(args.OtherEntity);
+                else if (_net.IsClient)
+                    _transform.DetachEntity(args.OtherEntity, Transform(args.OtherEntity));
+
+                args.Cancelled = true;
+            }
+
+            return;
+        }
+
+        // Mobs block the charge (handled by OnXenoChargeHit).
+        if (HasComp<MobStateComponent>(args.OtherEntity))
             return;
 
-        if (!crush.InstantDestroy || !crush.PassOnDestroy)
-            return;
-
-        if (_net.IsServer)
-            _destruct.DestroyEntity(args.OtherEntity);
-        else if (_net.IsClient)
-            _transform.DetachEntity(args.OtherEntity, Transform(args.OtherEntity));
-
+        // Everything else (chairs, grass, etc.) is passed through.
         args.Cancelled = true;
     }
 
@@ -530,8 +555,11 @@ public sealed partial class XenoChargeSystem : EntitySystem
             }
         }
         var length = diff.Length();
+        var minRange = 2f;
         if (length > xeno.Comp.Range)
             diff = diff.Normalized() * xeno.Comp.Range;
+        else if (length < minRange)
+            diff = diff.Normalized() * minRange;
         else
             diff = diff.Normalized() * MathF.Ceiling(length);
 

--- a/Content.Shared/_RMC14/Xenonids/Stomp/SharedXenoStompSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stomp/SharedXenoStompSystem.cs
@@ -171,10 +171,15 @@ public sealed partial class XenoStompSystem : EntitySystem
         _receivers.Clear();
         _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.Range, _receivers);
 
+        var origin = _transform.GetMapCoordinates(xeno);
+
         using var targetingSuppression = _hitLocation.SuppressBodyZoneTargeting(xeno.Owner);
         foreach (var receiver in _receivers)
         {
             if (!_xeno.CanAbilityAttackTarget(xeno, receiver))
+                continue;
+
+            if (IsBlockedByObstacle(origin, _transform.GetMapCoordinates(receiver), xeno.Owner))
                 continue;
 
             if (xeno.Comp.SlowBigInsteadOfStun && _size.TryGetSize(receiver, out var size) && size >= RMCSizes.Big)
@@ -238,7 +243,7 @@ public sealed partial class XenoStompSystem : EntitySystem
                         continue;
 
                     // Raycast to check for barricades blocking the tile.
-                    if (IsBlockedByBarricade(origin, new MapCoordinates(worldPos, origin.MapId), xeno.Owner))
+                    if (IsBlockedByObstacle(origin, new MapCoordinates(worldPos, origin.MapId), xeno.Owner))
                         continue;
 
                     var tileCenter = _map.GridTileToLocal(gridId, grid, tilePos);
@@ -267,7 +272,7 @@ public sealed partial class XenoStompSystem : EntitySystem
                 continue;
 
             // Barricade line-of-sight check.
-            if (IsBlockedByBarricade(origin, entMap, xeno.Owner))
+            if (IsBlockedByObstacle(origin, entMap, xeno.Owner))
                 continue;
 
             var stompDamage = xeno.Comp.Damage;
@@ -308,7 +313,7 @@ public sealed partial class XenoStompSystem : EntitySystem
         }
     }
 
-    private bool IsBlockedByBarricade(MapCoordinates origin, MapCoordinates target, EntityUid ignore)
+    private bool IsBlockedByObstacle(MapCoordinates origin, MapCoordinates target, EntityUid ignore)
     {
         if (origin.MapId != target.MapId)
             return true;
@@ -318,7 +323,8 @@ public sealed partial class XenoStompSystem : EntitySystem
         if (distance < 0.1f)
             return false;
 
-        var ray = new CollisionRay(origin.Position, diff.Normalized(), (int) CollisionGroup.BarricadeImpassable);
+        var mask = (int) (CollisionGroup.Impassable | CollisionGroup.InteractImpassable | CollisionGroup.BarricadeImpassable);
+        var ray = new CollisionRay(origin.Position, diff.Normalized(), mask);
         foreach (var _ in _physics.IntersectRay(origin.MapId, ray, distance, ignore, returnOnFirstHit: true))
         {
             return true;

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -773,7 +773,7 @@
       state: ready_charge
     useDelay: 14
   - type: TargetAction
-    range: 9
+    range: 15 # actual range is in XenoChargeComponent, this allows max-range clamp cast
     checkCanAccess: false
   - type: WorldTargetAction
     event: !type:XenoChargeActionEvent

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
@@ -109,8 +109,8 @@
   - type: XenoBrutalize
     damage:
       types:
-        Blunt: 20
-    armorPiercing: 10
+        Blunt: 15
+    armorPiercing: 5
   - type: RMCSize
     size: Immobile
   - type: RMCXenoDamageVisuals
@@ -151,7 +151,7 @@
   - type: XenoCharge
     damage:
       types:
-        Blunt: 90
+        Blunt: 80
         Structural: 750
   - type: XenoShield
   - type: XenoEvolution


### PR DESCRIPTION
Reworks several aspects of the Crusher xeno to improve reliability and feel.

- Stomp (circular and directional) now respects line of sight through walls, windows, doors, and barricades. Previously circular stomp had no LOS check, and directional stomp only checked barricades.
- Charge range increased from 8 to 9 tiles with max-range clamp casting (clicking beyond range fires at max range instead of failing). Minimum charge distance of 2 tiles so close-range clicks no longer fizzle.
- Charge now flings targets along the actual charge direction instead of calculating from positions at impact, which was unreliable at high speed.
- Charge passes through non-mob obstacles (chairs, grass, tables) instead of getting stuck on them. Overlay matches, stopping only at walls, doors, and barricades.
- Defensive Shield now displays the king-shield animated overlay (full/half/quarter states as it takes damage).
- Projectile reflect reduced to 10% front only (was 40% front, 30% side, 25% back).
- Brutalize passive reduced to 15 Blunt / 5 AP (was 20 / 10).
- Charge hit damage reduced from 90 to 80 Blunt.
- Fixed a client-side bug where melee wide swing ignored per-entity maxTargets, always sending only 1 target. Crusher's 60-degree 2-target swing now works.

## Why / Balance

Stomp hitting through walls and doors was unintended and allowed damage in situations where the target had no counterplay. Adding LOS checks brings it in line with how other xeno abilities work.

Charge had several frustration points: targets flying in random directions on hit because the direction was calculated from the crusher's position at the moment of physics collision (unreliable at high speed), the ability fizzling on close-range clicks, and chairs/grass silently blocking the charge path.

The shield visual gives both the crusher player and enemies clear feedback that the shield is active and how much is left, which was previously missing.

The melee wide swing fix is a general client bug where the global CVar (set to 1) overrode the per-entity maxTargets value. This affected any entity with a custom maxTargets.

## Technical details

- `SharedXenoStompSystem.IsBlockedByObstacle`: raycast mask widened to `Impassable | InteractImpassable | BarricadeImpassable`. Same mask applied to the client overlay in `XenoAbilityPreviewOverlay.DrawDirectionalStomp`.
- Circular stomp now raycasts each target through the same method.
- `XenoChargeSystem.OnXenoChargeHit`: charge direction captured before `StopCrusherCharge` nulls it, target flung via `TryThrow` along the saved direction.
- `XenoChargeSystem.OnXenoChargePreventCollide`: cancels collisions with entities that aren't mobs or `XenoCrusherChargable`.
- `DrawCharge` overlay: physics raycast for walls/doors/barricades, `DrawLine` with `hitBlocker: false` so furniture doesn't truncate it.
- `CrusherShieldSystem`: passes `visualState: "king-shield"` to `ApplyShield`, reusing existing sprite states.
- `MeleeWeaponSystem.ClientHeavyAttack`: uses `component.MaxTargets ?? MaxTargets` instead of just `MaxTargets`.

## Media

N/A

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Crusher stomp no longer hits through walls, windows, or doors.
- tweak: Crusher charge range increased from 8 to 9 tiles with max-range clamp casting.
- tweak: Crusher charge now flings targets in the correct direction consistently.
- tweak: Crusher charge passes through furniture and small obstacles instead of getting stuck.
- tweak: Crusher Defensive Shield now shows animated shield overlay.
- tweak: Crusher projectile reflect reduced to 10% front only.
- tweak: Crusher Brutalize passive reduced to 15 damage and 5 AP.
- tweak: Crusher charge hit damage reduced from 90 to 80.
- fix: Fixed melee wide swing ignoring per-entity max target count on the client.