### PR TITLE
Tracer Rounds, Various Fixes/Adjustments

### DIFF
--- a/Resources/Prototypes/_AU14/Catalog/Cargo/cmbciu_requisitions_catalog.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Cargo/cmbciu_requisitions_catalog.yml
@@ -182,7 +182,7 @@
         crate: RMCCrateBoxShellsShotgunFlechette
       - cost: 500
         crate: RMCCrateBoxShellsShotgunBuckshot
-      - cost: 100
+      - cost: 1000
         crate: AU14CrateM7SLAWAPRocket
       - cost: 2500
         crate: AU14CrateM7SLAWMixedRocket

--- a/Resources/Prototypes/_AU14/Catalog/Cargo/hazops_requisitions_catalog.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Cargo/hazops_requisitions_catalog.yml
@@ -182,7 +182,7 @@
         crate: RMCCrateBoxShellsShotgunFlechette
       - cost: 500
         crate: RMCCrateBoxShellsShotgunBuckshot
-      - cost: 100
+      - cost: 1000
         crate: AU14CrateM7SLAWAPRocket
       - cost: 2500
         crate: AU14CrateM7SLAWMixedRocket

--- a/Resources/Prototypes/_AU14/Catalog/Cargo/lacn_requisitions_catalog.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Cargo/lacn_requisitions_catalog.yml
@@ -182,7 +182,7 @@
         crate: RMCCrateBoxShellsShotgunFlechette
       - cost: 500
         crate: RMCCrateBoxShellsShotgunBuckshot
-      - cost: 100
+      - cost: 1000
         crate: AU14CrateM7SLAWAPRocket
       - cost: 2500
         crate: AU14CrateM7SLAWMixedRocket

--- a/Resources/Prototypes/_AU14/Catalog/Cargo/uscm_requisitions_catalog.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Cargo/uscm_requisitions_catalog.yml
@@ -190,7 +190,7 @@
         crate: RMCCrateBoxShellsShotgunFlechette
       - cost: 500
         crate: RMCCrateBoxShellsShotgunBuckshot
-      - cost: 100
+      - cost: 1000
         crate: AU14CrateM7SLAWAPRocket
       - cost: 2500
         crate: AU14CrateM7SLAWMixedRocket

--- a/Resources/Prototypes/_AU14/Catalog/Cargo/vaipo_requisitions_catalog.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Cargo/vaipo_requisitions_catalog.yml
@@ -182,7 +182,7 @@
         crate: RMCCrateBoxShellsShotgunFlechette
       - cost: 500
         crate: RMCCrateBoxShellsShotgunBuckshot
-      - cost: 100
+      - cost: 1000
         crate: AU14CrateM7SLAWAPRocket
       - cost: 2500
         crate: AU14CrateM7SLAWMixedRocket

--- a/Resources/Prototypes/_AU14/Catalog/Cargo/weyu_requisitions_catalog.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Cargo/weyu_requisitions_catalog.yml
@@ -182,7 +182,7 @@
         crate: RMCCrateBoxShellsShotgunFlechette
       - cost: 500
         crate: RMCCrateBoxShellsShotgunBuckshot
-      - cost: 100
+      - cost: 1000
         crate: AU14CrateM7SLAWAPRocket
       - cost: 2500
         crate: AU14CrateM7SLAWMixedRocket

--- a/Resources/Prototypes/_AU14/Entities/Vendors/hazopsvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/hazopsvendors.yml
@@ -460,6 +460,8 @@
         amount: 20
     - name: special issue firearms
       entries:
+      - id: RMCWeaponRifleM54CFilled
+        amount: 10
       - id: WeaponShotgunM42A1
         amount: 3
       - id: WeaponRifleM4SPR
@@ -474,8 +476,12 @@
       entries:
       - id: AU14MagazineXMP5A6
         amount: 200
+      - id: CMMagazineRifleM54C
+        amount: 100
       - id: CMMagazineRifleM54CAP
         amount: 15
+      - id: RMCMagazineRifleM54CWP
+        amount: 5
       - id: CMMagazineRifleM4SPR
         amount: 60
       - id: CMMagazineRifleM4SPRAP
@@ -509,6 +515,8 @@
       - id: CMPacketGrenadeHighExplosiveFilled
         amount: 6
       - id: RMCPacketGrenadeIncendiaryFilled
