### PR TITLE
Fix colony physician spawning with an extra ID

### DIFF
--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyphysician.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyphysician.yml
@@ -45,8 +45,6 @@
 
 - type: startingGear
   id: AU14GearCivilianPhysician
-  equipment:
-    id: AU14IDCardColonyPhysician
 
 - type: entity
   parent: CMSpawnPointJobBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
No longer spawns with an ID on the floor.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's annoying and weird.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed an erroneous extra line in the yml.
They get an ID from the loadout is why this is a problem, afaik.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Colony Physician no longer gets a spare ID.