+        amount: 3
+      - id: RMCPacketGrenadeWhitePhosphorusFilled
         amount: 3
       - id: CMPacketGrenadeFragFilled
         amount: 6

--- a/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
@@ -951,11 +951,11 @@
         amount: 1
     - name: Engineering Supplies
       entries:
-      - id: CMSandbagEmpty25
+      - id: CMSandbagEmpty50
         recommended: true
-        amount: 1
+        amount: 5
       - id: BarbedWire15
-        amount: 2
+        amount: 4
       - id: CMSheetMetal50
         amount: 2
       - id: CMSheetPlasteel50
@@ -1166,7 +1166,7 @@
   parent: CMVendorBundleRiflemanApparel
   id: AU14VendorBundleCombatTechnicianEssentials
   name: essential engineer set
-  description: Contains 50 metal, 40 plasteel, 25 sandbags, a high-capacity power cell, a light replacer, a welding visor, and a nailgun.
+  description: Contains 50 metal, 50 plasteel, 50 sandbags, a high-capacity power cell, a light replacer, a welding visor, and a nailgun.
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Tools/wrench.rsi
@@ -1174,9 +1174,11 @@
   - type: CMVendorBundle
     bundle:
     - RMCExplosivePlastic
-    - CMSandbagEmpty25
+    - RMCEngineerKit
+    - CMSandbagEmpty50
+    - RMCPlankWood
     - CMSheetMetal50
-    - CMSheetPlasteel40
+    - CMSheetPlasteel50
     - RMCPowerCellHigh
     - RMCLightReplacer
     - CMAPCElectronics
@@ -1319,6 +1321,8 @@
         amount: 200
       - id: CMMagazineRifleM54CMK1AP
         amount: 15
+      - id: CMMagazineRifleM54CMK1Tracer
+        amount: 5
       - id: CMMagazineSMGM63
         amount: 200
       - id: CMMagazineSMGM63AP
@@ -1341,8 +1345,6 @@
         amount: 10
       - id: RMCMagazineRifleM54CWP
         amount: 5
-      - id: RMCMagazineRifleM54CHEAPEmpty
-        amount: 0
       - id: RMCBoxShotgunBuckshot
         amount: 20
       - id: RMCBoxShotgunFlechette

--- a/Resources/Prototypes/_AU14/Entities/Vendors/rmcvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/rmcvendors.yml
@@ -331,11 +331,11 @@
         amount: 1
     - name: Engineering Supplies
       entries:
-      - id: CMSandbagEmpty25
+      - id: CMSandbagEmpty50
         recommended: true
-        amount: 2
+        amount: 5
       - id: BarbedWire15
-        amount: 3
+        amount: 4
       - id: CMSheetMetal50
         amount: 1
       - id: CMSheetPlasteel50

--- a/Resources/Prototypes/_AU14/Entities/Vendors/vaipovendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/vaipovendors.yml
@@ -926,6 +926,8 @@
         amount: 70
       - id: CMMagazineRifleM54CMK1AP
         amount: 10
+      - id: CMMagazineRifleM54CMK1Tracer
+        amount: 10
       - id: RMCBoxShotgunBuckshot
         amount: 20
       - id: RMCBoxShotgunFlechette

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -1929,6 +1929,7 @@
       - CMFireExtinguisherPortable
       - RMCMagazineML66D
       - RMCMagazineM2C
+      - AU14MagazineM2CTracter
       - CableCoil
       - Multitool
       - RMCExplosiveBreachingCharge

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/welders.yml
@@ -221,8 +221,8 @@
   parent: RMCWelderBase
   id: RMCWelderPVE
   name: modified blowtorch
-  description: A more 'advanced' version of the standard UNMC Blowtorch, this blowtorch has a welding shield for eye protection affixed to it. Seems the eye shield was ripped off of a standard ME3 hand welder and then crudely affixed.
-  suffix: PVE, DO NOT MAP
+  description: A more 'advanced' version of the standard Blowtorch, this blowtorch has a welding shield for eye protection affixed to it. Seems the eye shield was ripped off of a standard ME3 hand welder and then crudely affixed.
+  suffix: Eye Protection
   components:
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
@@ -716,6 +716,7 @@
       tags:
       - M2CMount
       - RMCMagazineM2C
+      - AU14MagazineM2CTracter
       - RMCSkillPamphlet
       - RMCMachineGunnerRig
   - type: StorageFill
@@ -725,5 +726,5 @@
     - id: RMCMagazineM2C
     - id: RMCMagazineM2C
     - id: RMCMagazineM2C
-    - id: RMCMagazineM2C
+    - id: AU14MagazineM2CTracter
     - id: RMCBeltMachineGunner

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/HMGs/m2c.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/HMGs/m2c.yml
@@ -72,6 +72,7 @@
         whitelist:
           tags:
           - RMCMagazineM2C
+          - AU14MagazineM2CTracter
   - type: GunDamageModifier
     multiplier: 1
   - type: GunRequiresSkills
@@ -134,6 +135,23 @@
     slots:
     - suitStorage
 
+- type: entity
+  parent: RMCMagazineM2C
+  id: AU14MagazineM2CTracter
+  name: M2C Tracer Ammunition Box (10x28mm tungsten tracer rounds)
+  description: A box of 125, 10x28mm caseless tungsten green tracer rounds for the M2C heavy machine gun system.
+  components:
+  - type: Tag
+    tags:
+    - AU14MagazineM2CTracter
+  - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+      - AU14CartridgeHMG10x28mmTungstenTracer
+    proto: AU14CartridgeHMG10x28mmTungstenTracer
+    capacity: 125
+    deleteWhenEmpty: false
+
 # Cartridges
 
 - type: entity
@@ -151,6 +169,17 @@
   - type: Tag
     tags:
     - RMCCartridgeHMG10x28mmTungsten
+
+- type: entity
+  parent: RMCCartridgeHMG10x28mmTungsten
+  id: AU14CartridgeHMG10x28mmTungstenTracer
+  name: cartridge (10x28mm Tungsten Tracer)
+  components:
+  - type: CartridgeAmmo
+    proto: AU14BulletHMG10x28mmTungstenTracer
+  - type: Tag
+    tags:
+    - AU14CartridgeHMG10x28mmTungstenTracer
 
 # Projectiles
 
@@ -183,9 +212,24 @@
     - range: 6 # porting this 1:1, which is what the component mentions, from cm13(10), makes it too accurate at high ranges so I lowered it
       falloff: 5
 
+- type: entity
+  parent: RMCBulletHMG10x28mmTungsten
+  id: AU14BulletHMG10x28mmTungstenTracer
+  name: bullet (10x28mm Tungsten Tracer)
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: PointLight
+    enabled: true
+    color: "#ff4300"
+    radius: 2.0
+    energy: 7.0
+
 # Tags
 - type: Tag
   id: RMCMagazineM2C
+
+- type: Tag
+  id: AU14MagazineM2CTracter
 
 - type: Tag
   id: RMCMachineGunM2C
@@ -193,3 +237,5 @@
 - type: Tag
   id: RMCCartridgeHMG10x28mmTungsten
 
+- type: Tag
+  id: AU14CartridgeHMG10x28mmTungstenTracer

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_mk1_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_mk1_rifle.yml
@@ -66,7 +66,7 @@
           - RMCMagazineRifleM54CMK1Incendiary
           - RMCMagazineRifleM54CMK1HEAP
           - RMCMagazineRifleM54CMK1WP
-          - CMMagazineRifleM54CMK1Tracer
+          - CMMagazineRifleM54CMK1TracerTag
         startingItem: CMMagazineRifleM54CMK1
   - type: GunDamageModifier
     multiplier: 1.1
@@ -125,7 +125,7 @@
           - RMCMagazineRifleM54CMK1Incendiary
           - RMCMagazineRifleM54CMK1HEAP
           - RMCMagazineRifleM54CMK1WP
-          - CMMagazineRifleM54CMK1Tracer
+          - CMMagazineRifleM54CMK1TracerTag
         startingItem: null
 
 - type: entity
@@ -208,7 +208,7 @@
   - type: Tag
     tags:
     - CMMagazineRifle
-    - CMMagazineRifleM54CMK1Tracer
+    - CMMagazineRifleM54CMK1TracerTag
   - type: BallisticAmmoProvider
     whitelist:
       tags:
@@ -322,3 +322,6 @@
 
 - type: Tag
   id: RMCMagazineRifleM54CMK1WP
+
+- type: Tag
+  id: CMMagazineRifleM54CMK1TracerTag

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_mk1_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_mk1_rifle.yml
@@ -66,6 +66,7 @@
           - RMCMagazineRifleM54CMK1Incendiary
           - RMCMagazineRifleM54CMK1HEAP
           - RMCMagazineRifleM54CMK1WP
+          - CMMagazineRifleM54CMK1Tracer
         startingItem: CMMagazineRifleM54CMK1
   - type: GunDamageModifier
     multiplier: 1.1
@@ -124,6 +125,7 @@
           - RMCMagazineRifleM54CMK1Incendiary
           - RMCMagazineRifleM54CMK1HEAP
           - RMCMagazineRifleM54CMK1WP
+          - CMMagazineRifleM54CMK1Tracer
         startingItem: null
 
 - type: entity
@@ -196,6 +198,31 @@
       color: "#1F951F"
   - type: RefillableByBulletBox
     bulletType: RMCBoxBulletsRifleAP
+
+- type: entity
+  parent: CMMagazineRifleM54CMK1
+  id: CMMagazineRifleM54CMK1Tracer
+  name: "M41A MK1 Tracer magazine (10x24mm)"
+  suffix: Tracer
+  components:
+  - type: Tag
+    tags:
+    - CMMagazineRifle
+    - CMMagazineRifleM54CMK1Tracer
+  - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+      - CMCartridgeRifle10x24mmTracer
+    proto: CMCartridgeRifle10x24mmTracer
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Ammunition/Magazines/m54cmk1.rsi
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+    - state: ammo_band
+      color: "#ff4300"
 
 - type: entity
   parent: CMMagazineRifleM54CMK1

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_rifle.yml
@@ -572,6 +572,19 @@
 
 - type: entity
   parent: CMCartridgeRifle10x24mm
+  id: CMCartridgeRifle10x24mmTracer
+  name: tracer cartridge (10x24mm)
+  description: An tracer 10x24mm cartridge. Fits in 10x24mm tracer magazines.
+  components:
+  - type: Tag
+    tags:
+    - Cartridge
+    - CMCartridgeRifle10x24mmTracer
+  - type: CartridgeAmmo
+    proto: BulletRifle10x24mmTracer
+
+- type: entity
+  parent: CMCartridgeRifle10x24mm
   id: RMCCartridgeRifle10x24mmIncendiary
   name: AP cartridge (10x24mm)
   description: An armor piercing 10x24mm cartridge. Fits in 10x24mm AP magazines.
@@ -693,6 +706,35 @@
   - type: CMArmorPiercing
     amount: 40
 
+- type: entity
+  parent: RMCBaseBullet
+  id: BulletRifle10x24mmTracer
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 40
+  - type: RMCProjectileDamageFalloff
+    thresholds:
+    - range: 24
+      falloff: 9999
+      ignoreModifiers: true
+    - range: 7
+      falloff: 4
+  - type: PointLight
+    enabled: true
+    color: "#ff4300"
+    radius: 2.0
+    energy: 7.0
+  - type: CMArmorPiercing
+    amount: 5
+  - type: RMCProjectileAccuracy
+    accuracy: 103
+    thresholds:
+    - range: 16
+      falloff: 10
+
 - type: Tag
   id: RMCWeaponRifleM54CMK2
 
@@ -719,6 +761,9 @@
 
 - type: Tag
   id: CMCartridgeRifle10x24mmAP
+
+- type: Tag
+  id: CMCartridgeRifle10x24mmTracer
 
 - type: Tag
   id: RMCCartridgeRifle10x24mmIncendiary


### PR DESCRIPTION
- Tracer magazines added for the Mk1 and M2C.
- AP rocket price increased.
- HAZOPs req can get MK2s.
- Equipment vendors buffed to start with 5 sandbag stacks and four barbed wire.
- Essential CT kits now have an engineering kit, wood and full versions of material stacks.
- Modified blowtorch description fixed.

**Changelog**
:cl:
- add: Tracer magazines for the M41A Mk1 and M2C.
- add: HAZOPs can now get MK2 from req.
- fix: AP rockets are no longer free.
- fix: Modified blowtorch description fixed/loreified.
- tweak: Equipment vendors now start with five sandbags and four barbed wire as opposed to one.
- tweak: CT essential kits now have an engineering kit, a stack of wood and full versions of the material stacks.