### PR TITLE
Some Xeno Buffs plus fixes

### DIFF
--- a/Content.Client/Eye/Blinding/BlurryVisionOverlay.cs
+++ b/Content.Client/Eye/Blinding/BlurryVisionOverlay.cs
@@ -1,6 +1,8 @@
 using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Content.Shared.CCVar;
+using Robust.Shared.Maths;
+using Robust.Shared.Timing;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
 using Content.Shared.Eye.Blinding.Components;
@@ -22,11 +24,15 @@ namespace Content.Client.Eye.Blinding
         public override OverlaySpace Space => OverlaySpace.WorldSpace;
         private readonly ShaderInstance _cataractsShader;
         private readonly ShaderInstance _circleMaskShader;
-        private float _magnitude;
+        private float _currentMagnitude;
         private float _correctionPower = 2.0f;
-
-        private const float Distortion_Pow = 2.0f; // Exponent for the distortion effect
+        private float _distortionPower = 2.0f;
         private const float Cloudiness_Pow = 1.0f; // Exponent for the cloudiness effect
+
+        public void Reset()
+        {
+            _currentMagnitude = 0f;
+        }
 
         private const float NoMotion_Radius = 30.0f; // Base radius for the nomotion variant at its full strength
         private const float NoMotion_Pow = 0.2f; // Exponent for the nomotion variant's gradient
@@ -45,6 +51,30 @@ namespace Content.Client.Eye.Blinding
             _circleMaskShader.SetParameter("CircleMult", NoMotion_Mult);
         }
 
+        protected override void FrameUpdate(FrameEventArgs args)
+        {
+            var playerEntity = _playerManager.LocalSession?.AttachedEntity;
+            var targetMagnitude = 0f;
+
+            if (playerEntity != null
+                && _entityManager.TryGetComponent<BlurryVisionComponent>(playerEntity.Value, out var blurComp)
+                && (!_entityManager.TryGetComponent<BlindableComponent>(playerEntity.Value, out var blindComp) || !blindComp.IsBlind))
+            {
+                targetMagnitude = blurComp.Magnitude;
+                _correctionPower = blurComp.CorrectionPower;
+                _distortionPower = blurComp.DistortionPower;
+            }
+
+            if (!MathHelper.CloseTo(_currentMagnitude, targetMagnitude, 0.001f))
+            {
+                _currentMagnitude += (targetMagnitude - _currentMagnitude) * 5f * args.DeltaSeconds;
+            }
+            else
+            {
+                _currentMagnitude = targetMagnitude;
+            }
+        }
+
         protected override bool BeforeDraw(in OverlayDrawArgs args)
         {
             if (!_entityManager.TryGetComponent(_playerManager.LocalSession?.AttachedEntity, out EyeComponent? eyeComp))
@@ -53,24 +83,7 @@ namespace Content.Client.Eye.Blinding
             if (args.Viewport.Eye != eyeComp.Eye)
                 return false;
 
-            var playerEntity = _playerManager.LocalSession?.AttachedEntity;
-
-            if (playerEntity == null)
-                return false;
-
-            if (!_entityManager.TryGetComponent<BlurryVisionComponent>(playerEntity, out var blurComp))
-                return false;
-
-            if (blurComp.Magnitude <= 0)
-                return false;
-
-            if (_entityManager.TryGetComponent<BlindableComponent>(playerEntity, out var blindComp)
-                && blindComp.IsBlind)
-                return false;
-
-            _magnitude = blurComp.Magnitude;
-            _correctionPower = blurComp.CorrectionPower;
-            return true;
+            return _currentMagnitude > 0.01f;
         }
 
         protected override void Draw(in OverlayDrawArgs args)
@@ -82,7 +95,7 @@ namespace Content.Client.Eye.Blinding
 
             var worldHandle = args.WorldHandle;
             var viewport = args.WorldBounds;
-            var strength = (float) Math.Pow(Math.Min(_magnitude / BlurryVisionComponent.MaxMagnitude, 1.0f), _correctionPower);
+            var strength = (float) Math.Pow(Math.Min(_currentMagnitude / BlurryVisionComponent.MaxMagnitude, 1.0f), _correctionPower);
 
             var zoom = 1.0f;
             if (_entityManager.TryGetComponent<EyeComponent>(playerEntity, out var eyeComponent))
@@ -109,7 +122,7 @@ namespace Content.Client.Eye.Blinding
 
             _cataractsShader.SetParameter("Zoom", zoom);
 
-            _cataractsShader.SetParameter("DistortionScalar", (float) Math.Pow(strength, Distortion_Pow));
+            _cataractsShader.SetParameter("DistortionScalar", (float) Math.Pow(strength, _distortionPower));
             _cataractsShader.SetParameter("CloudinessScalar", (float) Math.Pow(strength, Cloudiness_Pow));
 
             worldHandle.UseShader(_cataractsShader);

--- a/Content.Client/Eye/Blinding/BlurryVisionSystem.cs
+++ b/Content.Client/Eye/Blinding/BlurryVisionSystem.cs
@@ -26,18 +26,23 @@ public sealed partial class BlurryVisionSystem : EntitySystem
 
     private void OnPlayerAttached(EntityUid uid, BlurryVisionComponent component, LocalPlayerAttachedEvent args)
     {
+        _overlay.Reset();
         _overlayMan.AddOverlay(_overlay);
     }
 
     private void OnPlayerDetached(EntityUid uid, BlurryVisionComponent component, LocalPlayerDetachedEvent args)
     {
         _overlayMan.RemoveOverlay(_overlay);
+        _overlay.Reset();
     }
 
     private void OnBlurryInit(EntityUid uid, BlurryVisionComponent component, ComponentInit args)
     {
         if (_player.LocalEntity == uid)
+        {
+            _overlay.Reset();
             _overlayMan.AddOverlay(_overlay);
+        }
     }
 
     private void OnBlurryShutdown(EntityUid uid, BlurryVisionComponent component, ComponentShutdown args)
@@ -45,6 +50,7 @@ public sealed partial class BlurryVisionSystem : EntitySystem
         if (_player.LocalEntity == uid)
         {
             _overlayMan.RemoveOverlay(_overlay);
+            _overlay.Reset();
         }
     }
 }

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -5,6 +5,7 @@ using Content.Client.Cooldown;
 using Content.Client.Stylesheets;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
+using Content.Shared._RMC14.Xenonids.Construction;
 using Content.Shared.Charges.Components;
 using Content.Shared.Charges.Systems;
 using Robust.Client.GameObjects;
@@ -55,6 +56,7 @@ public sealed class ActionButton : Control, IEntityControl
     public readonly CooldownGraphic Cooldown;
     private readonly SpriteView _smallItemSpriteView;
     private readonly SpriteView _bigItemSpriteView;
+    private readonly Label _counterLabel;
 
     private Texture? _buttonBackgroundTexture;
 
@@ -108,6 +110,14 @@ public sealed class ActionButton : Control, IEntityControl
             VerticalAlignment = VAlignment.Top,
             Margin = new Thickness(5, 0, 0, 0)
         };
+        _counterLabel = new Label
+        {
+            Name = "CounterLabel",
+            HorizontalAlignment = HAlignment.Right,
+            VerticalAlignment = VAlignment.Bottom,
+            Margin = new Thickness(0, 0, 5, 3),
+            Visible = false,
+        };
         _bigItemSpriteView = new SpriteView
         {
             Name = "Big Sprite",
@@ -153,6 +163,7 @@ public sealed class ActionButton : Control, IEntityControl
         AddChild(_bigItemSpriteView);
         AddChild(HighlightRect);
         AddChild(Label);
+        AddChild(_counterLabel);
         AddChild(Cooldown);
         AddChild(paddingBoxItemIcon);
 
@@ -171,6 +182,7 @@ public sealed class ActionButton : Control, IEntityControl
         base.OnThemeUpdated();
         _buttonBackgroundTexture = Theme.ResolveTexture("SlotBackground");
         Label.FontColorOverride = Theme.ResolveColorOrSpecified("whiteText");
+        _counterLabel.FontColorOverride = Theme.ResolveColorOrSpecified("whiteText");
     }
 
     private void OnPressed(GUIBoundKeyEventArgs args)
@@ -357,6 +369,7 @@ public sealed class ActionButton : Control, IEntityControl
         Action = system.GetAction(actionId);
 
         Label.Visible = Action != null;
+        UpdateCounterLabel();
         UpdateIcons();
     }
 
@@ -366,6 +379,7 @@ public sealed class ActionButton : Control, IEntityControl
         Cooldown.Visible = false;
         Cooldown.Progress = 1;
         Label.Visible = false;
+        _counterLabel.Visible = false;
         UpdateIcons();
     }
 
@@ -379,11 +393,27 @@ public sealed class ActionButton : Control, IEntityControl
         if (Action?.Comp is not {} action)
             return;
 
+        UpdateCounterLabel();
+
         if (action.Cooldown is {} cooldown)
             Cooldown.FromTime(cooldown.Start, cooldown.End);
 
         if (_toggled != action.Toggled)
             _toggled = action.Toggled;
+    }
+
+    private void UpdateCounterLabel()
+    {
+        if (Action is not { } action ||
+            !_entities.TryGetComponent(action, out XenoHiveInstantBuildActionComponent? counter) ||
+            !counter.Visible)
+        {
+            _counterLabel.Visible = false;
+            return;
+        }
+
+        _counterLabel.Text = counter.BuildsLeft.ToString();
+        _counterLabel.Visible = true;
     }
 
     protected override void MouseEntered()

--- a/Content.IntegrationTests/_CMU14/Medical/ConditionDrivenSurgeryTest.cs
+++ b/Content.IntegrationTests/_CMU14/Medical/ConditionDrivenSurgeryTest.cs
@@ -25,8 +25,10 @@ using Content.Shared._RMC14.Medical.Wounds;
 using Content.Shared.Body.Organ;
 using Content.Shared.Body.Part;
 using Content.Shared.Body.Systems;
+using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.StatusEffectNew;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 
@@ -912,6 +914,111 @@ public sealed class ConditionDrivenSurgeryTest
                 BodyPartType.Head,
                 BodyPartSymmetry.None,
                 "hemostat");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task RepairingFailingStoppedHeartEndsCardiacArrestTicks()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        EntityUid human = default;
+        EntityUid surgeon = default;
+        EntityUid torso = default;
+        EntityUid heart = default;
+        FixedPoint2 damageAfterRepair = default;
+
+        await server.WaitPost(() =>
+        {
+            var entMan = server.EntMan;
+            var organHealth = entMan.System<SharedOrganHealthSystem>();
+            var traits = entMan.System<SharedCMUSurgicalTraitSystem>();
+
+            human = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            surgeon = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            entMan.EnsureComponent<BypassSkillChecksComponent>(surgeon);
+            entMan.EnsureComponent<CMUAutodocContainedPatientComponent>(human);
+
+            torso = GetBodyPart(entMan, human, BodyPartType.Torso, BodyPartSymmetry.None);
+            OpenBoneCavity(entMan, torso);
+            ClearSurgicalTraits(traits, torso);
+
+            heart = GetPartOrgan<HeartComponent>(entMan, torso);
+            var health = entMan.GetComponent<OrganHealthComponent>(heart);
+            SetPublicField(health, nameof(OrganHealthComponent.Current), FixedPoint2.New(8));
+            organHealth.RecomputeStage((heart, health), human);
+
+            var heartComp = entMan.GetComponent<HeartComponent>(heart);
+            SetPublicField(heartComp, nameof(HeartComponent.StopGracePeriod), TimeSpan.Zero);
+
+            Assert.That(health.Stage, Is.EqualTo(OrganDamageStage.Failing));
+        });
+
+        await pair.RunSeconds(8);
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var status = entMan.System<SharedStatusEffectsSystem>();
+            var heartComp = entMan.GetComponent<HeartComponent>(heart);
+            var damage = entMan.GetComponent<DamageableComponent>(human);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(heartComp.Stopped, Is.True);
+                Assert.That(status.HasStatusEffect(human, "StatusEffectCMUCardiacArrest"), Is.True);
+                Assert.That(damage.TotalDamage, Is.GreaterThan(FixedPoint2.Zero));
+            });
+        });
+
+        await server.WaitPost(() =>
+        {
+            var entMan = server.EntMan;
+            var flow = entMan.System<CMUSurgeryFlowSystem>();
+            var traits = entMan.System<SharedCMUSurgicalTraitSystem>();
+            ClearSurgicalTraits(traits, torso);
+
+            var armed = ArmStep(
+                flow,
+                surgeon,
+                human,
+                torso,
+                "CMUSurgeryRepairHeart",
+                BodyPartType.Torso,
+                BodyPartSymmetry.None,
+                "CMUSurgeryRepairHeart");
+
+            armed = CompleteExpectedStep(entMan, flow, human, surgeon, armed, "organ_clamp", "CMUSurgeryRepairHeart")!;
+            CompleteExpectedStep(entMan, flow, human, surgeon, armed, "hemostat", "CMUSurgeryRepairHeart");
+            AssertAwaitingClosure(entMan, human, torso, "CMUSurgeryRepairHeart");
+
+            damageAfterRepair = entMan.GetComponent<DamageableComponent>(human).TotalDamage;
+
+            var heartComp = entMan.GetComponent<HeartComponent>(heart);
+            var health = entMan.GetComponent<OrganHealthComponent>(heart);
+            var status = entMan.System<SharedStatusEffectsSystem>();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(health.Stage, Is.EqualTo(OrganDamageStage.Healthy));
+                Assert.That(heartComp.Stopped, Is.False);
+                Assert.That(status.HasStatusEffect(human, "StatusEffectCMUCardiacArrest"), Is.False);
+            });
+        });
+
+        await pair.RunSeconds(3);
+
+        await server.WaitPost(() =>
+        {
+            var entMan = server.EntMan;
+            var damage = entMan.GetComponent<DamageableComponent>(human);
+
+            Assert.That(damage.TotalDamage, Is.LessThanOrEqualTo(damageAfterRepair));
+
+            entMan.DeleteEntity(human);
+            entMan.DeleteEntity(surgeon);
         });
 
         await pair.CleanReturnAsync();

--- a/Content.IntegrationTests/_CMU14/Medical/PainPlayerFeedbackTest.cs
+++ b/Content.IntegrationTests/_CMU14/Medical/PainPlayerFeedbackTest.cs
@@ -1,0 +1,370 @@
+using Content.Shared._CMU14.Medical.StatusEffects;
+using Content.Shared._CMU14.Medical.TemporaryBlurryVision;
+using Content.Shared.Chat.Prototypes;
+using Content.Shared.Damage;
+using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.FixedPoint;
+using Content.Shared.StatusEffect;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests._CMU14.Medical;
+
+[TestFixture]
+public sealed class PainPlayerFeedbackTest
+{
+    [Test]
+    public async Task SeverePainAppliesPlayerFacingFeedback()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        EntityUid human = default;
+
+        await server.WaitPost(() =>
+        {
+            var entMan = server.EntMan;
+            human = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            SetPainTier(entMan, human, PainTier.Severe);
+        });
+
+        await pair.RunTicksSync(pair.SecondsToTicks(2));
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var oldStatus = entMan.System<StatusEffectQuerySystem>();
+            var prototypes = server.ResolveDependency<IPrototypeManager>();
+            var feedback = entMan.GetComponent<CMUPainFeedbackComponent>(human);
+            var damageable = entMan.GetComponent<DamageableComponent>(human);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(oldStatus.HasStatusEffect(human, "Stutter"), Is.True);
+                Assert.That(oldStatus.HasStatusEffect(human, "Drunk"), Is.True);
+                Assert.That(oldStatus.HasStatusEffect(human, "SlurredSpeech"), Is.False);
+                Assert.That(entMan.HasComponent<BlurryVisionComponent>(human), Is.True);
+                Assert.That(entMan.GetComponent<BlurryVisionComponent>(human).Magnitude,
+                    Is.EqualTo(feedback.SevereBlurStartAmount));
+                Assert.That(feedback.SevereBlurStartAmount,
+                    Is.LessThanOrEqualTo(0.2f),
+                    "Severe pain should start the cataracts barely visible instead of snapping to the full severe amount.");
+                Assert.That(damageable.Damage.DamageDict["Asphyxiation"], Is.GreaterThan(FixedPoint2.Zero));
+                AssertPainEmotesExist(prototypes, feedback);
+            });
+
+            entMan.DeleteEntity(human);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task TemporaryPainBlurExpiresWhenNotRefreshed()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        EntityUid human = default;
+
+        await server.WaitPost(() =>
+        {
+            var entMan = server.EntMan;
+            human = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            entMan.System<CMUTemporaryBlurryVisionSystem>()
+                .AddTemporaryBlurModifier(human, TimeSpan.FromSeconds(1), 2);
+        });
+
+        await pair.RunTicksSync(1);
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            Assert.That(entMan.GetComponent<BlurryVisionComponent>(human).Magnitude, Is.EqualTo(2));
+        });
+
+        await pair.RunTicksSync(pair.SecondsToTicks(2));
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(server.EntMan.HasComponent<BlurryVisionComponent>(human), Is.False);
+            server.EntMan.DeleteEntity(human);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task TemporaryPainBlurBypassesEyeDamageDelay()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        EntityUid human = default;
+
+        await server.WaitPost(() =>
+        {
+            var entMan = server.EntMan;
+            human = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            entMan.System<BlindableSystem>().AdjustEyeDamage(human, 5);
+            entMan.System<CMUTemporaryBlurryVisionSystem>()
+                .AddTemporaryBlurModifier(human, TimeSpan.FromSeconds(10), 2);
+        });
+
+        await pair.RunTicksSync(1);
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            Assert.That(entMan.GetComponent<BlurryVisionComponent>(human).Magnitude, Is.EqualTo(2));
+            entMan.DeleteEntity(human);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ModeratePainDoesNotApplyPlayerFacingFeedback()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        EntityUid human = default;
+
+        await server.WaitPost(() =>
+        {
+            var entMan = server.EntMan;
+            human = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            SetPainTier(entMan, human, PainTier.Moderate);
+        });
+
+        await pair.RunTicksSync(pair.SecondsToTicks(2));
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var oldStatus = entMan.System<StatusEffectQuerySystem>();
+            var damageable = entMan.GetComponent<DamageableComponent>(human);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(oldStatus.HasStatusEffect(human, "Stutter"), Is.False);
+                Assert.That(oldStatus.HasStatusEffect(human, "Drunk"), Is.False);
+                Assert.That(oldStatus.HasStatusEffect(human, "SlurredSpeech"), Is.False);
+                Assert.That(entMan.HasComponent<BlurryVisionComponent>(human), Is.True);
+                Assert.That(entMan.GetComponent<BlurryVisionComponent>(human).Magnitude, Is.EqualTo(0.02f).Within(0.001f));
+                Assert.That(damageable.Damage.DamageDict["Asphyxiation"], Is.EqualTo(FixedPoint2.Zero));
+            });
+
+            entMan.DeleteEntity(human);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task PainBlurInterpolatesAfterSevereThreshold()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        EntityUid human = default;
+
+        await server.WaitPost(() =>
+        {
+            var entMan = server.EntMan;
+            human = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            SetPainValue(entMan, human, (FixedPoint2)61);
+        });
+
+        await pair.RunTicksSync(pair.SecondsToTicks(2));
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var feedback = entMan.GetComponent<CMUPainFeedbackComponent>(human);
+            var blur = entMan.GetComponent<BlurryVisionComponent>(human).Magnitude;
+            const float expectedProgress = (61f - 60f) / (85f - 60f);
+            var expected = feedback.SevereBlurStartAmount +
+                (feedback.ShockBlurStartAmount - feedback.SevereBlurStartAmount) * expectedProgress;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(blur, Is.EqualTo(expected).Within(0.01f));
+                Assert.That(blur, Is.GreaterThan(feedback.SevereBlurStartAmount));
+                Assert.That(blur, Is.LessThan(0.2f));
+            });
+
+            entMan.DeleteEntity(human);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task PainBlurInterpolatesAfterShockThreshold()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        EntityUid human = default;
+
+        await server.WaitPost(() =>
+        {
+            var entMan = server.EntMan;
+            human = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            SetPainValue(entMan, human, (FixedPoint2)90);
+        });
+
+        await pair.RunTicksSync(pair.SecondsToTicks(2));
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var feedback = entMan.GetComponent<CMUPainFeedbackComponent>(human);
+            var blur = entMan.GetComponent<BlurryVisionComponent>(human).Magnitude;
+            const float expectedProgress = (90f - 85f) / (95f - 85f);
+            var expected = feedback.ShockBlurStartAmount +
+                (feedback.ShockBlurAmount - feedback.ShockBlurStartAmount) * expectedProgress;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(blur, Is.EqualTo(expected).Within(0.01f));
+                Assert.That(blur, Is.GreaterThan(feedback.ShockBlurStartAmount));
+                Assert.That(blur, Is.LessThan(feedback.ShockBlurAmount));
+            });
+
+            entMan.DeleteEntity(human);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task PainSuppressionLoweringEffectiveTierPreventsFeedback()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        EntityUid human = default;
+
+        await server.WaitPost(() =>
+        {
+            var entMan = server.EntMan;
+            human = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            var pain = entMan.GetComponent<PainShockComponent>(human);
+            SetPainState(entMan, human, pain, PainTier.Shock);
+            entMan.System<SharedPainShockSystem>()
+                .AddPainSuppressionProfile(human, 0f, 4, 0f, TimeSpan.FromSeconds(10));
+        });
+
+        await pair.RunTicksSync(pair.SecondsToTicks(2));
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var oldStatus = entMan.System<StatusEffectQuerySystem>();
+            var damageable = entMan.GetComponent<DamageableComponent>(human);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(oldStatus.HasStatusEffect(human, "Stutter"), Is.False);
+                Assert.That(oldStatus.HasStatusEffect(human, "Drunk"), Is.False);
+                Assert.That(oldStatus.HasStatusEffect(human, "SlurredSpeech"), Is.False);
+                Assert.That(entMan.HasComponent<BlurryVisionComponent>(human), Is.False);
+                Assert.That(damageable.Damage.DamageDict["Asphyxiation"], Is.EqualTo(FixedPoint2.Zero));
+            });
+
+            entMan.DeleteEntity(human);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ShockPainAppliesStrongerBreathingPressureThanSeverePain()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        EntityUid severe = default;
+        EntityUid shock = default;
+
+        await server.WaitPost(() =>
+        {
+            var entMan = server.EntMan;
+            severe = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            shock = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            SetPainTier(entMan, severe, PainTier.Severe);
+            SetPainTier(entMan, shock, PainTier.Shock);
+        });
+
+        await pair.RunTicksSync(pair.SecondsToTicks(2));
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var oldStatus = entMan.System<StatusEffectQuerySystem>();
+            var severeDamage = entMan.GetComponent<DamageableComponent>(severe).Damage.DamageDict["Asphyxiation"];
+            var shockDamage = entMan.GetComponent<DamageableComponent>(shock).Damage.DamageDict["Asphyxiation"];
+            var severeBlur = entMan.GetComponent<BlurryVisionComponent>(severe).Magnitude;
+            var shockBlur = entMan.GetComponent<BlurryVisionComponent>(shock).Magnitude;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(shockDamage, Is.GreaterThan(severeDamage));
+                Assert.That(oldStatus.TryGetTime(severe, "Drunk", out var severeDrunkTime), Is.True);
+                Assert.That(oldStatus.TryGetTime(shock, "Drunk", out var shockDrunkTime), Is.True);
+                Assert.That(shockDrunkTime!.Value.Item2, Is.GreaterThan(severeDrunkTime!.Value.Item2));
+                Assert.That(oldStatus.HasStatusEffect(shock, "SlurredSpeech"), Is.True);
+                Assert.That(oldStatus.HasStatusEffect(shock, "Stutter"), Is.True);
+                Assert.That(shockBlur, Is.GreaterThan(severeBlur));
+                Assert.That(shockBlur, Is.LessThan(BlurryVisionComponent.MaxMagnitude),
+                    "Pain shock should get bad without snapping to the full cataracts/off-white screen effect.");
+            });
+
+            entMan.DeleteEntity(severe);
+            entMan.DeleteEntity(shock);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    private static void SetPainTier(IEntityManager entMan, EntityUid uid, PainTier tier)
+    {
+        var pain = entMan.GetComponent<PainShockComponent>(uid);
+        SetPainState(entMan, uid, pain, tier);
+        entMan.Dirty(uid, pain);
+    }
+
+    private static void SetPainValue(IEntityManager entMan, EntityUid uid, FixedPoint2 painValue)
+    {
+        var pain = entMan.GetComponent<PainShockComponent>(uid);
+        pain.Pain = painValue;
+        pain.PainTarget = pain.Pain;
+        pain.NextUpdate = TimeSpan.Zero;
+        entMan.System<SharedPainShockSystem>().TickOne((uid, pain), refreshCache: false);
+        entMan.Dirty(uid, pain);
+    }
+
+    private static void SetPainState(IEntityManager entMan, EntityUid uid, PainShockComponent pain, PainTier tier)
+    {
+        pain.Pain = tier switch
+        {
+            PainTier.None => FixedPoint2.Zero,
+            PainTier.Mild => PainTierThresholds.UpwardThresholds[0],
+            PainTier.Moderate => PainTierThresholds.UpwardThresholds[1],
+            PainTier.Severe => PainTierThresholds.UpwardThresholds[2],
+            PainTier.Shock => pain.PainMax,
+            _ => FixedPoint2.Zero,
+        };
+
+        pain.PainTarget = pain.Pain;
+        pain.NextUpdate = TimeSpan.Zero;
+        entMan.System<SharedPainShockSystem>().TickOne((uid, pain), refreshCache: false);
+        entMan.Dirty(uid, pain);
+    }
+
+    private static void AssertPainEmotesExist(IPrototypeManager prototypes, CMUPainFeedbackComponent feedback)
+    {
+        foreach (var emote in feedback.SevereEmotes)
+            Assert.That(prototypes.HasIndex<EmotePrototype>(emote), Is.True, $"{emote} must exist");
+
+        foreach (var emote in feedback.ShockEmotes)
+            Assert.That(prototypes.HasIndex<EmotePrototype>(emote), Is.True, $"{emote} must exist");
+    }
+}

--- a/Content.IntegrationTests/_CMU14/Medical/PainShockReworkTest.cs
+++ b/Content.IntegrationTests/_CMU14/Medical/PainShockReworkTest.cs
@@ -1,5 +1,6 @@
 using Content.Shared._CMU14.Medical;
 using Content.Shared._CMU14.Medical.Bones;
+using Content.Shared._CMU14.Medical.EntityEffects;
 using Content.Shared._CMU14.Medical.Organs;
 using Content.Shared._CMU14.Medical.Organs.Heart;
 using Content.Shared._CMU14.Medical.Organs.Lungs;
@@ -10,13 +11,19 @@ using Content.Shared._CMU14.Medical.StatusEffects;
 using Content.Shared._CMU14.Medical.Wounds;
 using Content.Shared._RMC14.Medical.Wounds;
 using Content.Shared.Body.Part;
+using Content.Shared.Body.Prototypes;
 using Content.Shared.Body.Systems;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.EntityEffects;
+using Content.Shared.EntityEffects.EffectConditions;
+using Content.Shared.EntityEffects.Effects;
 using Content.Shared.FixedPoint;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Verbs;
 using Content.Server.Verbs;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -438,6 +445,102 @@ public sealed class PainShockReworkTest
         await pair.CleanReturnAsync();
     }
 
+    [Test]
+    public async Task DrugPainSuppressionWeakensAsPainRises()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var painSystem = entMan.System<SharedPainShockSystem>();
+            var human = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+
+            try
+            {
+                var pain = entMan.EnsureComponent<PainShockComponent>(human);
+                pain.Pain = 90;
+                pain.PainTarget = 90;
+                pain.CachedRiseRate = 0;
+
+                painSystem.AddPainSuppressionProfile(
+                    human,
+                    0.75f,
+                    4,
+                    1.25f,
+                    TimeSpan.FromSeconds(30),
+                    reductionDecreaseRate: 0.25f);
+                painSystem.RefreshTier(human);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(pain.RawTier, Is.EqualTo(PainTier.Shock));
+                    Assert.That(painSystem.GetTierSuppression(human), Is.EqualTo(3));
+                    Assert.That(pain.Tier, Is.EqualTo(PainTier.Mild));
+                    Assert.That(painSystem.GetAccumulationSuppression(human), Is.LessThan(0.75f));
+                    Assert.That(painSystem.GetDecayBonus(human), Is.LessThan(1.25f));
+                });
+            }
+            finally
+            {
+                entMan.DeleteEntity(human);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task StrongPainkillerOverdosesApplyDrunkenness()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var prototypes = server.ResolveDependency<IPrototypeManager>();
+
+            AssertPainkillerHasDrunkOverdoseEffect(
+                prototypes.Index<ReagentPrototype>("CMUTramadol"),
+                FixedPoint2.New(30));
+
+            AssertPainkillerHasDrunkOverdoseEffect(
+                prototypes.Index<ReagentPrototype>("CMUOxycodone"),
+                FixedPoint2.New(20));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task EpinephrineAndInaprovalineReducePain()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var prototypes = server.ResolveDependency<IPrototypeManager>();
+            var epinephrine = AssertReagentHasPainSuppression(
+                prototypes.Index<ReagentPrototype>("CMEpinephrine"),
+                1);
+            var inaprovaline = AssertReagentHasPainSuppression(
+                prototypes.Index<ReagentPrototype>("CMInaprovaline"),
+                2);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(epinephrine.Additive, Is.True);
+                Assert.That(inaprovaline.Additive, Is.True);
+                Assert.That(inaprovaline.TierSuppression, Is.GreaterThan(epinephrine.TierSuppression));
+                Assert.That(inaprovaline.DecayBonus, Is.GreaterThan(epinephrine.DecayBonus));
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
     private static EntityUid GetFirstPart(IEntityManager entMan, EntityUid bodyUid)
     {
         var body = entMan.System<SharedBodySystem>();
@@ -529,6 +632,59 @@ public sealed class PainShockReworkTest
         foreach (var verb in verbs)
         {
             if (verb.Text == text)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static void AssertPainkillerHasDrunkOverdoseEffect(ReagentPrototype reagent, FixedPoint2 min)
+    {
+        var metabolism = reagent.Metabolisms![new ProtoId<MetabolismGroupPrototype>("Medicine")];
+        foreach (var effect in metabolism.Effects)
+        {
+            if (effect is not Drunk drunk || !drunk.SlurSpeech)
+                continue;
+
+            if (HasReagentThreshold(effect, min))
+                return;
+        }
+
+        Assert.Fail($"{reagent.ID} must apply drunkenness at overdose threshold {min}.");
+    }
+
+    private static CMUApplyPainSuppressionEffect AssertReagentHasPainSuppression(
+        ReagentPrototype reagent,
+        int minTierSuppression)
+    {
+        var metabolism = reagent.Metabolisms![new ProtoId<MetabolismGroupPrototype>("Medicine")];
+        foreach (var effect in metabolism.Effects)
+        {
+            if (effect is not CMUApplyPainSuppressionEffect suppression)
+                continue;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(suppression.TierSuppression, Is.GreaterThanOrEqualTo(minTierSuppression));
+                Assert.That(suppression.DurationPerUnit, Is.GreaterThan(0f));
+                Assert.That(suppression.ReductionDecreaseRate, Is.EqualTo(0f));
+            });
+
+            return suppression;
+        }
+
+        Assert.Fail($"{reagent.ID} must apply CMU pain suppression.");
+        return default!;
+    }
+
+    private static bool HasReagentThreshold(EntityEffect effect, FixedPoint2 min)
+    {
+        if (effect.Conditions == null)
+            return false;
+
+        foreach (var condition in effect.Conditions)
+        {
+            if (condition is ReagentThreshold threshold && threshold.Min == min)
                 return true;
         }
 

--- a/Content.IntegrationTests/_RMC14/LarvaQueueDialogTest.cs
+++ b/Content.IntegrationTests/_RMC14/LarvaQueueDialogTest.cs
@@ -227,6 +227,61 @@ public sealed class LarvaQueueJoinXenoUiTest
     }
 
     [Test]
+    public async Task LarvaQueueOffersGhostedLesserDroneWhenNoLarvaAvailable()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = true,
+            Dirty = true,
+            DummyTicker = false,
+        });
+
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        var entMan = server.EntMan;
+        var hiveSystem = entMan.System<SharedXenoHiveSystem>();
+        var mind = entMan.System<MindSystem>();
+        var player = server.PlayerMan.Sessions.Single();
+
+        EntityUid ghost = default;
+        EntityUid hive = default;
+        EntityUid lesser = default;
+        NetEntity ghostNet = default;
+        string lesserName = string.Empty;
+        await server.WaitAssertion(() =>
+        {
+            ghost = entMan.SpawnEntity(GameTicker.ObserverPrototypeName, map.GridCoords);
+            BypassRoundstartDelay(entMan, ghost);
+            hive = entMan.SpawnEntity("CMXenoHive", map.GridCoords.Offset(new Vector2(1, 0)));
+            lesser = entMan.SpawnEntity("CMXenoLesserDrone", map.GridCoords.Offset(new Vector2(2, 0)));
+            hiveSystem.SetHive(lesser, hive);
+            lesserName = entMan.GetComponent<MetaDataComponent>(lesser).EntityName;
+
+            var mindId = mind.CreateMind(player.UserId, "Lesser Drone");
+            mind.TransferTo(mindId, lesser);
+            mind.TransferTo(mindId, ghost);
+            mind.SetUserId(mindId, player.UserId);
+            ghostNet = entMan.GetNetEntity(ghost);
+
+            entMan.EventBus.RaiseLocalEvent(ghost, new JoinLarvaQueueEvent(entMan.GetNetEntity(hive)));
+        });
+
+        await pair.RunTicksSync(5);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(player.AttachedEntity, Is.EqualTo(ghost));
+            AssertConfirmDialog(entMan, ghost, lesserName);
+        });
+
+        await DeclineDialog(pair, ghostNet);
+        await pair.RunTicksSync(5);
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
     public async Task LarvaQueueDoesNotOfferGhostedLesserXeno()
     {
         await using var pair = await PoolManager.GetServerClient(new PoolSettings
@@ -1000,6 +1055,16 @@ public sealed class LarvaQueueJoinXenoUiTest
 
     private static async Task ConfirmDialog(TestPair pair, NetEntity ghostNet)
     {
+        await ChooseDialogOption(pair, ghostNet, 0);
+    }
+
+    private static async Task DeclineDialog(TestPair pair, NetEntity ghostNet)
+    {
+        await ChooseDialogOption(pair, ghostNet, 1);
+    }
+
+    private static async Task ChooseDialogOption(TestPair pair, NetEntity ghostNet, int option)
+    {
         await pair.Client.WaitAssertion(() =>
         {
             var clientEntMan = pair.Client.EntMan;
@@ -1013,7 +1078,7 @@ public sealed class LarvaQueueJoinXenoUiTest
             var clientEntMan = pair.Client.EntMan;
             var clientGhost = clientEntMan.GetEntity(ghostNet);
             var ui = clientEntMan.GetComponent<UserInterfaceComponent>(clientGhost);
-            ui.ClientOpenInterfaces[DialogUiKey.Key].SendPredictedMessage(new DialogOptionBuiMsg(0));
+            ui.ClientOpenInterfaces[DialogUiKey.Key].SendPredictedMessage(new DialogOptionBuiMsg(option));
         });
     }
 

--- a/Content.IntegrationTests/_RMC14/RMCFlamerPrototypeRegressionTest.cs
+++ b/Content.IntegrationTests/_RMC14/RMCFlamerPrototypeRegressionTest.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using Content.Shared._RMC14.Xenonids.Acid;
 using Content.Shared.Timing;
 using Robust.Shared.Prototypes;
 
@@ -6,10 +8,12 @@ namespace Content.IntegrationTests._RMC14;
 [TestFixture]
 public sealed class RMCFlamerPrototypeRegressionTest
 {
+    private static readonly EntProtoId M240Flamer = "RMCWeaponFlamer";
     private static readonly EntProtoId M34TFlamer = "RMCWeaponFlamerSpec";
+    private static readonly EntProtoId Smaw = "RMCWeaponLauncherM5ATL";
 
-    [Test]
-    public async Task M34TIncineratorHasUseDelay()
+    [TestCaseSource(nameof(FlamerUseDelays))]
+    public async Task FlamersKeepRequestedUseDelay(EntProtoId prototype, double expectedDelaySeconds)
     {
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
@@ -19,11 +23,43 @@ public sealed class RMCFlamerPrototypeRegressionTest
             var prototypes = server.ResolveDependency<IPrototypeManager>();
             var factory = server.EntMan.ComponentFactory;
 
-            Assert.That(prototypes.TryIndex<EntityPrototype>(M34TFlamer, out var flamer), Is.True);
+            Assert.That(prototypes.TryIndex<EntityPrototype>(prototype, out var flamer), Is.True);
             Assert.That(flamer!.TryGetComponent<UseDelayComponent>(out var useDelay, factory), Is.True);
-            Assert.That(useDelay!.Delay, Is.EqualTo(TimeSpan.FromSeconds(0.5)));
+            Assert.That(useDelay!.Delay, Is.EqualTo(TimeSpan.FromSeconds(expectedDelaySeconds)));
         });
 
         await pair.CleanReturnAsync();
+    }
+
+    [TestCaseSource(nameof(MeltableWeaponPrototypes))]
+    public async Task RequestedWeaponsAreMeltable(EntProtoId prototype)
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var prototypes = server.ResolveDependency<IPrototypeManager>();
+            var factory = server.EntMan.ComponentFactory;
+
+            Assert.That(prototypes.TryIndex<EntityPrototype>(prototype, out var weapon), Is.True);
+            Assert.That(weapon!.TryGetComponent<CorrodibleComponent>(out var corrodible, factory), Is.True);
+            Assert.That(corrodible!.IsCorrodible, Is.True);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    private static IEnumerable<TestCaseData> FlamerUseDelays()
+    {
+        yield return new TestCaseData(M240Flamer, 2).SetName("M240IncineratorHasTwoSecondUseDelay");
+        yield return new TestCaseData(M34TFlamer, 3).SetName("M34TIncineratorHasThreeSecondUseDelay");
+    }
+
+    private static IEnumerable<TestCaseData> MeltableWeaponPrototypes()
+    {
+        yield return new TestCaseData(M240Flamer).SetName("M240IncineratorIsMeltable");
+        yield return new TestCaseData(M34TFlamer).SetName("M34TIncineratorIsMeltable");
+        yield return new TestCaseData(Smaw).SetName("SmawIsMeltable");
     }
 }

--- a/Content.IntegrationTests/_RMC14/RMCHumanPrototypeRegressionTest.cs
+++ b/Content.IntegrationTests/_RMC14/RMCHumanPrototypeRegressionTest.cs
@@ -1217,6 +1217,69 @@ public sealed class RMCHumanPrototypeRegressionTest
     }
 
     [Test]
+    public async Task CmuExternalBleedSpawnsBloodPuddle()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var tileDefinitionManager = server.ResolveDependency<ITileDefinitionManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var map = entMan.System<SharedMapSystem>();
+            var solutions = entMan.System<SharedSolutionContainerSystem>();
+            var woundsSystem = entMan.System<CMUWoundsSystem>();
+
+            map.CreateMap(out var mapId);
+            var grid = mapManager.CreateGridEntity(mapId);
+            var tile = Vector2i.Zero;
+            map.SetTile(grid, tile, new Tile(tileDefinitionManager["FloorSteel"].TileId));
+
+            var patient = entMan.SpawnEntity("CMMobHuman", map.GridTileToLocal(grid, grid.Comp, tile));
+
+            try
+            {
+                var rightArm = GetBodyPart(entMan, patient, BodyPartType.Arm, BodyPartSymmetry.Right);
+                AddBodyPartWound(entMan, rightArm, WoundType.Brute);
+
+                var wounds = entMan.GetComponent<BodyPartWoundComponent>(rightArm);
+                SetField(wounds, nameof(BodyPartWoundComponent.ExternalBleeding), ExternalBleedTier.Arterial);
+                entMan.Dirty(rightArm, wounds);
+
+                var bloodstream = entMan.GetComponent<BloodstreamComponent>(patient);
+                typeof(BloodstreamComponent)
+                    .GetField(nameof(BloodstreamComponent.BleedPuddleThreshold), BindingFlags.Instance | BindingFlags.Public)!
+                    .SetValue(bloodstream, FixedPoint2.New(0.1f));
+                Assert.That(
+                    solutions.ResolveSolution(patient, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution),
+                    Is.True);
+
+                var bloodBefore = bloodSolution.Volume;
+                var puddlesBefore = CountPuddles(entMan);
+
+                woundsSystem.Update(1f);
+
+                Assert.That(
+                    solutions.ResolveSolution(patient, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out bloodSolution),
+                    Is.True);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(bloodSolution.Volume.Float(), Is.LessThan(bloodBefore.Float()));
+                    Assert.That(CountPuddles(entMan), Is.GreaterThan(puddlesBefore));
+                });
+            }
+            finally
+            {
+                entMan.DeleteEntity(patient);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
     public async Task CmuSurgeryToolUseOnOtherSurgeonInFlightOpensUiInsteadOfAutoResuming()
     {
         await using var pair = await PoolManager.GetServerClient();

--- a/Content.IntegrationTests/_RMC14/RMCHumanPrototypeRegressionTest.cs
+++ b/Content.IntegrationTests/_RMC14/RMCHumanPrototypeRegressionTest.cs
@@ -17,6 +17,7 @@ using Content.Server._CMU14.Medical.Surgery;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Fluids.Components;
 using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared._RMC14.Medical.Stasis;
 using Content.Shared._RMC14.Medical.Wounds;
 using Content.Shared._RMC14.Medical.Surgery;
 using Content.Shared._RMC14.Medical.Surgery.Steps.Parts;
@@ -29,6 +30,7 @@ using Content.Shared.Body.Systems;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
+using Content.Shared.Damage.Systems;
 using Content.Shared.Eye;
 using Content.Shared.Explosion;
 using Content.Shared.FixedPoint;
@@ -935,10 +937,15 @@ public sealed class RMCHumanPrototypeRegressionTest
     }
 
     [Test]
-    public async Task CmuSynthRepairToolOpensReattachMenuBeforeRepair()
+    public async Task CmuSynthRepairToolRepairsDamageBeforeReattachMenu()
     {
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
+        EntityUid patient = default;
+        EntityUid surgeon = default;
+        EntityUid cable = default;
+        EntityUid leftArm = default;
+        FixedPoint2 damageBefore = FixedPoint2.Zero;
 
         await server.WaitAssertion(() =>
         {
@@ -949,48 +956,51 @@ public sealed class RMCHumanPrototypeRegressionTest
             var skills = entMan.System<SkillsSystem>();
             var xform = entMan.System<SharedTransformSystem>();
 
-            var patient = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
-            var surgeon = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
-            var cable = entMan.SpawnEntity("RMCCableCoil30", MapCoordinates.Nullspace);
-            EntityUid leftArm = default;
+            patient = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            surgeon = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            cable = entMan.SpawnEntity("RMCCableCoil30", MapCoordinates.Nullspace);
 
-            try
+            entMan.EnsureComponent<SynthComponent>(patient);
+            skills.SetSkill(surgeon, "RMCSkillSurgery", 3);
+            standing.Down(patient, playSound: false, dropHeldItems: false, force: true);
+
+            foreach (var (partUid, part) in body.GetBodyChildren(patient))
             {
-                entMan.EnsureComponent<SynthComponent>(patient);
-                skills.SetSkill(surgeon, "RMCSkillSurgery", 3);
-                standing.Down(patient, playSound: false, dropHeldItems: false, force: true);
+                if (part.PartType != BodyPartType.Arm || part.Symmetry != BodyPartSymmetry.Left)
+                    continue;
 
-                foreach (var (partUid, part) in body.GetBodyChildren(patient))
-                {
-                    if (part.PartType != BodyPartType.Arm || part.Symmetry != BodyPartSymmetry.Left)
-                        continue;
-
-                    leftArm = partUid;
-                    break;
-                }
-
-                Assert.That(leftArm, Is.Not.EqualTo(default(EntityUid)));
-                xform.DetachEntity(leftArm, entMan.GetComponent<TransformComponent>(leftArm));
-                damageable.TryChangeDamage(patient, new DamageSpecifier { DamageDict = { ["Heat"] = 10 } }, true);
-
-                var interact = new InteractUsingEvent(surgeon, cable, patient, entMan.GetComponent<TransformComponent>(patient).Coordinates);
-                entMan.EventBus.RaiseLocalEvent(patient, interact);
-
-                Assert.Multiple(() =>
-                {
-                    Assert.That(interact.Handled, Is.True);
-                    Assert.That(entMan.HasComponent<CMUSurgeryWindowOpenComponent>(surgeon), Is.True);
-                    Assert.That(entMan.GetComponent<CMUSurgeryWindowOpenComponent>(surgeon).Patient, Is.EqualTo(patient));
-                });
+                leftArm = partUid;
+                break;
             }
-            finally
+
+            Assert.That(leftArm, Is.Not.EqualTo(default(EntityUid)));
+            xform.DetachEntity(leftArm, entMan.GetComponent<TransformComponent>(leftArm));
+            damageable.TryChangeDamage(patient, new DamageSpecifier { DamageDict = { ["Heat"] = 10 } }, true);
+            damageBefore = entMan.GetComponent<DamageableComponent>(patient).TotalDamage;
+
+            var interact = new InteractUsingEvent(surgeon, cable, patient, entMan.GetComponent<TransformComponent>(patient).Coordinates);
+            entMan.EventBus.RaiseLocalEvent(patient, interact);
+
+            Assert.Multiple(() =>
             {
-                if (leftArm != default)
-                    entMan.DeleteEntity(leftArm);
-                entMan.DeleteEntity(cable);
-                entMan.DeleteEntity(patient);
-                entMan.DeleteEntity(surgeon);
-            }
+                Assert.That(interact.Handled, Is.True);
+                Assert.That(entMan.HasComponent<CMUSurgeryWindowOpenComponent>(surgeon), Is.False);
+            });
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var damage = entMan.GetComponent<DamageableComponent>(patient).TotalDamage;
+
+            Assert.That(damage, Is.LessThan(damageBefore));
+
+            entMan.DeleteEntity(leftArm);
+            entMan.DeleteEntity(cable);
+            entMan.DeleteEntity(patient);
+            entMan.DeleteEntity(surgeon);
         });
 
         await pair.CleanReturnAsync();
@@ -1090,6 +1100,150 @@ public sealed class RMCHumanPrototypeRegressionTest
 
             entMan.DeleteEntity(patient);
             entMan.DeleteEntity(surgeon);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task CmuSynthLimbReattachClearsOrganicWoundState()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        EntityUid patient = default;
+        EntityUid surgeon = default;
+        EntityUid leftArm = default;
+        EntityUid socketAnchor = default;
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var body = entMan.System<SharedBodySystem>();
+            var flow = entMan.System<CMUSurgeryFlowSystem>();
+            var hands = entMan.System<SharedHandsSystem>();
+            var standing = entMan.System<StandingStateSystem>();
+            var skills = entMan.System<SkillsSystem>();
+            var xform = entMan.System<SharedTransformSystem>();
+
+            patient = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            surgeon = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+
+            entMan.EnsureComponent<SynthComponent>(patient);
+            skills.SetSkill(surgeon, "RMCSkillSurgery", 3);
+            standing.Down(patient, playSound: false, dropHeldItems: false, force: true);
+
+            var root = body.GetRootPartOrNull(patient);
+            Assert.That(root, Is.Not.Null);
+            socketAnchor = root!.Value.Entity;
+
+            leftArm = GetBodyPart(entMan, patient, BodyPartType.Arm, BodyPartSymmetry.Left);
+            xform.DetachEntity(leftArm, entMan.GetComponent<TransformComponent>(leftArm));
+
+            AddBodyPartWound(entMan, leftArm, WoundType.Brute);
+            var wounds = entMan.GetComponent<BodyPartWoundComponent>(leftArm);
+            SetField(wounds, nameof(BodyPartWoundComponent.ExternalBleeding), ExternalBleedTier.Arterial);
+            entMan.EnsureComponent<InternalBleedingComponent>(leftArm);
+            entMan.EnsureComponent<CMUTourniquetComponent>(leftArm);
+            entMan.EnsureComponent<CMUEscharComponent>(leftArm);
+            entMan.EnsureComponent<CMUNecroticComponent>(leftArm);
+
+            Assert.That(hands.TryPickupAnyHand(surgeon, leftArm, checkActionBlocker: false), Is.True);
+
+            entMan.EnsureComponent<CMUStumpRemovedComponent>(socketAnchor);
+            entMan.EnsureComponent<CMUReattachPreppedComponent>(socketAnchor);
+
+            var armed = flow.TryArmStep(
+                surgeon,
+                patient,
+                socketAnchor,
+                "RMCSynthSurgeryReattachLimb",
+                0,
+                BodyPartType.Arm,
+                BodyPartSymmetry.Left);
+
+            Assert.That(armed, Is.Not.Null);
+            Assert.That(flow.TryHandleArmedToolUse(patient, armed!, surgeon, leftArm, socketAnchor, out var handled, out var started), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(started, Is.True);
+            });
+        });
+
+        await server.WaitRunTicks(120);
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.HasComponent<BodyPartWoundComponent>(leftArm), Is.False);
+                Assert.That(entMan.HasComponent<InternalBleedingComponent>(leftArm), Is.False);
+                Assert.That(entMan.HasComponent<CMUTourniquetComponent>(leftArm), Is.False);
+                Assert.That(entMan.HasComponent<CMUEscharComponent>(leftArm), Is.False);
+                Assert.That(entMan.HasComponent<CMUNecroticComponent>(leftArm), Is.False);
+            });
+
+            entMan.DeleteEntity(patient);
+            entMan.DeleteEntity(surgeon);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task CmuSynthPhysiologyRejectsMetabolismBleedingAndTourniquets()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var patient = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            var medic = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            var tourniquet = entMan.SpawnEntity("AU14Tourniquet", MapCoordinates.Nullspace);
+
+            try
+            {
+                entMan.EnsureComponent<SynthComponent>(patient);
+                var rightArm = GetBodyPart(entMan, patient, BodyPartType.Arm, BodyPartSymmetry.Right);
+                AddBodyPartWound(entMan, rightArm, WoundType.Brute);
+
+                var metabolism = new CMMetabolizeAttemptEvent();
+                entMan.EventBus.RaiseLocalEvent(patient, ref metabolism);
+
+                var bleedAttempt = new CMBleedAttemptEvent();
+                entMan.EventBus.RaiseLocalEvent(patient, ref bleedAttempt);
+
+                var damageable = entMan.GetComponent<DamageableComponent>(patient);
+                var bleed = new CMBleedEvent(new DamageChangedEvent(
+                    damageable,
+                    new DamageSpecifier { DamageDict = { ["Piercing"] = FixedPoint2.New(10) } },
+                    true,
+                    null,
+                    null));
+                entMan.EventBus.RaiseLocalEvent(patient, ref bleed);
+
+                var interact = new AfterInteractEvent(medic, tourniquet, patient, default, true);
+                entMan.EventBus.RaiseLocalEvent(tourniquet, interact);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(metabolism.Cancelled, Is.True);
+                    Assert.That(bleedAttempt.Cancelled, Is.True);
+                    Assert.That(bleed.Handled, Is.True);
+                    Assert.That(interact.Handled, Is.False);
+                    Assert.That(entMan.HasComponent<CMUTourniquetComponent>(rightArm), Is.False);
+                });
+            }
+            finally
+            {
+                entMan.DeleteEntity(tourniquet);
+                entMan.DeleteEntity(medic);
+                entMan.DeleteEntity(patient);
+            }
         });
 
         await pair.CleanReturnAsync();

--- a/Content.IntegrationTests/_RMC14/RMCSmartGunPrototypeRegressionTest.cs
+++ b/Content.IntegrationTests/_RMC14/RMCSmartGunPrototypeRegressionTest.cs
@@ -12,11 +12,11 @@ public sealed class RMCSmartGunPrototypeRegressionTest
     private const string HazopsCartridge = "AU14CartridgeMinigunHAZOPS9mm";
     private const string HazopsBullet = "AU14BulletMinigunHAZOPS9mm";
 
-    [TestCase("CMBulletSmartGun10x30mm", 12f, 7f, 4)]
-    [TestCase("RMCBulletSmartGun10x30mmirradiated", 12f, 7f, 4)]
-    [TestCase("RMCBulletSmartGun10x30mmHT", 12f, 7f, 4)]
-    [TestCase("AU14CartridgeSmartGun127x40mm", 10f, 7f, 4)]
-    [TestCase(HazopsBullet, 12f, 7f, 4)]
+    [TestCase("CMBulletSmartGun10x30mm", 12f, 4.5f, 4)]
+    [TestCase("RMCBulletSmartGun10x30mmirradiated", 12f, 4.5f, 4)]
+    [TestCase("RMCBulletSmartGun10x30mmHT", 12f, 4.5f, 4)]
+    [TestCase("AU14CartridgeSmartGun127x40mm", 10f, 4.5f, 4)]
+    [TestCase(HazopsBullet, 12f, 4.5f, 4)]
     public async Task SmartGunProjectilesKeepDamageFalloff(
         string projectileId,
         float expectedCapRange,

--- a/Content.IntegrationTests/_RMC14/XenoAlchemistTest.cs
+++ b/Content.IntegrationTests/_RMC14/XenoAlchemistTest.cs
@@ -1,4 +1,10 @@
+using System.Linq;
 using System.Numerics;
+using Content.Shared._CMU14.Chemistry.Effects.Negative;
+using Content.Shared._RMC14.Chemistry.Effects;
+using Content.Shared._RMC14.Chemistry.Effects.Negative;
+using Content.Shared._RMC14.Slow;
+using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Xenonids.Alchemist;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared.Actions;
@@ -7,6 +13,8 @@ using Content.Shared.Actions.Events;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Damage;
+using Content.Shared.EntityEffects;
+using Content.Shared.EntityEffects.Effects;
 using Content.Shared.FixedPoint;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.GameObjects;
@@ -37,6 +45,29 @@ public sealed class XenoAlchemistTest
   - type: XenoAlchemist
     sagunine: 20
     selectedChemical: Cholinine
+
+- type: entity
+  parent: CMXenoSpitterAlchemist
+  id: RMCTestXenoSpitterAlchemistNoctineFull
+  components:
+  - type: XenoAlchemist
+    noctine: 20
+
+- type: entity
+  parent: CMXenoSpitterAlchemist
+  id: RMCTestXenoSpitterAlchemistCrynineFull
+  components:
+  - type: XenoAlchemist
+    cholinine: 10
+    noctine: 10
+
+- type: entity
+  parent: CMXenoSpitterAlchemist
+  id: RMCTestXenoSpitterAlchemistPyrinineFull
+  components:
+  - type: XenoAlchemist
+    sagunine: 10
+    cholinine: 10
 ";
 
     private static readonly string[] AlchemistReagents =
@@ -167,6 +198,92 @@ public sealed class XenoAlchemistTest
     }
 
     [Test]
+    public async Task AlchemistChemicalsApplyPressureOverFiftySeconds()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var prototypes = server.ResolveDependency<IPrototypeManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var brute = prototypes.Index<ReagentPrototype>("RMCXenoAlchBrute");
+            var burn = prototypes.Index<ReagentPrototype>("RMCXenoAlchBurn");
+            var pain = prototypes.Index<ReagentPrototype>("RMCXenoAlchPain");
+            var fire = prototypes.Index<ReagentPrototype>("RMCXenoAlchFire");
+            var bloodloss = prototypes.Index<ReagentPrototype>("RMCXenoAlchBloodloss");
+            var freeze = prototypes.Index<ReagentPrototype>("RMCXenoAlchFreeze");
+            var purge = prototypes.Index<ReagentPrototype>("RMCXenoAlchPurge");
+
+            foreach (var reagent in new[] { brute, burn, pain, fire, bloodloss, freeze, purge })
+            {
+                Assert.That(GetPoison(reagent).MetabolismRate, Is.EqualTo(FixedPoint2.New(0.4f)), reagent.ID);
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetEffect<Biocidic>(brute).Potency, Is.EqualTo(4), brute.ID);
+                Assert.That(GetEffect<Corrosive>(burn).Potency, Is.EqualTo(4), burn.ID);
+                Assert.That(GetEffect<RMCAlchemistPain>(pain).Potency, Is.EqualTo(8), pain.ID);
+                Assert.That(GetEffect<Corrosive>(fire).Potency, Is.EqualTo(4), fire.ID);
+                Assert.That(GetEffect<Hemolytic>(bloodloss).Potency, Is.EqualTo(2), bloodloss.ID);
+                Assert.That(GetEffect<RMCAlchemistPurgeNonToxins>(purge).Amount, Is.EqualTo(FixedPoint2.New(0.4f)), purge.ID);
+            });
+
+            AssertAdjusts(brute, "CMBicaridine", -0.4f);
+            AssertAdjusts(brute, "CMMeralyne", -0.4f);
+            AssertAdjusts(burn, "CMKelotane", -0.4f);
+            AssertAdjusts(burn, "CMDermaline", -0.4f);
+            AssertAdjusts(pain, "CMUParacetamol", -0.4f);
+            AssertAdjusts(pain, "CMUTramadol", -0.4f);
+            AssertAdjusts(pain, "CMUOxycodone", -0.4f);
+            AssertAdjusts(bloodloss, "CMDexalin", -0.4f);
+            AssertAdjusts(bloodloss, "CMDexalinPlus", -0.4f);
+            AssertAdjusts(bloodloss, "CMInaprovaline", -0.4f);
+            AssertAdjusts(bloodloss, "RMCIron", -0.4f);
+            AssertAdjusts(freeze, "CMCryoxadone", -0.4f);
+            AssertAdjusts(freeze, "CMClonexadone", -0.4f);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task AlchemistMeleeHitGeneratesTwoChemicalUnits()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var alchemist = entMan.SpawnEntity("CMXenoSpitterAlchemist", map.GridCoords);
+            var target = entMan.SpawnEntity("CMMobHuman", map.GridCoords.Offset(new Vector2(1, 0)));
+
+            try
+            {
+                var comp = entMan.GetComponent<XenoAlchemistComponent>(alchemist);
+                var ev = new MeleeHitEvent([target], alchemist, alchemist, new DamageSpecifier(), null);
+
+                entMan.EventBus.RaiseLocalEvent(alchemist, ev);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(comp.SlashGenerateAmount, Is.EqualTo(2));
+                    Assert.That(comp.Sagunine, Is.EqualTo(2));
+                });
+            }
+            finally
+            {
+                entMan.DeleteEntity(alchemist);
+                entMan.DeleteEntity(target);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
     public async Task AlchemistStockpileCapsAtTwentyTotal()
     {
         await using var pair = await PoolManager.GetServerClient();
@@ -203,6 +320,99 @@ public sealed class XenoAlchemistTest
         await pair.CleanReturnAsync();
     }
 
+    [Test]
+    public async Task NoctineInjectionDazesHumanTargets()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var alchemist = entMan.SpawnEntity("RMCTestXenoSpitterAlchemistNoctineFull", map.GridCoords);
+            var target = entMan.SpawnEntity("CMMobHuman", map.GridCoords.Offset(new Vector2(1, 0)));
+            var action = SpawnAction(entMan);
+
+            try
+            {
+                RaiseTailInjection(entMan, alchemist, target, action);
+
+                Assert.That(entMan.HasComponent<RMCDazedComponent>(target), Is.True);
+            }
+            finally
+            {
+                entMan.DeleteEntity(alchemist);
+                entMan.DeleteEntity(target);
+                entMan.DeleteEntity(action.Owner);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task CrynineInjectionSlowsHumanTargets()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var alchemist = entMan.SpawnEntity("RMCTestXenoSpitterAlchemistCrynineFull", map.GridCoords);
+            var target = entMan.SpawnEntity("CMMobHuman", map.GridCoords.Offset(new Vector2(1, 0)));
+            var action = SpawnAction(entMan);
+
+            try
+            {
+                RaiseTailInjection(entMan, alchemist, target, action);
+
+                Assert.That(entMan.HasComponent<RMCSlowdownComponent>(target), Is.True);
+            }
+            finally
+            {
+                entMan.DeleteEntity(alchemist);
+                entMan.DeleteEntity(target);
+                entMan.DeleteEntity(action.Owner);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task PyrinineInjectionDazesHumanTargets()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var alchemist = entMan.SpawnEntity("RMCTestXenoSpitterAlchemistPyrinineFull", map.GridCoords);
+            var target = entMan.SpawnEntity("CMMobHuman", map.GridCoords.Offset(new Vector2(1, 0)));
+            var action = SpawnAction(entMan);
+
+            try
+            {
+                RaiseTailInjection(entMan, alchemist, target, action);
+
+                Assert.That(entMan.HasComponent<RMCDazedComponent>(target), Is.True);
+            }
+            finally
+            {
+                entMan.DeleteEntity(alchemist);
+                entMan.DeleteEntity(target);
+                entMan.DeleteEntity(action.Owner);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
     private static Entity<ActionComponent> SpawnAction(IEntityManager entMan)
     {
         var action = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
@@ -228,5 +438,29 @@ public sealed class XenoAlchemistTest
     private static float TotalDamage(IEntityManager entMan, EntityUid target)
     {
         return entMan.GetComponent<DamageableComponent>(target).Damage.GetTotal().Float();
+    }
+
+    private static ReagentEffectsEntry GetPoison(ReagentPrototype reagent)
+    {
+        Assert.That(reagent.Metabolisms, Is.Not.Null, reagent.ID);
+        Assert.That(reagent.Metabolisms!.TryGetValue("Poison", out var poison), Is.True, reagent.ID);
+        return poison!;
+    }
+
+    private static T GetEffect<T>(ReagentPrototype reagent) where T : EntityEffect
+    {
+        var effect = GetPoison(reagent).Effects.OfType<T>().SingleOrDefault();
+        Assert.That(effect, Is.Not.Null, reagent.ID);
+        return effect!;
+    }
+
+    private static void AssertAdjusts(ReagentPrototype reagent, string target, float amount)
+    {
+        var effect = GetPoison(reagent).Effects
+            .OfType<AdjustReagent>()
+            .SingleOrDefault(e => e.Reagent == target);
+
+        Assert.That(effect, Is.Not.Null, $"{reagent.ID} should adjust {target}");
+        Assert.That(effect!.Amount, Is.EqualTo(FixedPoint2.New(amount)), $"{reagent.ID} should adjust {target}");
     }
 }

--- a/Content.IntegrationTests/_RMC14/XenoGhostRoleAvailabilityTest.cs
+++ b/Content.IntegrationTests/_RMC14/XenoGhostRoleAvailabilityTest.cs
@@ -12,6 +12,34 @@ namespace Content.IntegrationTests._RMC14;
 public sealed class XenoGhostRoleAvailabilityTest
 {
     [Test]
+    public async Task LarvaDoesNotRegisterAsGhostRole()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = true,
+            Dirty = true,
+            DummyTicker = false,
+        });
+
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var ghostRole = entMan.System<GhostRoleSystem>();
+
+        EntityUid larva = default;
+
+        await server.WaitAssertion(() =>
+        {
+            larva = entMan.SpawnEntity("CMXenoLarva", MapCoordinates.Nullspace);
+
+            var larvaNet = entMan.GetNetEntity(larva);
+            Assert.That(ghostRole.GetGhostRoleCount(), Is.EqualTo(0));
+            Assert.That(ghostRole.GetGhostRolesInfo(null).Any(info => info.Entity == larvaNet), Is.False);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
     public async Task ControlledEntityDoesNotRegisterAsGhostRole()
     {
         await using var pair = await PoolManager.GetServerClient(new PoolSettings

--- a/Content.IntegrationTests/_RMC14/XenoHeatshieldTest.cs
+++ b/Content.IntegrationTests/_RMC14/XenoHeatshieldTest.cs
@@ -10,6 +10,8 @@ namespace Content.IntegrationTests._RMC14;
 [TestFixture]
 public sealed class XenoHeatshieldTest
 {
+    private const string FireSpewEffectPrototype = "RMCEffectXenoFireSpew";
+
     [Test]
     public async Task BurningVomitBileIgnitesThreeTilesInFront()
     {
@@ -55,10 +57,12 @@ public sealed class XenoHeatshieldTest
                     Assert.That(IsOnFire(entMan, targetCenter), Is.True);
                     Assert.That(IsOnFire(entMan, targetSouth), Is.True);
                     Assert.That(IsOnFire(entMan, behind), Is.False);
+                    Assert.That(CountPrototype(entMan, FireSpewEffectPrototype), Is.EqualTo(3));
                 });
             }
             finally
             {
+                DeletePrototypeEntities(entMan, FireSpewEffectPrototype);
                 entMan.DeleteEntity(xeno);
                 entMan.DeleteEntity(targetNorth);
                 entMan.DeleteEntity(targetCenter);
@@ -96,5 +100,28 @@ public sealed class XenoHeatshieldTest
     private static bool IsOnFire(IEntityManager entMan, EntityUid entity)
     {
         return entMan.GetComponent<FlammableComponent>(entity).OnFire;
+    }
+
+    private static int CountPrototype(IEntityManager entMan, string prototypeId)
+    {
+        var count = 0;
+        var query = entMan.EntityQueryEnumerator<MetaDataComponent>();
+        while (query.MoveNext(out _, out var metadata))
+        {
+            if (metadata.EntityPrototype?.ID == prototypeId)
+                count++;
+        }
+
+        return count;
+    }
+
+    private static void DeletePrototypeEntities(IEntityManager entMan, string prototypeId)
+    {
+        var query = entMan.EntityQueryEnumerator<MetaDataComponent>();
+        while (query.MoveNext(out var uid, out var metadata))
+        {
+            if (metadata.EntityPrototype?.ID == prototypeId)
+                entMan.DeleteEntity(uid);
+        }
     }
 }

--- a/Content.IntegrationTests/_RMC14/XenoHeatshieldTest.cs
+++ b/Content.IntegrationTests/_RMC14/XenoHeatshieldTest.cs
@@ -1,0 +1,100 @@
+using System.Numerics;
+using Content.Shared._RMC14.Xenonids.Heatshield;
+using Content.Shared.Actions.Components;
+using Content.Shared.Atmos.Components;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests._RMC14;
+
+[TestFixture]
+public sealed class XenoHeatshieldTest
+{
+    [Test]
+    public async Task BurningVomitBileIgnitesThreeTilesInFront()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        EntityUid xeno = default;
+        EntityUid targetNorth = default;
+        EntityUid targetCenter = default;
+        EntityUid targetSouth = default;
+        EntityUid behind = default;
+        Entity<ActionComponent> action = default;
+
+        await server.WaitPost(() =>
+        {
+            var entMan = server.EntMan;
+            xeno = entMan.SpawnEntity("CMXenoDefenderHeatshield", map.GridCoords);
+            targetNorth = entMan.SpawnEntity("CMMobHuman", map.GridCoords.Offset(new Vector2(1, 1)));
+            targetCenter = entMan.SpawnEntity("CMMobHuman", map.GridCoords.Offset(new Vector2(1, 0)));
+            targetSouth = entMan.SpawnEntity("CMMobHuman", map.GridCoords.Offset(new Vector2(1, -1)));
+            behind = entMan.SpawnEntity("CMMobHuman", map.GridCoords.Offset(new Vector2(-1, 0)));
+            action = SpawnAction(entMan);
+
+            var flammable = entMan.GetComponent<FlammableComponent>(xeno);
+            flammable.OnFire = true;
+            entMan.Dirty(xeno, flammable);
+        });
+
+        await server.WaitRunTicks(1);
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+
+            try
+            {
+                RaiseVomitBile(entMan, xeno, map.GridCoords.Offset(new Vector2(1, 0)), action);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(IsOnFire(entMan, targetNorth), Is.True);
+                    Assert.That(IsOnFire(entMan, targetCenter), Is.True);
+                    Assert.That(IsOnFire(entMan, targetSouth), Is.True);
+                    Assert.That(IsOnFire(entMan, behind), Is.False);
+                });
+            }
+            finally
+            {
+                entMan.DeleteEntity(xeno);
+                entMan.DeleteEntity(targetNorth);
+                entMan.DeleteEntity(targetCenter);
+                entMan.DeleteEntity(targetSouth);
+                entMan.DeleteEntity(behind);
+                entMan.DeleteEntity(action.Owner);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    private static Entity<ActionComponent> SpawnAction(IEntityManager entMan)
+    {
+        var action = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+        return (action, entMan.EnsureComponent<ActionComponent>(action));
+    }
+
+    private static void RaiseVomitBile(
+        IEntityManager entMan,
+        EntityUid xeno,
+        EntityCoordinates target,
+        Entity<ActionComponent> action)
+    {
+        var ev = new XenoVomitBileActionEvent
+        {
+            Performer = xeno,
+            Action = action,
+            Target = target,
+        };
+
+        entMan.EventBus.RaiseLocalEvent(xeno, ev);
+    }
+
+    private static bool IsOnFire(IEntityManager entMan, EntityUid entity)
+    {
+        return entMan.GetComponent<FlammableComponent>(entity).OnFire;
+    }
+}

--- a/Content.IntegrationTests/_RMC14/XenoHiveInstantBuildTest.cs
+++ b/Content.IntegrationTests/_RMC14/XenoHiveInstantBuildTest.cs
@@ -1,0 +1,276 @@
+using System.Numerics;
+using Content.Shared._RMC14.Xenonids.Construction;
+using Content.Shared._RMC14.Xenonids.Construction.Events;
+using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
+using Content.Shared.DoAfter;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests._RMC14;
+
+[TestFixture]
+public sealed class XenoHiveInstantBuildTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  parent: CMXenoDrone
+  id: RMCTestXenoDroneBuildResinWall
+  components:
+  - type: XenoConstruction
+    buildChoice: WallXenoResin
+  - type: XenoPlasma
+    plasma: 0
+    maxPlasma: 0
+";
+
+    [Test]
+    public async Task InstantBuildPoolIsPerHive()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var construction = entMan.System<SharedXenoConstructionSystem>();
+            var hiveOne = entMan.SpawnEntity("CMXenoHive", map.GridCoords);
+            var hiveTwo = entMan.SpawnEntity("CMXenoHive", map.GridCoords.Offset(new Vector2(1, 0)));
+
+            try
+            {
+                Assert.Multiple(() =>
+                {
+                    Assert.That(construction.GetHiveInstantBuildsRemaining(hiveOne), Is.EqualTo(200));
+                    Assert.That(construction.GetHiveInstantBuildsRemaining(hiveTwo), Is.EqualTo(200));
+                });
+
+                Assert.That(construction.TryUseHiveInstantBuild(hiveOne), Is.True);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(construction.GetHiveInstantBuildsRemaining(hiveOne), Is.EqualTo(199));
+                    Assert.That(construction.GetHiveInstantBuildsRemaining(hiveTwo), Is.EqualTo(200));
+                });
+            }
+            finally
+            {
+                entMan.DeleteEntity(hiveOne);
+                entMan.DeleteEntity(hiveTwo);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task InstantBuildCounterMirrorsHivePoolForSecreteActions()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var hiveSystem = entMan.System<SharedXenoHiveSystem>();
+            var construction = entMan.System<SharedXenoConstructionSystem>();
+            var hive = entMan.SpawnEntity("CMXenoHive", map.GridCoords);
+            var droneOne = entMan.SpawnEntity("CMXenoDrone", map.GridCoords.Offset(new Vector2(1, 0)));
+            var droneTwo = entMan.SpawnEntity("CMXenoDrone", map.GridCoords.Offset(new Vector2(2, 0)));
+
+            try
+            {
+                hiveSystem.SetHive(droneOne, hive);
+                hiveSystem.SetHive(droneTwo, hive);
+
+                construction.RefreshHiveInstantBuildActionCounters(hive);
+
+                var counterOne = GetSecreteActionCounter(entMan, droneOne);
+                var counterTwo = GetSecreteActionCounter(entMan, droneTwo);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(counterOne.Visible, Is.True);
+                    Assert.That(counterOne.BuildsLeft, Is.EqualTo(200));
+                    Assert.That(counterTwo.Visible, Is.True);
+                    Assert.That(counterTwo.BuildsLeft, Is.EqualTo(200));
+                });
+
+                Assert.That(construction.TryUseHiveInstantBuild(hive), Is.True);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(counterOne.BuildsLeft, Is.EqualTo(199));
+                    Assert.That(counterTwo.BuildsLeft, Is.EqualTo(199));
+                });
+            }
+            finally
+            {
+                entMan.DeleteEntity(hive);
+                entMan.DeleteEntity(droneOne);
+                entMan.DeleteEntity(droneTwo);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task SecreteStructureUsesHiveInstantBuildWithoutPlasmaOrDoAfter()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+        var tileManager = server.ResolveDependency<ITileDefinitionManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var hiveSystem = entMan.System<SharedXenoHiveSystem>();
+            var construction = entMan.System<SharedXenoConstructionSystem>();
+            var mapSystem = entMan.System<SharedMapSystem>();
+            var hive = entMan.SpawnEntity("CMXenoHive", map.GridCoords);
+            var drone = entMan.SpawnEntity("RMCTestXenoDroneBuildResinWall", map.GridCoords);
+            var target = map.GridCoords.Offset(new Vector2(1, 0));
+            mapSystem.SetTile(map.Grid.Owner, map.Grid.Comp, target, new Tile(tileManager["Plating"].TileId));
+            var weeds = entMan.SpawnEntity("XenoWeeds", target);
+            var action = SpawnAction(entMan);
+
+            try
+            {
+                hiveSystem.SetHive(drone, hive);
+                hiveSystem.SetSameHive(drone, weeds);
+
+                RaiseSecreteStructure(entMan, drone, target, action);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(CountPrototype(entMan, "WallXenoResin"), Is.EqualTo(1));
+                    Assert.That(construction.GetHiveInstantBuildsRemaining(hive), Is.EqualTo(199));
+                    Assert.That(HasActiveConstructionDoAfter(entMan, drone), Is.False);
+                });
+            }
+            finally
+            {
+                entMan.DeleteEntity(hive);
+                entMan.DeleteEntity(drone);
+                entMan.DeleteEntity(weeds);
+                entMan.DeleteEntity(action.Owner);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task FailedSecreteStructureDoesNotConsumeHiveInstantBuild()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+        var tileManager = server.ResolveDependency<ITileDefinitionManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var hiveSystem = entMan.System<SharedXenoHiveSystem>();
+            var construction = entMan.System<SharedXenoConstructionSystem>();
+            var mapSystem = entMan.System<SharedMapSystem>();
+            var hive = entMan.SpawnEntity("CMXenoHive", map.GridCoords);
+            var drone = entMan.SpawnEntity("RMCTestXenoDroneBuildResinWall", map.GridCoords);
+            var target = map.GridCoords.Offset(new Vector2(1, 0));
+            mapSystem.SetTile(map.Grid.Owner, map.Grid.Comp, target, new Tile(tileManager["Plating"].TileId));
+            var action = SpawnAction(entMan);
+
+            try
+            {
+                hiveSystem.SetHive(drone, hive);
+
+                RaiseSecreteStructure(entMan, drone, target, action);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(CountPrototype(entMan, "WallXenoResin"), Is.Zero);
+                    Assert.That(construction.GetHiveInstantBuildsRemaining(hive), Is.EqualTo(200));
+                });
+            }
+            finally
+            {
+                entMan.DeleteEntity(hive);
+                entMan.DeleteEntity(drone);
+                entMan.DeleteEntity(action.Owner);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    private static Entity<ActionComponent> SpawnAction(IEntityManager entMan)
+    {
+        var action = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+        return (action, entMan.EnsureComponent<ActionComponent>(action));
+    }
+
+    private static void RaiseSecreteStructure(
+        IEntityManager entMan,
+        EntityUid xeno,
+        EntityCoordinates target,
+        Entity<ActionComponent> action)
+    {
+        var ev = new XenoSecreteStructureActionEvent
+        {
+            Performer = xeno,
+            Action = action,
+            Target = target,
+        };
+
+        entMan.EventBus.RaiseLocalEvent(xeno, ev);
+    }
+
+    private static XenoHiveInstantBuildActionComponent GetSecreteActionCounter(IEntityManager entMan, EntityUid xeno)
+    {
+        var actions = entMan.System<SharedActionsSystem>();
+        foreach (var action in actions.GetActions(xeno))
+        {
+            if (entMan.GetComponent<MetaDataComponent>(action).EntityPrototype?.ID != "ActionXenoSecreteStructure")
+                continue;
+
+            Assert.That(entMan.TryGetComponent(action, out XenoHiveInstantBuildActionComponent counter), Is.True);
+            return counter;
+        }
+
+        Assert.Fail("Expected xeno to have ActionXenoSecreteStructure");
+        throw new InvalidOperationException();
+    }
+
+    private static bool HasActiveConstructionDoAfter(IEntityManager entMan, EntityUid xeno)
+    {
+        if (!entMan.TryGetComponent(xeno, out DoAfterComponent doAfter))
+            return false;
+
+        foreach (var active in doAfter.DoAfters.Values)
+        {
+            if (active.Args.Event is XenoSecreteStructureDoAfterEvent)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static int CountPrototype(IEntityManager entMan, string prototypeId)
+    {
+        var count = 0;
+        var query = entMan.EntityQueryEnumerator<MetaDataComponent>();
+        while (query.MoveNext(out _, out var metadata))
+        {
+            if (metadata.EntityPrototype?.ID == prototypeId)
+                count++;
+        }
+
+        return count;
+    }
+}

--- a/Content.IntegrationTests/_RMC14/XenoReaperTest.cs
+++ b/Content.IntegrationTests/_RMC14/XenoReaperTest.cs
@@ -49,6 +49,13 @@ public sealed class XenoReaperTest
 
 - type: entity
   parent: CMXenoReaper
+  id: RMCTestXenoReaperFlesh298
+  components:
+  - type: XenoReaper
+    fleshResin: 298
+
+- type: entity
+  parent: CMXenoReaper
   id: RMCTestXenoReaperFlesh301
   components:
   - type: XenoReaper
@@ -60,6 +67,7 @@ public sealed class XenoReaperTest
   components:
   - type: XenoReaper
     fleshResin: 40
+    passiveGain: 0
 ";
 
     [Test]
@@ -386,33 +394,37 @@ public sealed class XenoReaperTest
     }
 
     [Test]
-    public async Task PassiveFleshDrainOnlyRemovesOneAboveThreeHundred()
+    public async Task PassiveFleshGainAddsTwoPerSecondUpToThreeHundred()
     {
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
         var map = await pair.CreateTestMap();
 
+        EntityUid belowThreshold = default;
         EntityUid atThreshold = default;
         EntityUid overThreshold = default;
 
         await server.WaitAssertion(() =>
         {
             var entMan = server.EntMan;
-            atThreshold = entMan.SpawnEntity("RMCTestXenoReaperFlesh300", map.GridCoords);
-            overThreshold = entMan.SpawnEntity("RMCTestXenoReaperFlesh301", map.GridCoords.Offset(new Vector2(1, 0)));
+            belowThreshold = entMan.SpawnEntity("RMCTestXenoReaperFlesh298", map.GridCoords);
+            atThreshold = entMan.SpawnEntity("RMCTestXenoReaperFlesh300", map.GridCoords.Offset(new Vector2(1, 0)));
+            overThreshold = entMan.SpawnEntity("RMCTestXenoReaperFlesh301", map.GridCoords.Offset(new Vector2(2, 0)));
         });
 
-        await server.WaitRunTicks(5);
+        await server.WaitRunTicks(70);
 
         await server.WaitAssertion(() =>
         {
             var entMan = server.EntMan;
             Assert.Multiple(() =>
             {
+                Assert.That(entMan.GetComponent<XenoReaperComponent>(belowThreshold).FleshResin, Is.EqualTo(300));
                 Assert.That(entMan.GetComponent<XenoReaperComponent>(atThreshold).FleshResin, Is.EqualTo(300));
-                Assert.That(entMan.GetComponent<XenoReaperComponent>(overThreshold).FleshResin, Is.EqualTo(300));
+                Assert.That(entMan.GetComponent<XenoReaperComponent>(overThreshold).FleshResin, Is.EqualTo(301));
             });
 
+            entMan.DeleteEntity(belowThreshold);
             entMan.DeleteEntity(atThreshold);
             entMan.DeleteEntity(overThreshold);
         });

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -26,6 +26,7 @@ using Content.Shared.Mobs;
 using Content.Shared.Players;
 using Content.Shared.Roles;
 using Content.Shared.Verbs;
+using Content.Shared._RMC14.Xenonids;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
@@ -69,6 +70,8 @@ public sealed partial class GhostRoleSystem : EntitySystem
 
     private readonly Dictionary<ICommonSession, GhostRolesEui> _openUis = new();
     private readonly Dictionary<ICommonSession, MakeGhostRoleEui> _openMakeGhostRoleUis = new();
+
+    private static readonly ProtoId<JobPrototype> XenoLarvaRole = "CMXenoLarva";
 
     [ViewVariables]
     public IReadOnlyCollection<Entity<GhostRoleComponent>> GhostRoles => _ghostRoles.Values;
@@ -902,13 +905,20 @@ public sealed partial class GhostRoleSystem : EntitySystem
         return Resolve(uid, ref component, false) &&
                !component.Taken &&
                !MetaData(uid).EntityPaused &&
-               !IsControlledGhostRole(uid);
+               !IsControlledGhostRole(uid) &&
+               !IsBlockedXenoGhostRole(uid);
     }
 
     private bool IsControlledGhostRole(EntityUid uid)
     {
         return HasComp<ActorComponent>(uid) ||
                TryComp(uid, out MindContainerComponent? mind) && mind.HasMind;
+    }
+
+    private bool IsBlockedXenoGhostRole(EntityUid uid)
+    {
+        return TryComp(uid, out XenoComponent? xeno) &&
+               xeno.Role == XenoLarvaRole;
     }
 
     private void OnTakeoverTakeRole(EntityUid uid, GhostTakeoverAvailableComponent component, ref TakeGhostRoleEvent args)

--- a/Content.Server/_CMU14/Medical/StatusEffects/CMUPainFeedbackSystem.cs
+++ b/Content.Server/_CMU14/Medical/StatusEffects/CMUPainFeedbackSystem.cs
@@ -1,0 +1,205 @@
+using Content.Server._RMC14.Damage;
+using Content.Server.Body.Systems;
+using Content.Server.Speech.Components;
+using Content.Shared._CMU14.Medical;
+using Content.Shared._CMU14.Medical.StatusEffects;
+using Content.Shared._CMU14.Medical.TemporaryBlurryVision;
+using Content.Shared._RMC14.Emote;
+using Content.Shared._RMC14.Synth;
+using Content.Shared.Chat.Prototypes;
+using Content.Shared.Damage;
+using Content.Shared.Drunk;
+using Content.Shared.FixedPoint;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.StatusEffect;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server._CMU14.Medical.StatusEffects;
+
+public sealed partial class CMUPainFeedbackSystem : EntitySystem
+{
+    [Dependency] private DamageableSystem _damage = default!;
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IPrototypeManager _prototypes = default!;
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private SharedPainShockSystem _pain = default!;
+    [Dependency] private CMUTemporaryBlurryVisionSystem _blur = default!;
+    [Dependency] private SharedRMCEmoteSystem _emote = default!;
+    [Dependency] private StatusEffectQuerySystem _status = default!;
+    [Dependency] private SharedDrunkSystem _drunk = default!;
+
+    private static readonly ProtoId<StatusEffectPrototype> Stutter = "Stutter";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        UpdatesAfter.Add(typeof(RMCDamageableSystem));
+        UpdatesAfter.Add(typeof(RespiratorSystem));
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (!_pain.IsLayerEnabled())
+            return;
+
+        var now = _timing.CurTime;
+        var query = EntityQueryEnumerator<CMUPainFeedbackComponent, PainShockComponent, CMUHumanMedicalComponent, MobStateComponent>();
+        while (query.MoveNext(out var uid, out var feedback, out var pain, out _, out var mob))
+        {
+            if (mob.CurrentState == MobState.Dead || HasComp<SynthComponent>(uid))
+                continue;
+
+            if (pain.Tier < PainTier.Moderate)
+            {
+                feedback.NextEffect = TimeSpan.Zero;
+                continue;
+            }
+
+            if (feedback.NextEffect > now)
+                continue;
+
+            feedback.NextEffect = now + feedback.EffectInterval;
+            ApplyFeedback(uid, feedback, pain);
+        }
+    }
+
+    private void ApplyFeedback(EntityUid uid, CMUPainFeedbackComponent feedback, PainShockComponent pain)
+    {
+        var tier = pain.Tier;
+        var shock = tier == PainTier.Shock;
+
+        ApplyTemporaryBlur(
+            uid,
+            GetBlurDuration(feedback, tier),
+            GetBlurAmount(feedback, pain));
+
+        if (tier < PainTier.Severe)
+            return;
+
+        ApplyTimedStatus<StutteringAccentComponent>(
+            uid,
+            Stutter,
+            shock ? feedback.ShockStutterDuration : feedback.SevereStutterDuration);
+
+        ApplyDrunkenness(
+            uid,
+            shock ? feedback.ShockDrunkPower : feedback.SevereDrunkPower,
+            shock);
+
+        ApplyAsphyxiation(
+            uid,
+            shock ? feedback.ShockAsphyxiation : feedback.SevereAsphyxiation);
+
+        TryPainEmote(
+            uid,
+            shock ? feedback.ShockEmoteChance : feedback.SevereEmoteChance,
+            shock ? feedback.ShockEmotes : feedback.SevereEmotes);
+    }
+
+    private TimeSpan GetBlurDuration(CMUPainFeedbackComponent feedback, PainTier tier)
+    {
+        return tier switch
+        {
+            PainTier.Moderate => feedback.SevereBlurDuration,
+            PainTier.Severe => feedback.SevereBlurDuration,
+            PainTier.Shock => feedback.ShockBlurDuration,
+            _ => TimeSpan.Zero,
+        };
+    }
+
+    private float GetBlurAmount(CMUPainFeedbackComponent feedback, PainShockComponent pain)
+    {
+        var value = pain.Pain.Float();
+        var moderate = PainTierThresholds.UpwardThresholds[(int) PainTier.Moderate - 1].Float();
+        var severe = PainTierThresholds.UpwardThresholds[(int) PainTier.Severe - 1].Float();
+        var shock = _pain.ShockThreshold.Float();
+
+        if (value < moderate)
+            return 0f;
+
+        if (value < severe)
+            return Lerp(0.02f, feedback.SevereBlurStartAmount, InverseLerp(moderate, severe, value));
+
+        if (value < shock)
+            return Lerp(feedback.SevereBlurStartAmount, feedback.ShockBlurStartAmount, InverseLerp(severe, shock, value));
+
+        var shockEnd = Math.Max(feedback.ShockBlurFullPain, shock);
+        return Lerp(feedback.ShockBlurStartAmount, feedback.ShockBlurAmount, InverseLerp(shock, shockEnd, value));
+    }
+
+    private static float InverseLerp(float from, float to, float value)
+    {
+        if (to <= from)
+            return 1f;
+
+        return Math.Clamp((value - from) / (to - from), 0f, 1f);
+    }
+
+    private static float Lerp(float from, float to, float amount)
+    {
+        return from + (to - from) * amount;
+    }
+
+    private void ApplyTemporaryBlur(EntityUid uid, TimeSpan duration, float amount)
+    {
+        _blur.AddTemporaryBlurModifier(uid, duration, amount);
+    }
+
+    private void ApplyDrunkenness(EntityUid uid, float power, bool slur)
+    {
+        if (power <= 0f)
+            return;
+
+        var targetDuration = TimeSpan.FromSeconds(power);
+        if (_status.TryGetTime(uid, SharedDrunkSystem.DrunkKey, out var time) &&
+            time.Value.Item2 - _timing.CurTime >= targetDuration)
+        {
+            return;
+        }
+
+        _drunk.TryApplyDrunkenness(uid, power, slur);
+    }
+
+    private void ApplyTimedStatus<T>(
+        EntityUid uid,
+        ProtoId<StatusEffectPrototype> status,
+        TimeSpan duration)
+        where T : IComponent, new()
+    {
+        if (duration <= TimeSpan.Zero)
+            return;
+
+        _status.TryAddStatusEffect<T>(uid, status, duration, refresh: true);
+    }
+
+    private void ApplyAsphyxiation(EntityUid uid, FixedPoint2 amount)
+    {
+        if (amount <= FixedPoint2.Zero)
+            return;
+
+        var damage = new DamageSpecifier();
+        damage.DamageDict["Asphyxiation"] = amount;
+        _damage.TryChangeDamage(uid, damage, ignoreResistances: true, interruptsDoAfters: false);
+    }
+
+    private void TryPainEmote(
+        EntityUid uid,
+        float chance,
+        IReadOnlyList<ProtoId<EmotePrototype>> emotes)
+    {
+        if (chance <= 0f || emotes.Count == 0 || !_random.Prob(chance))
+            return;
+
+        var emote = _random.Pick(emotes);
+        if (!_prototypes.HasIndex<EmotePrototype>(emote))
+            return;
+
+        _emote.TryEmoteWithChat(uid, emote, forceEmote: true, cooldown: TimeSpan.Zero);
+    }
+}

--- a/Content.Server/_CMU14/Medical/Surgery/CMUSurgerySystem.cs
+++ b/Content.Server/_CMU14/Medical/Surgery/CMUSurgerySystem.cs
@@ -4,6 +4,7 @@ using Content.Shared._CMU14.Medical.Bones;
 using Content.Shared._CMU14.Medical.BodyPart;
 using Content.Shared._CMU14.Medical.Organs;
 using Content.Shared._CMU14.Medical.Surgery;
+using Content.Shared._CMU14.Medical.Wounds;
 using Content.Shared._RMC14.Synth;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Organ;
@@ -107,6 +108,8 @@ public sealed partial class CMUSurgerySystem : SharedCMUSurgerySystem
         // (Comminuted) from prior trauma, leave it.
         if (HasComp<SynthComponent>(body))
         {
+            ClearSynthLimbOrganicMedicalState(limb);
+
             if (TryComp<FractureComponent>(limb, out var existingFracture))
                 Fracture.SetSeverity((limb, existingFracture), FractureSeverity.None, forceUpgrade: false);
         }
@@ -119,6 +122,28 @@ public sealed partial class CMUSurgerySystem : SharedCMUSurgerySystem
         TryClearMissingLimbStatus(body, limbPart.PartType, limbPart.Symmetry);
 
         _popup.PopupEntity(Loc.GetString("cmu-medical-reattach-success"), body, user, PopupType.Medium);
+    }
+
+    private void ClearSynthLimbOrganicMedicalState(EntityUid limb)
+    {
+        if (TryComp<BodyPartWoundComponent>(limb, out var wounds))
+        {
+            Wounds.ClearAllWounds((limb, wounds));
+
+            if (HasComp<BodyPartWoundComponent>(limb))
+                RemComp<BodyPartWoundComponent>(limb);
+        }
+
+        if (HasComp<InternalBleedingComponent>(limb))
+            RemComp<InternalBleedingComponent>(limb);
+        if (HasComp<CMUInternalBleedingSuppressedComponent>(limb))
+            RemComp<CMUInternalBleedingSuppressedComponent>(limb);
+        if (HasComp<CMUTourniquetComponent>(limb))
+            RemComp<CMUTourniquetComponent>(limb);
+        if (HasComp<CMUEscharComponent>(limb))
+            RemComp<CMUEscharComponent>(limb);
+        if (HasComp<CMUNecroticComponent>(limb))
+            RemComp<CMUNecroticComponent>(limb);
     }
 
     private void RestoreUsableHands(EntityUid body)

--- a/Content.Server/_CMU14/Medical/Wounds/CMUWoundsSystem.cs
+++ b/Content.Server/_CMU14/Medical/Wounds/CMUWoundsSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared._CMU14.Medical.BodyPart;
 using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Medical.Wounds;
 using Content.Shared.Body.Components;
+using Content.Shared.Body.Systems;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
@@ -16,6 +17,7 @@ public sealed partial class CMUWoundsSystem : SharedCMUWoundsSystem
 {
     [Dependency] private SharedRMCDamageableSystem _rmcDamageable = default!;
     [Dependency] private SharedSolutionContainerSystem _solutions = default!;
+    [Dependency] private SharedBloodstreamSystem _bloodstream = default!;
 
     private static readonly ProtoId<DamageGroupPrototype> BruteGroup = "Brute";
     private static readonly ProtoId<DamageGroupPrototype> BurnGroup = "Burn";
@@ -42,7 +44,8 @@ public sealed partial class CMUWoundsSystem : SharedCMUWoundsSystem
         if (rate <= 0f || tickSeconds <= 0f)
             return;
 
-        DrainBlood(body, rate * tickSeconds);
+        if (TryComp<BloodstreamComponent>(body, out var bloodstream))
+            _bloodstream.TryModifyBloodLevel((body, bloodstream), FixedPoint2.New(-(rate * tickSeconds)));
     }
 
     private void DrainBlood(EntityUid body, float amount)

--- a/Content.Server/_RMC14/Dropship/Weapon/DropshipWeaponSystem.cs
+++ b/Content.Server/_RMC14/Dropship/Weapon/DropshipWeaponSystem.cs
@@ -39,7 +39,7 @@ public sealed partial class DropshipWeaponSystem : SharedDropshipWeaponSystem
 
     protected override void RemovePvs(Entity<DropshipTerminalWeaponsComponent> terminal, Entity<ActorComponent?> actor)
     {
-        base.AddPvs(terminal, actor);
+        base.RemovePvs(terminal, actor);
 
         if (terminal.Comp.Target is not { } target)
             return;

--- a/Content.Server/_RMC14/Medical/Surgery/CMSurgerySystem.cs
+++ b/Content.Server/_RMC14/Medical/Surgery/CMSurgerySystem.cs
@@ -42,7 +42,9 @@ public sealed partial class CMSurgerySystem : SharedCMSurgerySystem
     [Dependency] private PopupSystem _popup = default!;
     [Dependency] private SkillsSystem _skills = default!;
     [Dependency] private UserInterfaceSystem _ui = default!;
+    [Dependency] private SharedSynthSystem _synth = default!;
     [Dependency] private SharedToolSystem _tool = default!;
+    [Dependency] private RMCRepairableSystem _repairable = default!;
     [Dependency] private WoundsSystem _wounds = default!;
     [Dependency] private CMUSurgeryDispatchSystem _cmuDispatch = default!;
     [Dependency] private CMUSurgeryFlowSystem _cmuFlow = default!;
@@ -91,6 +93,9 @@ public sealed partial class CMSurgerySystem : SharedCMSurgerySystem
                 args.Handled = handled;
             return;
         }
+
+        if (IsSynthRepairToolForCurrentDamage(ent, args.User, args.Used))
+            return;
 
         if (!HasMissingSynthLimbSlot(ent.Owner))
             return;
@@ -169,6 +174,21 @@ public sealed partial class CMSurgerySystem : SharedCMSurgerySystem
         return HasComp<BlowtorchComponent>(used) ||
                HasComp<RMCCableCoilComponent>(used) ||
                HasComp<BodyPartComponent>(used);
+    }
+
+    private bool IsSynthRepairToolForCurrentDamage(Entity<SynthComponent> synth, EntityUid user, EntityUid used)
+    {
+        if (HasComp<RMCCableCoilComponent>(used))
+            return _synth.HasDamage(synth.Owner, synth.Comp.CableCoilDamageGroup);
+
+        if (HasComp<BlowtorchComponent>(used) &&
+            _tool.HasQuality(used, synth.Comp.RepairQuality) &&
+            _synth.HasDamage(synth.Owner, synth.Comp.WelderDamageGroup))
+        {
+            return _repairable.UseFuel(used, user, 5, true);
+        }
+
+        return false;
     }
 
     private bool HasMissingSynthLimbSlot(EntityUid patient)

--- a/Content.Server/_RMC14/Xenonids/JoinXeno/LarvaQueueSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/JoinXeno/LarvaQueueSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.GameTicking;
 using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Components;
+using Content.Server._RMC14.Xenonids.Construction;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Dialog;
 using Content.Shared._RMC14.Dropship;
@@ -380,7 +381,8 @@ public sealed partial class LarvaQueueSystem : EntitySystem
             return false;
         }
 
-        return xeno.Role != LesserDroneRole;
+        return xeno.Role != LesserDroneRole ||
+               HasComp<XenoHiveCoreRoleComponent>(uid);
     }
 
     private bool TryOfferEntityClaim(EntityUid uid, Entity<HiveComponent> hive, LarvaQueueState queue)

--- a/Content.Shared/Eye/Blinding/Components/BlurryVisionComponent.cs
+++ b/Content.Shared/Eye/Blinding/Components/BlurryVisionComponent.cs
@@ -23,6 +23,13 @@ public sealed partial class BlurryVisionComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField("correctionPower"), AutoNetworkedField]
     public float CorrectionPower;
 
+    /// <summary>
+    ///     Exponent that controls the distortion level of the effect.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("distortionPower"), AutoNetworkedField]
+    public float DistortionPower = DefaultDistortionPower;
+
     public const float MaxMagnitude = 6;
     public const float DefaultCorrectionPower = 2f;
+    public const float DefaultDistortionPower = 2f;
 }

--- a/Content.Shared/Eye/Blinding/Systems/BlurryVisionSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlurryVisionSystem.cs
@@ -39,6 +39,7 @@ public sealed class BlurryVisionSystem : EntitySystem
         var blurry = EnsureComp<BlurryVisionComponent>(ent);
         blurry.Magnitude = blur;
         blurry.CorrectionPower = ev.CorrectionPower;
+        blurry.DistortionPower = ev.DistortionPower;
         Dirty(ent, blurry);
     }
 
@@ -58,6 +59,7 @@ public sealed class GetBlurEvent : EntityEventArgs, IInventoryRelayEvent
     public readonly float BaseBlur;
     public float Blur;
     public float CorrectionPower = BlurryVisionComponent.DefaultCorrectionPower;
+    public float DistortionPower = BlurryVisionComponent.DefaultDistortionPower;
 
     public GetBlurEvent(float blur)
     {

--- a/Content.Shared/_CMU14/Medical/EntityEffects/CMUApplyPainSuppressionEffect.cs
+++ b/Content.Shared/_CMU14/Medical/EntityEffects/CMUApplyPainSuppressionEffect.cs
@@ -21,6 +21,12 @@ public sealed partial class CMUApplyPainSuppressionEffect : EntityEffect
     public float DecayBonus = 0.75f;
 
     [DataField]
+    public float ReductionDecreaseRate = 0.25f;
+
+    [DataField]
+    public bool Additive;
+
+    [DataField]
     public float DurationPerUnit = 60f;
 
     public override void Effect(EntityEffectBaseArgs args)
@@ -28,12 +34,26 @@ public sealed partial class CMUApplyPainSuppressionEffect : EntityEffect
         if (args is not EntityEffectReagentArgs reagent)
             return;
         var duration = TimeSpan.FromSeconds(DurationPerUnit * (float)reagent.Quantity);
-        args.EntityManager.System<SharedPainShockSystem>().AddPainSuppressionProfile(
-            reagent.TargetEntity,
-            AccumulationSuppression,
-            TierSuppression,
-            DecayBonus,
-            duration);
+        var pain = args.EntityManager.System<SharedPainShockSystem>();
+        if (Additive)
+        {
+            pain.AddAdditivePainSuppressionProfile(
+                reagent.TargetEntity,
+                AccumulationSuppression,
+                TierSuppression,
+                DecayBonus,
+                duration);
+        }
+        else
+        {
+            pain.AddPainSuppressionProfile(
+                reagent.TargetEntity,
+                AccumulationSuppression,
+                TierSuppression,
+                DecayBonus,
+                duration,
+                ReductionDecreaseRate);
+        }
     }
 
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
@@ -41,5 +61,6 @@ public sealed partial class CMUApplyPainSuppressionEffect : EntityEffect
             ("percent", (int)(AccumulationSuppression * 100f)),
             ("tiers", TierSuppression),
             ("decay", DecayBonus),
+            ("decrease", ReductionDecreaseRate),
             ("seconds", DurationPerUnit));
 }

--- a/Content.Shared/_CMU14/Medical/EntityEffects/TemporaryBlurryVision.cs
+++ b/Content.Shared/_CMU14/Medical/EntityEffects/TemporaryBlurryVision.cs
@@ -1,0 +1,26 @@
+using Content.Shared._CMU14.Medical.TemporaryBlurryVision;
+using Content.Shared.EntityEffects;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._CMU14.Medical.EntityEffects;
+
+[UsedImplicitly]
+public sealed partial class TemporaryBlurryVision : EntityEffect
+{
+    [DataField]
+    public float Blur = 2f;
+
+    [DataField]
+    public float Time = 4f;
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        var scale = (args as EntityEffectReagentArgs)?.Scale.Float() ?? 1f;
+        args.EntityManager.System<CMUTemporaryBlurryVisionSystem>()
+            .AddTemporaryBlurModifier(args.TargetEntity, TimeSpan.FromSeconds(Time * scale), Blur);
+    }
+
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => null;
+}

--- a/Content.Shared/_CMU14/Medical/Organs/Eyes/CMUBlurDelaySystem.cs
+++ b/Content.Shared/_CMU14/Medical/Organs/Eyes/CMUBlurDelaySystem.cs
@@ -2,7 +2,7 @@ using Content.Shared.Eye.Blinding.Systems;
 
 namespace Content.Shared._CMU14.Medical.Organs.Eyes;
 
-public sealed class CMUBlurDelaySystem : EntitySystem
+public sealed partial class CMUBlurDelaySystem : EntitySystem
 {
     public override void Initialize()
     {
@@ -12,6 +12,8 @@ public sealed class CMUBlurDelaySystem : EntitySystem
 
     private void OnGetBlur(Entity<CMUBlurDelayComponent> ent, ref GetBlurEvent args)
     {
-        args.Blur -= ent.Comp.Threshold;
+        var baseBlur = MathF.Min(args.Blur, args.BaseBlur);
+        var extraBlur = args.Blur - baseBlur;
+        args.Blur = MathF.Max(0f, baseBlur - ent.Comp.Threshold) + extraBlur;
     }
 }

--- a/Content.Shared/_CMU14/Medical/StatusEffects/CMUPainFeedbackComponent.cs
+++ b/Content.Shared/_CMU14/Medical/StatusEffects/CMUPainFeedbackComponent.cs
@@ -1,0 +1,72 @@
+using Content.Shared.Chat.Prototypes;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._CMU14.Medical.StatusEffects;
+
+[RegisterComponent, AutoGenerateComponentPause]
+public sealed partial class CMUPainFeedbackComponent : Component
+{
+    [DataField]
+    public TimeSpan EffectInterval = TimeSpan.FromSeconds(1);
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [AutoPausedField]
+    public TimeSpan NextEffect;
+
+    [DataField]
+    public TimeSpan SevereBlurDuration = TimeSpan.FromSeconds(2);
+
+    [DataField]
+    public TimeSpan ShockBlurDuration = TimeSpan.FromSeconds(2);
+
+    [DataField]
+    public float SevereBlurStartAmount = 0.1f;
+
+    [DataField]
+    public float ShockBlurStartAmount = 2.25f;
+
+    [DataField]
+    public float ShockBlurAmount = 4f;
+
+    [DataField]
+    public float ShockBlurFullPain = 95f;
+
+    [DataField]
+    public TimeSpan SevereStutterDuration = TimeSpan.FromSeconds(4);
+
+    [DataField]
+    public TimeSpan ShockStutterDuration = TimeSpan.FromSeconds(4);
+
+    [DataField]
+    public float SevereDrunkPower = 2f;
+
+    [DataField]
+    public float ShockDrunkPower = 6f;
+
+    [DataField]
+    public FixedPoint2 SevereAsphyxiation = FixedPoint2.New(0.1);
+
+    [DataField]
+    public FixedPoint2 ShockAsphyxiation = FixedPoint2.New(0.5);
+
+    [DataField]
+    public float SevereEmoteChance = 0.033f;
+
+    [DataField]
+    public float ShockEmoteChance = 0.033f;
+
+    [DataField]
+    public List<ProtoId<EmotePrototype>> SevereEmotes = new()
+    {
+        "PainGrimace",
+        "TroubleEyeOpen",
+    };
+
+    [DataField]
+    public List<ProtoId<EmotePrototype>> ShockEmotes = new()
+    {
+        "TroubleStanding",
+    };
+}

--- a/Content.Shared/_CMU14/Medical/StatusEffects/PainSuppressionComponent.cs
+++ b/Content.Shared/_CMU14/Medical/StatusEffects/PainSuppressionComponent.cs
@@ -37,6 +37,9 @@ public sealed partial class PainSuppressionEntry
     [DataField]
     public float DecayBonus;
 
+    [DataField]
+    public float ReductionDecreaseRate;
+
     /// <summary>
     ///     Drug profiles compete with each other; non-drug morale/order
     ///     profiles add on top of the strongest drug profile.

--- a/Content.Shared/_CMU14/Medical/StatusEffects/SharedPainShockSystem.cs
+++ b/Content.Shared/_CMU14/Medical/StatusEffects/SharedPainShockSystem.cs
@@ -668,14 +668,16 @@ public abstract partial class SharedPainShockSystem : EntitySystem
         float accumulationSuppression,
         int tierSuppression,
         float decayBonus,
-        TimeSpan duration)
+        TimeSpan duration,
+        float reductionDecreaseRate = 0f)
         => AddPainSuppressionProfile(
             body,
             accumulationSuppression,
             tierSuppression,
             decayBonus,
             duration,
-            additive: false);
+            additive: false,
+            reductionDecreaseRate);
 
     public void AddAdditivePainSuppressionProfile(
         EntityUid body,
@@ -689,7 +691,8 @@ public abstract partial class SharedPainShockSystem : EntitySystem
             tierSuppression,
             decayBonus,
             duration,
-            additive: true);
+            additive: true,
+            reductionDecreaseRate: 0f);
 
     public void AddPainPulse(EntityUid body, FixedPoint2 amount)
     {
@@ -716,7 +719,8 @@ public abstract partial class SharedPainShockSystem : EntitySystem
         int tierSuppression,
         float decayBonus,
         TimeSpan duration,
-        bool additive)
+        bool additive,
+        float reductionDecreaseRate)
     {
         if (Net.IsClient || duration <= TimeSpan.Zero)
             return;
@@ -728,7 +732,7 @@ public abstract partial class SharedPainShockSystem : EntitySystem
         }
 
         var sup = EnsureComp<PainSuppressionComponent>(effectUid);
-        ResolveSuppressionProfile((effectUid, sup), dirty: false);
+        ResolveSuppressionProfile(body, (effectUid, sup), dirty: false);
         var oldAccumulation = sup.AccumulationSuppression;
         var oldTier = sup.TierSuppression;
         var oldDecay = sup.DecayBonus;
@@ -738,11 +742,12 @@ public abstract partial class SharedPainShockSystem : EntitySystem
             AccumulationSuppression = Math.Clamp(accumulationSuppression, 0f, 1f),
             TierSuppression = Math.Max(0, tierSuppression),
             DecayBonus = Math.Max(0f, decayBonus),
+            ReductionDecreaseRate = Math.Max(0f, reductionDecreaseRate),
             Additive = additive,
             ExpiresAt = Timing.CurTime + duration,
         });
 
-        ResolveSuppressionProfile((effectUid, sup));
+        ResolveSuppressionProfile(body, (effectUid, sup));
         RefreshTier(body);
 
         if (TryComp<PainShockComponent>(body, out var pain))
@@ -795,15 +800,16 @@ public abstract partial class SharedPainShockSystem : EntitySystem
 
         sup = suppression;
         if (Net.IsServer)
-            ResolveSuppressionProfile((effect, sup));
+            ResolveSuppressionProfile(body, (effect, sup));
 
         return sup.AccumulationSuppression > 0f || sup.TierSuppression > 0 || sup.DecayBonus > 0f;
     }
 
-    private void ResolveSuppressionProfile(Entity<PainSuppressionComponent> ent, bool dirty = true)
+    private void ResolveSuppressionProfile(EntityUid body, Entity<PainSuppressionComponent> ent, bool dirty = true)
     {
         var now = Timing.CurTime;
         var removed = ent.Comp.ActiveProfiles.RemoveAll(entry => entry.ExpiresAt <= now) > 0;
+        var painFraction = GetPainSuppressionPainFraction(body);
 
         var bestAccumulation = 0f;
         var bestTier = 0;
@@ -813,19 +819,24 @@ public abstract partial class SharedPainShockSystem : EntitySystem
         var additiveDecay = 0f;
         foreach (var entry in ent.Comp.ActiveProfiles)
         {
+            var effectiveness = GetPainSuppressionEffectiveness(entry, painFraction);
+            var accumulation = entry.AccumulationSuppression * effectiveness;
+            var tier = (int)MathF.Floor(entry.TierSuppression * effectiveness + 0.001f);
+            var decay = entry.DecayBonus * effectiveness;
+
             if (entry.Additive)
             {
-                additiveAccumulation += entry.AccumulationSuppression;
-                additiveTier += entry.TierSuppression;
-                additiveDecay += entry.DecayBonus;
+                additiveAccumulation += accumulation;
+                additiveTier += tier;
+                additiveDecay += decay;
                 continue;
             }
 
-            if (IsProfileStronger(entry, bestAccumulation, bestTier, bestDecay))
+            if (IsProfileStronger(accumulation, tier, decay, bestAccumulation, bestTier, bestDecay))
             {
-                bestAccumulation = entry.AccumulationSuppression;
-                bestTier = entry.TierSuppression;
-                bestDecay = entry.DecayBonus;
+                bestAccumulation = accumulation;
+                bestTier = tier;
+                bestDecay = decay;
             }
         }
 
@@ -846,17 +857,35 @@ public abstract partial class SharedPainShockSystem : EntitySystem
             Dirty(ent);
     }
 
+    private float GetPainSuppressionPainFraction(EntityUid body)
+    {
+        if (!TryComp<PainShockComponent>(body, out var pain) || pain.PainMax <= FixedPoint2.Zero)
+            return 0f;
+
+        return Math.Clamp(pain.Pain.Float() / pain.PainMax.Float(), 0f, 1f);
+    }
+
+    private static float GetPainSuppressionEffectiveness(PainSuppressionEntry entry, float painFraction)
+    {
+        if (entry.ReductionDecreaseRate <= 0f || painFraction <= 0f)
+            return 1f;
+
+        return Math.Clamp(1f - painFraction * entry.ReductionDecreaseRate, 0f, 1f);
+    }
+
     private static bool IsProfileStronger(
-        PainSuppressionEntry entry,
+        float accumulation,
+        int tier,
+        float decay,
         float bestAccumulation,
         int bestTier,
         float bestDecay)
     {
-        if (entry.TierSuppression != bestTier)
-            return entry.TierSuppression > bestTier;
-        if (MathF.Abs(entry.AccumulationSuppression - bestAccumulation) > 0.001f)
-            return entry.AccumulationSuppression > bestAccumulation;
-        return entry.DecayBonus > bestDecay;
+        if (tier != bestTier)
+            return tier > bestTier;
+        if (MathF.Abs(accumulation - bestAccumulation) > 0.001f)
+            return accumulation > bestAccumulation;
+        return decay > bestDecay;
     }
 
     private static bool SuppressionImproved(

--- a/Content.Shared/_CMU14/Medical/Surgery/SharedCMUSurgerySystem.cs
+++ b/Content.Shared/_CMU14/Medical/Surgery/SharedCMUSurgerySystem.cs
@@ -3,6 +3,7 @@ using Content.Shared._CMU14.Medical.Bones;
 using Content.Shared._CMU14.Medical.Items;
 using Content.Shared._CMU14.Medical.Organs;
 using Content.Shared._CMU14.Medical.Organs.Events;
+using Content.Shared._CMU14.Medical.Organs.Heart;
 using Content.Shared._CMU14.Medical.Surgery.Conditions;
 using Content.Shared._CMU14.Medical.Surgery.Effects;
 using Content.Shared._CMU14.Medical.Surgery.Traits;
@@ -35,6 +36,7 @@ public abstract partial class SharedCMUSurgerySystem : EntitySystem
     [Dependency] protected SharedBoneSystem Bone = default!;
     [Dependency] protected SharedContainerSystem Containers = default!;
     [Dependency] protected SharedFractureSystem Fracture = default!;
+    [Dependency] protected SharedHeartSystem Heart = default!;
     [Dependency] protected SharedOrganHealthSystem OrganHealth = default!;
     [Dependency] protected SharedCMUSurgicalTraitSystem SurgicalTraits = default!;
     [Dependency] protected SharedCMUShrapnelSystem Shrapnel = default!;
@@ -221,7 +223,14 @@ public abstract partial class SharedCMUSurgerySystem : EntitySystem
         if (!TryComp<OrganHealthComponent>(organ, out var oh))
             return;
 
+        HeartComponent? heart = null;
+        var canRestartHeart = oh.Stage != OrganDamageStage.Dead &&
+                              TryComp(organ, out heart);
+
         OrganHealth.HealOrgan((organ, oh), args.Body, oh.Max - oh.Current);
+        if (canRestartHeart)
+            Heart.TryRestartHeart((organ, heart));
+
         Wounds.RecomputeInternalBleed(args.Part);
     }
 

--- a/Content.Shared/_CMU14/Medical/TemporaryBlurryVision/CMUTemporaryBlurryVisionComponent.cs
+++ b/Content.Shared/_CMU14/Medical/TemporaryBlurryVision/CMUTemporaryBlurryVisionComponent.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._CMU14.Medical.TemporaryBlurryVision;
+
+[RegisterComponent, AutoGenerateComponentPause]
+public sealed partial class CMUTemporaryBlurryVisionComponent : Component
+{
+    [DataField]
+    public TimeSpan UpdateRate = TimeSpan.FromSeconds(1);
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [AutoPausedField]
+    public TimeSpan NextUpdate;
+
+    [DataField]
+    public List<CMUTemporaryBlurModifier> Modifiers = new();
+}
+
+[DataDefinition, Serializable]
+public sealed partial class CMUTemporaryBlurModifier
+{
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan ExpiresAt;
+
+    [DataField]
+    public float Strength;
+}

--- a/Content.Shared/_CMU14/Medical/TemporaryBlurryVision/CMUTemporaryBlurryVisionSystem.cs
+++ b/Content.Shared/_CMU14/Medical/TemporaryBlurryVision/CMUTemporaryBlurryVisionSystem.cs
@@ -1,0 +1,98 @@
+using Content.Shared._CMU14.Medical.Organs.Eyes;
+using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.Rejuvenate;
+using Robust.Shared.Network;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._CMU14.Medical.TemporaryBlurryVision;
+
+public sealed partial class CMUTemporaryBlurryVisionSystem : EntitySystem
+{
+    [Dependency] private BlurryVisionSystem _blur = default!;
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private INetManager _net = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CMUTemporaryBlurryVisionComponent, GetBlurEvent>(
+            OnGetBlur,
+            after: new[] { typeof(CMUBlurDelaySystem) });
+        SubscribeLocalEvent<CMUTemporaryBlurryVisionComponent, RejuvenateEvent>(OnRejuvenate);
+    }
+
+    public void AddTemporaryBlurModifier(
+        EntityUid uid,
+        TimeSpan duration,
+        float strength,
+        CMUTemporaryBlurryVisionComponent? blur = null)
+    {
+        if (_net.IsClient || duration <= TimeSpan.Zero || strength <= 0f)
+            return;
+
+        blur ??= EnsureComp<CMUTemporaryBlurryVisionComponent>(uid);
+        blur.Modifiers.Add(new CMUTemporaryBlurModifier
+        {
+            ExpiresAt = _timing.CurTime + duration,
+            Strength = strength,
+        });
+
+        blur.NextUpdate = _timing.CurTime + blur.UpdateRate;
+        _blur.UpdateBlurMagnitude(uid);
+    }
+
+    private void OnGetBlur(Entity<CMUTemporaryBlurryVisionComponent> ent, ref GetBlurEvent args)
+    {
+        var now = _timing.CurTime;
+        var strongest = 0f;
+        var hasActive = false;
+        foreach (var modifier in ent.Comp.Modifiers)
+        {
+            if (modifier.ExpiresAt > now)
+            {
+                strongest = MathF.Max(strongest, modifier.Strength);
+                hasActive = true;
+            }
+        }
+
+        if (hasActive)
+        {
+            args.Blur = MathF.Max(args.Blur, strongest);
+            args.CorrectionPower = 1.0f;
+            args.DistortionPower = 1.0f;
+        }
+    }
+
+    private void OnRejuvenate(Entity<CMUTemporaryBlurryVisionComponent> ent, ref RejuvenateEvent args)
+    {
+        ent.Comp.Modifiers.Clear();
+        _blur.UpdateBlurMagnitude(ent.Owner);
+        RemCompDeferred<CMUTemporaryBlurryVisionComponent>(ent.Owner);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_net.IsClient)
+            return;
+
+        var now = _timing.CurTime;
+        var query = EntityQueryEnumerator<CMUTemporaryBlurryVisionComponent>();
+        while (query.MoveNext(out var uid, out var blur))
+        {
+            if (blur.NextUpdate > now)
+                continue;
+
+            blur.NextUpdate = now + blur.UpdateRate;
+            var removed = blur.Modifiers.RemoveAll(modifier => modifier.ExpiresAt <= now) > 0;
+            if (!removed)
+                continue;
+
+            _blur.UpdateBlurMagnitude(uid);
+            if (blur.Modifiers.Count == 0)
+                RemCompDeferred<CMUTemporaryBlurryVisionComponent>(uid);
+        }
+    }
+}

--- a/Content.Shared/_CMU14/Medical/Wounds/SharedCMUTourniquetSystem.cs
+++ b/Content.Shared/_CMU14/Medical/Wounds/SharedCMUTourniquetSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared._CMU14.Medical.Items;
 using Content.Shared._CMU14.Medical.Wounds;
 using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Medical.Unrevivable;
+using Content.Shared._RMC14.Synth;
 using Content.Shared.Body.Part;
 using Content.Shared.Body.Systems;
 using Content.Shared.DoAfter;
@@ -70,6 +71,10 @@ public abstract partial class SharedCMUTourniquetSystem : EntitySystem
         {
             return;
         }
+        if (HasComp<SynthComponent>(target))
+        {
+            return;
+        }
 
         if (!TryFindTourniquetTargetPart(args.User, target, out var part, out var alreadyOn))
         {
@@ -100,6 +105,10 @@ public abstract partial class SharedCMUTourniquetSystem : EntitySystem
         if (args.Cancelled || args.Target is not { } target)
             return;
         if (!IsLayerEnabled())
+        {
+            return;
+        }
+        if (HasComp<SynthComponent>(target))
         {
             return;
         }
@@ -181,6 +190,10 @@ public abstract partial class SharedCMUTourniquetSystem : EntitySystem
     public bool ApplyTourniquetToPart(Entity<CMUTourniquetItemComponent> ent, EntityUid part)
     {
         if (!HasComp<BodyPartComponent>(part))
+            return false;
+        if (HasComp<SynthComponent>(part))
+            return false;
+        if (Wounds.TryGetBodyOwner(part) is { } body && HasComp<SynthComponent>(body))
             return false;
 
         var now = Timing.CurTime;
@@ -340,7 +353,7 @@ public abstract partial class SharedCMUTourniquetSystem : EntitySystem
         var query = EntityQueryEnumerator<CMUTourniquetComponent, BodyPartComponent>();
         while (query.MoveNext(out var partUid, out var tq, out var part))
         {
-            if (part.Body is not { } body || Unrevivable.IsUnrevivable(body))
+            if (part.Body is not { } body || Unrevivable.IsUnrevivable(body) || HasComp<SynthComponent>(body))
                 continue;
 
             if (tq.NextUpdate > now)

--- a/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
@@ -291,7 +291,8 @@ public abstract partial class SharedDropshipWeaponSystem : EntitySystem
             }
         }
 
-        MakeDropshipTarget(ent, abbreviation);
+        var creatorFaction = projectile.Shooter is { } shooter ? GetUserFaction(shooter) : null;
+        MakeDropshipTarget(ent, abbreviation, creatorFaction);
         _physics.SetBodyType(ent, BodyType.Static);
     }
 
@@ -1537,6 +1538,17 @@ public abstract partial class SharedDropshipWeaponSystem : EntitySystem
         return abbreviation;
     }
 
+    public string? GetUserFaction(EntityUid user)
+    {
+        if (TryComp(user, out MarineComponent? marine) &&
+            !string.IsNullOrEmpty(marine.Faction))
+        {
+            return marine.Faction;
+        }
+
+        return null;
+    }
+
     protected virtual void AddPvs(Entity<DropshipTerminalWeaponsComponent> terminal, Entity<ActorComponent?> actor)
     {
     }
@@ -1574,8 +1586,8 @@ public abstract partial class SharedDropshipWeaponSystem : EntitySystem
         if (user != null)
             active.Abbreviation = GetUserAbbreviation(user.Value, id);
 
-        if (user != null && TryComp<MarineComponent>(user.Value, out var marine) && !string.IsNullOrEmpty(marine.Faction))
-            active.CreatorFaction = marine.Faction;
+        if (user != null)
+            active.CreatorFaction = GetUserFaction(user.Value);
 
         Dirty(ent, active);
     }

--- a/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
@@ -91,6 +91,7 @@ public abstract partial class SharedDropshipWeaponSystem : EntitySystem
     [Dependency] private SharedPointLightSystem _pointLight = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private PowerLoaderSystem _powerloader = default!;
+    [Dependency] private IPrototypeManager _prototypes = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private SharedRMCCameraSystem _rmcCamera = default!;
     [Dependency] private SharedRMCFlammableSystem _rmcFlammable = default!;
@@ -1743,7 +1744,8 @@ public abstract partial class SharedDropshipWeaponSystem : EntitySystem
                 var target = _transform.ToMapCoordinates(flight.Target).Offset(spread);
                 foreach (var effect in flight.ImpactEffects)
                 {
-                    Spawn(effect, target, rotation: _random.NextAngle());
+                    var rotation = GetImpactEffectRotation(_random.NextAngle(), ImpactEffectHasOccluder(effect));
+                    Spawn(effect, target, rotation: rotation);
                 }
 
                 if (flight.Damage != null)
@@ -1863,6 +1865,19 @@ public abstract partial class SharedDropshipWeaponSystem : EntitySystem
             if (!_transform.InRange(xform.Coordinates, active.Origin, active.BreakRange))
                 RemCompDeferred<ActiveLaserDesignatorComponent>(uid);
         }
+    }
+
+    public static Angle GetImpactEffectRotation(Angle randomRotation, bool hasOccluder)
+    {
+        return hasOccluder
+            ? randomRotation.RoundToCardinalAngle()
+            : randomRotation;
+    }
+
+    private bool ImpactEffectHasOccluder(EntProtoId effect)
+    {
+        return _prototypes.TryIndex<EntityPrototype>(effect, out var prototype) &&
+               prototype.Components.ContainsKey("Occluder");
     }
 
     public void TargetUpdated(Entity<DropshipTargetComponent> ent)

--- a/Content.Shared/_RMC14/Synth/SharedSynthSystem.cs
+++ b/Content.Shared/_RMC14/Synth/SharedSynthSystem.cs
@@ -1,6 +1,8 @@
 using Content.Shared._RMC14.IdentityManagement;
 using Content.Shared._RMC14.Medical.HUD.Components;
+using Content.Shared._RMC14.Medical.Stasis;
 using Content.Shared._RMC14.Medical.Unrevivable;
+using Content.Shared._RMC14.Medical.Wounds;
 using Content.Shared._RMC14.Repairable;
 using Content.Shared._RMC14.StatusEffect;
 using Content.Shared.Actions;
@@ -56,6 +58,9 @@ public abstract partial class SharedSynthSystem : EntitySystem
         SubscribeLocalEvent<SynthComponent, AttackAttemptEvent>(OnMeleeAttempted);
         SubscribeLocalEvent<SynthComponent, ShotAttemptedEvent>(OnShotAttempted);
         SubscribeLocalEvent<SynthComponent, TryingToSleepEvent>(OnSleepAttempt);
+        SubscribeLocalEvent<SynthComponent, CMMetabolizeAttemptEvent>(OnMetabolizeAttempt);
+        SubscribeLocalEvent<SynthComponent, CMBleedAttemptEvent>(OnBleedAttempt);
+        SubscribeLocalEvent<SynthComponent, CMBleedEvent>(OnBleed);
         SubscribeLocalEvent<SynthComponent, InteractUsingEvent>(OnSynthInteractUsing);
         SubscribeLocalEvent<SynthComponent, RMCSynthRepairEvent>(OnSynthRepairDoAfter);
 
@@ -195,6 +200,21 @@ public abstract partial class SharedSynthSystem : EntitySystem
     private void OnSleepAttempt(Entity<SynthComponent> ent, ref TryingToSleepEvent args)
     {
         args.Cancelled = true; // Synths dont sleep
+    }
+
+    private void OnMetabolizeAttempt(Entity<SynthComponent> ent, ref CMMetabolizeAttemptEvent args)
+    {
+        args.Cancel();
+    }
+
+    private void OnBleedAttempt(Entity<SynthComponent> ent, ref CMBleedAttemptEvent args)
+    {
+        args.Cancelled = true;
+    }
+
+    private void OnBleed(Entity<SynthComponent> ent, ref CMBleedEvent args)
+    {
+        args.Handled = true;
     }
 
     private void OnSynthInteractUsing(Entity<SynthComponent> synth, ref InteractUsingEvent args)

--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCAirShotSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCAirShotSystem.cs
@@ -85,7 +85,7 @@ public sealed partial class RMCAirShotSystem : EntitySystem
                     {
                         var id = _dropship.ComputeNextId();
                         var flareIdentifier = _dropship.GetUserAbbreviation(args.User, id);
-                        _dropship.MakeDropshipTarget(spawned, flareIdentifier);
+                        _dropship.MakeDropshipTarget(spawned, flareIdentifier, _dropship.GetUserFaction(args.User));
 
                         ent.Comp.LastFlareId = flareIdentifier;
                         Dirty(ent);

--- a/Content.Shared/_RMC14/Xenonids/Alchemist/XenoAlchemistComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Alchemist/XenoAlchemistComponent.cs
@@ -53,10 +53,10 @@ public sealed partial class XenoAlchemistComponent : Component
     public int MaxStockpile = 20;
 
     [DataField, AutoNetworkedField]
-    public int ProduceAmount = 2;
+    public int ProduceAmount = 4;
 
     [DataField, AutoNetworkedField]
-    public int SlashGenerateAmount = 1;
+    public int SlashGenerateAmount = 2;
 
     [DataField, AutoNetworkedField]
     public TimeSpan ProduceDelay = TimeSpan.FromSeconds(2);
@@ -69,6 +69,15 @@ public sealed partial class XenoAlchemistComponent : Component
     {
         DamageDict = { ["Piercing"] = 20 },
     };
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan NoctineDazeTime = TimeSpan.FromSeconds(3);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan PyrinineDazeTime = TimeSpan.FromSeconds(2);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan CrynineSlowTime = TimeSpan.FromSeconds(4);
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier TailInjectionSound = new SoundPathSpecifier("/Audio/_RMC14/Xeno/alien_tail_attack.ogg");

--- a/Content.Shared/_RMC14/Xenonids/Alchemist/XenoAlchemistSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Alchemist/XenoAlchemistSystem.cs
@@ -1,6 +1,8 @@
 using Content.Shared._CMU14.Medical;
 using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Armor;
+using Content.Shared._RMC14.Slow;
+using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Synth;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Plasma;
@@ -32,9 +34,11 @@ public sealed partial class XenoAlchemistSystem : EntitySystem
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedRMCActionsSystem _rmcActions = default!;
     [Dependency] private SharedRMCMeleeWeaponSystem _rmcMelee = default!;
+    [Dependency] private RMCSlowSystem _rmcSlow = default!;
     [Dependency] private SharedSolutionContainerSystem _solution = default!;
     [Dependency] private SharedUserInterfaceSystem _ui = default!;
     [Dependency] private MovementSpeedModifierSystem _speed = default!;
+    [Dependency] private RMCDazedSystem _dazed = default!;
     [Dependency] private XenoPlasmaSystem _xenoPlasma = default!;
     [Dependency] private XenoSystem _xeno = default!;
 
@@ -369,7 +373,13 @@ public sealed partial class XenoAlchemistSystem : EntitySystem
 
     private void ApplyMixture(Entity<XenoAlchemistComponent> xeno, EntityUid target, AlchemistMixture mixture, int potency, bool injected)
     {
-        if (injected || !HasComp<XenoComponent>(target))
+        if (injected)
+        {
+            ApplyInjectedMixture(xeno, target, mixture, potency);
+            return;
+        }
+
+        if (!HasComp<XenoComponent>(target))
             return;
 
         var damage = mixture switch
@@ -396,6 +406,29 @@ public sealed partial class XenoAlchemistSystem : EntitySystem
 
         if (mixture == AlchemistMixture.Vapinine && TryComp(target, out XenoPlasmaComponent? plasma))
             _xenoPlasma.RemovePlasma((target, plasma), potency * 4);
+    }
+
+    private void ApplyInjectedMixture(Entity<XenoAlchemistComponent> xeno, EntityUid target, AlchemistMixture mixture, int potency)
+    {
+        var multiplier = Math.Clamp((float) potency / xeno.Comp.MaxStockpile, 0.25f, 1f);
+
+        switch (mixture)
+        {
+            case AlchemistMixture.Noctine:
+                _dazed.TryDaze(target, ScaleDuration(xeno.Comp.NoctineDazeTime, multiplier), true, stutter: true);
+                break;
+            case AlchemistMixture.Pyrinine:
+                _dazed.TryDaze(target, ScaleDuration(xeno.Comp.PyrinineDazeTime, multiplier), true);
+                break;
+            case AlchemistMixture.Crynine:
+                _rmcSlow.TrySlowdown(target, ScaleDuration(xeno.Comp.CrynineSlowTime, multiplier), ignoreDurationModifier: true);
+                break;
+        }
+    }
+
+    private static TimeSpan ScaleDuration(TimeSpan duration, float multiplier)
+    {
+        return TimeSpan.FromSeconds(duration.TotalSeconds * multiplier);
     }
 
     private void SetTailInjectionCooldown(Entity<XenoAlchemistComponent> xeno, int total)

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -35,6 +35,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Doors.Components;
 using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
+using Content.Shared.GameTicking;
 using Content.Shared.Interaction;
 using Content.Shared.Maps;
 using Content.Shared.Popups;
@@ -67,6 +68,7 @@ public sealed partial class SharedXenoConstructionSystem : EntitySystem
     [Dependency] private IComponentFactory _compFactory = default!;
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private SharedGameTicker _gameTicker = default!;
     [Dependency] private SharedXenoHiveSystem _hive = default!;
     [Dependency] private EntityLookupSystem _entityLookup = default!;
     [Dependency] private IMapManager _map = default!;
@@ -105,13 +107,16 @@ public sealed partial class SharedXenoConstructionSystem : EntitySystem
     private EntityQuery<XenoEggComponent> _xenoEggQuery;
     private EntityQuery<XenoTunnelComponent> _xenoTunnelQuery;
     private EntityQuery<QueenBuildingBoostComponent> _queenBoostQuery;
+    private EntityQuery<XenoHiveInstantBuildActionComponent> _xenoInstantBuildActionQuery;
 
     private const string XenoStructuresAnimation = "RMCEffect";
     private const string XenoHiveCoreNodeId = "HiveCoreXenoConstructionNode";
     private const float VehicleConstructionBlockRange = 3f;
+    private static readonly TimeSpan InstantBuildCounterRefreshInterval = TimeSpan.FromSeconds(1);
 
     private float _densityThreshold;
     private TimeSpan _newResinPreventCollideTime;
+    private TimeSpan _nextInstantBuildCounterRefresh;
 
     private readonly HashSet<EntityUid> _intersectingResin = new();
 
@@ -127,6 +132,7 @@ public sealed partial class SharedXenoConstructionSystem : EntitySystem
         _xenoEggQuery = GetEntityQuery<XenoEggComponent>();
         _xenoTunnelQuery = GetEntityQuery<XenoTunnelComponent>();
         _queenBoostQuery = GetEntityQuery<QueenBuildingBoostComponent>();
+        _xenoInstantBuildActionQuery = GetEntityQuery<XenoHiveInstantBuildActionComponent>();
 
         SubscribeLocalEvent<NewXenoEvolvedEvent>(OnNewXenoEvolved);
         SubscribeLocalEvent<XenoDevolvedEvent>(OnXenoDevolved);
@@ -502,7 +508,8 @@ public sealed partial class SharedXenoConstructionSystem : EntitySystem
             return;
         }
 
-        if (!CanSecreteOnTilePopup(xeno, choice, args.Target, true, true))
+        var canUseHiveInstantBuild = CanUseHiveInstantBuild(xeno.Owner);
+        if (!CanSecreteOnTilePopup(xeno, choice, args.Target, true, true, checkPlasma: !canUseHiveInstantBuild))
             return;
 
         var attempt = new XenoSecreteStructureAttemptEvent(args.Target);
@@ -524,6 +531,26 @@ public sealed partial class SharedXenoConstructionSystem : EntitySystem
             buildMult *= boostComp.BuildSpeedMultiplier;
 
         var finalBuildTime = xeno.Comp.BuildDelay * buildMult;
+
+        if (TryUseHiveInstantBuild(xeno.Owner, out var hive))
+        {
+            if (TryCompleteSecreteStructure(xeno, coordinates, choice, false))
+            {
+                args.Handled = true;
+            }
+            else if (hive is { } hiveEnt)
+            {
+                RefundHiveInstantBuild(hiveEnt);
+            }
+
+            return;
+        }
+
+        if (canUseHiveInstantBuild &&
+            !CanSecreteOnTilePopup(xeno, choice, args.Target, true, true))
+        {
+            return;
+        }
 
         if (_net.IsServer && _prototype.HasIndex(effectId))
         {
@@ -561,6 +588,138 @@ public sealed partial class SharedXenoConstructionSystem : EntitySystem
         Dirty(xeno);
     }
 
+    public int GetHiveInstantBuildsRemaining(EntityUid hive)
+    {
+        return TryComp(hive, out HiveComponent? comp)
+            ? comp.InstantBuildsRemaining
+            : 0;
+    }
+
+    public bool TryUseHiveInstantBuild(EntityUid hive)
+    {
+        if (!TryComp(hive, out HiveComponent? comp))
+            return false;
+
+        return TryUseHiveInstantBuild((hive, comp));
+    }
+
+    private bool TryUseHiveInstantBuild(Entity<HiveComponent> hive)
+    {
+        if (!CanUseHiveInstantBuild(hive))
+            return false;
+
+        hive.Comp.InstantBuildsRemaining--;
+        Dirty(hive);
+
+        if (_net.IsServer)
+            RefreshHiveInstantBuildActionCounters(hive);
+
+        return true;
+    }
+
+    private void RefundHiveInstantBuild(Entity<HiveComponent> hive)
+    {
+        var refunded = Math.Min(hive.Comp.InstantBuildsRemaining + 1, hive.Comp.MaxInstantBuilds);
+        if (refunded == hive.Comp.InstantBuildsRemaining)
+            return;
+
+        hive.Comp.InstantBuildsRemaining = refunded;
+        Dirty(hive);
+
+        if (_net.IsServer)
+            RefreshHiveInstantBuildActionCounters(hive);
+    }
+
+    private bool TryUseHiveInstantBuild(EntityUid user, out Entity<HiveComponent>? hive)
+    {
+        hive = _hive.GetHive(user);
+        if (hive is not { } hiveEnt)
+            return false;
+
+        if (!TryUseHiveInstantBuild(hiveEnt))
+            return false;
+
+        hive = hiveEnt;
+        return true;
+    }
+
+    private bool CanUseHiveInstantBuild(Entity<HiveComponent> hive)
+    {
+        return hive.Comp.InstantBuildsRemaining > 0 &&
+               IsHiveInstantBuildActive(hive);
+    }
+
+    private bool CanUseHiveInstantBuild(EntityUid user)
+    {
+        var hive = _hive.GetHive(user);
+        return hive is { } hiveEnt &&
+               CanUseHiveInstantBuild(hiveEnt);
+    }
+
+    private bool IsHiveInstantBuildActive(Entity<HiveComponent> hive)
+    {
+        return _gameTicker.RoundDuration() < hive.Comp.InstantBuildDuration;
+    }
+
+    private bool ShouldShowHiveInstantBuildCounter(Entity<HiveComponent> hive)
+    {
+        return IsHiveInstantBuildActive(hive) ||
+               hive.Comp.InstantBuildsRemaining > 0;
+    }
+
+    public void RefreshHiveInstantBuildActionCounters(EntityUid hiveUid)
+    {
+        if (!TryComp(hiveUid, out HiveComponent? hive))
+            return;
+
+        RefreshHiveInstantBuildActionCounters((hiveUid, hive));
+    }
+
+    private void RefreshAllHiveInstantBuildActionCounters()
+    {
+        var hives = EntityQueryEnumerator<HiveComponent>();
+        while (hives.MoveNext(out var hiveUid, out var hive))
+        {
+            RefreshHiveInstantBuildActionCounters((hiveUid, hive));
+        }
+    }
+
+    private void RefreshHiveInstantBuildActionCounters(Entity<HiveComponent> hive)
+    {
+        if (_net.IsClient)
+            return;
+
+        var showCounter = ShouldShowHiveInstantBuildCounter(hive);
+        var buildsLeft = Math.Max(0, hive.Comp.InstantBuildsRemaining);
+        var xenos = EntityQueryEnumerator<XenoComponent, HiveMemberComponent>();
+        while (xenos.MoveNext(out _, out var xeno, out var member))
+        {
+            if (member.Hive != hive.Owner)
+                continue;
+
+            foreach (var actionId in xeno.Actions.Values)
+            {
+                if (!_xenoInstantBuildActionQuery.TryComp(actionId, out var counter))
+                    continue;
+
+                SetInstantBuildActionCounter((actionId, counter), buildsLeft, showCounter);
+            }
+        }
+    }
+
+    private void SetInstantBuildActionCounter(Entity<XenoHiveInstantBuildActionComponent> action, int buildsLeft, bool visible)
+    {
+        if (action.Comp.BuildsLeft == buildsLeft &&
+            action.Comp.Visible == visible)
+        {
+            return;
+        }
+
+        action.Comp.BuildsLeft = buildsLeft;
+        action.Comp.Visible = visible;
+        Dirty(action);
+    }
+
     private void OnXenoSecreteStructureDoAfter(Entity<XenoConstructionComponent> xeno, ref XenoSecreteStructureDoAfterEvent args)
     {
         if (_net.IsServer && args.Effect != null)
@@ -569,46 +728,54 @@ public sealed partial class SharedXenoConstructionSystem : EntitySystem
         if (args.Handled || args.Cancelled)
             return;
 
-        var coordinates = GetCoordinates(args.Coordinates);
+        if (TryCompleteSecreteStructure(xeno, args.Coordinates, args.StructureId))
+            args.Handled = true;
+    }
+
+    private bool TryCompleteSecreteStructure(Entity<XenoConstructionComponent> xeno, NetCoordinates netCoordinates, EntProtoId structureId, bool consumePlasma = true)
+    {
+        var coordinates = GetCoordinates(netCoordinates);
         if (!coordinates.IsValid(EntityManager) ||
-            !xeno.Comp.CanBuild.Contains(args.StructureId) ||
-            !CanSecreteOnTilePopup(xeno, args.StructureId, GetCoordinates(args.Coordinates), true, true))
+            !xeno.Comp.CanBuild.Contains(structureId) ||
+            !CanSecreteOnTilePopup(xeno, structureId, coordinates, true, true, checkPlasma: consumePlasma))
         {
-            return;
+            return false;
         }
 
         var hasBoost = _queenBoostQuery.HasComp(xeno.Owner);
-        if (_area.TryGetArea(GetCoordinates(args.Coordinates), out var area, out _) &&
-            GetStructurePlasmaCost(args.StructureId) is { } baseCost)
+        if (_area.TryGetArea(coordinates, out var area, out _) &&
+            GetStructurePlasmaCost(structureId) is { } baseCost)
         {
             var cost = baseCost;
             if (area.Value.Comp.ResinConstructCount != 0 &&
                 !area.Value.Comp.Unweedable &&
-                _prototype.TryIndex(args.StructureId, out var structure) &&
+                _prototype.TryIndex(structureId, out var structure) &&
                 structure.TryGetComponent(out XenoConstructionPlasmaCostComponent? plasmaCost, _compFactory) &&
                 plasmaCost.ScalingCost)
             {
                 cost = GetDensityCost(area.Value, xeno, cost);
             }
 
-            var plasmaMult = GetDesignNodePlasmaCostMultiplier(xeno.Owner, coordinates, args.StructureId);
+            var plasmaMult = GetDesignNodePlasmaCostMultiplier(xeno.Owner, coordinates, structureId);
             if (plasmaMult > 0f && plasmaMult != 1f)
                 cost = Math.Ceiling(cost.Float() * plasmaMult);
 
-            if (!hasBoost && !_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, cost))
-                return;
+            if (consumePlasma &&
+                !hasBoost &&
+                !_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, cost))
+            {
+                return false;
+            }
         }
-
-        args.Handled = true;
 
         if (_net.IsServer)
         {
-            var structureToSpawn = args.StructureId;
+            var structureToSpawn = structureId;
             structureToSpawn = ResolveDesignerDesignNodeChoice(xeno.Owner, structureToSpawn);
 
             if (hasBoost)
             {
-                var queenVariant = GetQueenVariant(args.StructureId);
+                var queenVariant = GetQueenVariant(structureId);
                 if (_prototype.HasIndex(queenVariant))
                 {
                     structureToSpawn = queenVariant;
@@ -708,6 +875,7 @@ public sealed partial class SharedXenoConstructionSystem : EntitySystem
         }
 
         _audio.PlayPredicted(xeno.Comp.BuildSound, coordinates, xeno);
+        return true;
     }
 
     private void OnXenoOrderConstructionAction(Entity<XenoConstructionComponent> xeno, ref XenoOrderConstructionActionEvent args)
@@ -1310,7 +1478,7 @@ public sealed partial class SharedXenoConstructionSystem : EntitySystem
         return true;
     }
 
-    public bool CanSecreteOnTilePopup(Entity<XenoConstructionComponent> xeno, EntProtoId? buildChoice, EntityCoordinates target, bool checkStructureSelected, bool checkWeeds, bool popup = true)
+    public bool CanSecreteOnTilePopup(Entity<XenoConstructionComponent> xeno, EntProtoId? buildChoice, EntityCoordinates target, bool checkStructureSelected, bool checkWeeds, bool popup = true, bool checkPlasma = true)
     {
         if (checkStructureSelected && buildChoice == null)
         {
@@ -1412,7 +1580,8 @@ public sealed partial class SharedXenoConstructionSystem : EntitySystem
             }
         }
 
-        if (checkStructureSelected &&
+        if (checkPlasma &&
+            checkStructureSelected &&
             GetStructurePlasmaCost(buildChoice) is { } cost &&
             !hasBoost &&
             !_xenoPlasma.HasPlasmaPopup(xeno.Owner, cost, doPopup: popup))
@@ -1842,6 +2011,12 @@ public sealed partial class SharedXenoConstructionSystem : EntitySystem
     public override void Update(float frameTime)
     {
         var time = _timing.CurTime;
+        if (_net.IsServer && time >= _nextInstantBuildCounterRefresh)
+        {
+            _nextInstantBuildCounterRefresh = time + InstantBuildCounterRefreshInterval;
+            RefreshAllHiveInstantBuildActionCounters();
+        }
+
         var query = EntityQueryEnumerator<XenoRecentlyConstructedComponent>();
         while (query.MoveNext(out var uid, out var comp))
         {

--- a/Content.Shared/_RMC14/Xenonids/Construction/XenoHiveInstantBuildActionComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/XenoHiveInstantBuildActionComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Construction;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedXenoConstructionSystem), Other = AccessPermissions.ReadExecute)]
+public sealed partial class XenoHiveInstantBuildActionComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public int BuildsLeft;
+
+    [DataField, AutoNetworkedField]
+    public bool Visible;
+}

--- a/Content.Shared/_RMC14/Xenonids/Heatshield/XenoHeatshieldSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Heatshield/XenoHeatshieldSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Numerics;
 using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Damage;
@@ -29,9 +30,13 @@ public sealed partial class XenoHeatshieldSystem : EntitySystem
     [Dependency] private SharedRMCActionsSystem _rmcActions = default!;
     [Dependency] private MovementSpeedModifierSystem _speed = default!;
     [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private XenoSystem _xeno = default!;
 
+    private const float BileSprayTileRadius = 0.65f;
+
     private readonly HashSet<Entity<FlammableComponent>> _nearbyFlammables = new();
+    private readonly HashSet<EntityUid> _bileSprayTargets = new();
 
     public override void Initialize()
     {
@@ -68,8 +73,12 @@ public sealed partial class XenoHeatshieldSystem : EntitySystem
         if (args.Handled)
             return;
 
-        if (args.Entity is { } entity && TryUseBileOnEntity(xeno, entity, ref args))
+        if (args.Entity is { } entity &&
+            _hive.FromSameHive(xeno.Owner, entity) &&
+            TryUseBileOnEntity(xeno, entity, ref args))
+        {
             return;
+        }
 
         if (TryExtinguishTileFire(xeno, args.Target, ref args))
             return;
@@ -80,48 +89,92 @@ public sealed partial class XenoHeatshieldSystem : EntitySystem
             return;
         }
 
-        if (TryFindBileTarget(xeno, args.Target, out var target) &&
-            TryUseBileOnEntity(xeno, target, ref args))
-        {
+        if (TryUseBileSpray(xeno, args.Target, ref args))
             return;
-        }
 
         _popup.PopupClient(Loc.GetString("cm-xeno-heatshield-vomit-bile-no-target"), xeno, xeno);
     }
 
     private bool TryUseBileOnEntity(Entity<XenoHeatshieldComponent> xeno, EntityUid target, ref XenoVomitBileActionEvent args)
     {
-        if (TerminatingOrDeleted(target))
-            return false;
-
-        if (_hive.FromSameHive(xeno.Owner, target))
-        {
-            if (!_flammable.IsOnFire((target, null)))
-                return false;
-
-            if (!_rmcActions.TryUseAction(args))
-                return true;
-
-            args.Handled = true;
-            _flammable.Extinguish((target, null));
-            _popup.PopupClient(Loc.GetString("cm-xeno-heatshield-vomit-bile-extinguish"), target, xeno);
-            return true;
-        }
-
-        if (!_xeno.CanAbilityAttackTarget(xeno, target))
+        if (!CanUseBileOnEntity(xeno, target))
             return false;
 
         if (!_rmcActions.TryUseAction(args))
             return true;
 
         args.Handled = true;
+        ApplyBileToEntity(xeno, target);
+        return true;
+    }
+
+    private bool TryUseBileSpray(Entity<XenoHeatshieldComponent> xeno, EntityCoordinates target, ref XenoVomitBileActionEvent args)
+    {
+        _bileSprayTargets.Clear();
+
+        var xenoCoords = _transform.GetMoverCoordinates(xeno);
+        if (!TryGetBileSprayVectors(xenoCoords, target, out var forward, out var side))
+            return false;
+
+        var center = _rmcMap.SnapToGrid(xenoCoords.Offset(forward));
+        AddBileSprayTargets(xeno, center.Offset(-side));
+        AddBileSprayTargets(xeno, center);
+        AddBileSprayTargets(xeno, center.Offset(side));
+
+        if (_bileSprayTargets.Count == 0)
+            return false;
+
+        if (!_rmcActions.TryUseAction(args))
+            return true;
+
+        args.Handled = true;
+        foreach (var bileTarget in _bileSprayTargets)
+        {
+            if (CanUseBileOnEntity(xeno, bileTarget))
+                ApplyBileToEntity(xeno, bileTarget);
+        }
+
+        return true;
+    }
+
+    private void AddBileSprayTargets(Entity<XenoHeatshieldComponent> xeno, EntityCoordinates coordinates)
+    {
+        _nearbyFlammables.Clear();
+        _entityLookup.GetEntitiesInRange(coordinates, BileSprayTileRadius, _nearbyFlammables);
+
+        foreach (var flammable in _nearbyFlammables)
+        {
+            if (CanUseBileOnEntity(xeno, flammable.Owner))
+                _bileSprayTargets.Add(flammable.Owner);
+        }
+    }
+
+    private bool CanUseBileOnEntity(Entity<XenoHeatshieldComponent> xeno, EntityUid target)
+    {
+        if (target == xeno.Owner || TerminatingOrDeleted(target))
+            return false;
+
+        if (_hive.FromSameHive(xeno.Owner, target))
+            return _flammable.IsOnFire((target, null));
+
+        return _xeno.CanAbilityAttackTarget(xeno, target);
+    }
+
+    private void ApplyBileToEntity(Entity<XenoHeatshieldComponent> xeno, EntityUid target)
+    {
+        if (_hive.FromSameHive(xeno.Owner, target))
+        {
+            _flammable.Extinguish((target, null));
+            _popup.PopupClient(Loc.GetString("cm-xeno-heatshield-vomit-bile-extinguish"), target, xeno);
+            return;
+        }
+
         if (_flammable.IsOnFire((xeno.Owner, null)))
             _flammable.Ignite((target, null), 4, 8, 16);
         else
             _flammable.AdjustStacks((target, null), 4);
 
         _popup.PopupClient(Loc.GetString("cm-xeno-heatshield-vomit-bile-hostile"), target, xeno);
-        return true;
     }
 
     private bool TryExtinguishTileFire(Entity<XenoHeatshieldComponent> xeno, EntityCoordinates target, ref XenoVomitBileActionEvent args)
@@ -138,40 +191,30 @@ public sealed partial class XenoHeatshieldSystem : EntitySystem
         return true;
     }
 
-    private bool TryFindBileTarget(Entity<XenoHeatshieldComponent> xeno, EntityCoordinates target, out EntityUid found)
+    private bool TryGetBileSprayVectors(
+        EntityCoordinates xenoCoords,
+        EntityCoordinates target,
+        out Vector2 forward,
+        out Vector2 side)
     {
-        found = default;
-        _nearbyFlammables.Clear();
-        _entityLookup.GetEntitiesInRange(target, 0.45f, _nearbyFlammables);
+        forward = default;
+        side = default;
 
-        foreach (var flammable in _nearbyFlammables)
-        {
-            if (flammable.Owner == xeno.Owner || TerminatingOrDeleted(flammable.Owner))
-                continue;
+        var from = _transform.ToMapCoordinates(xenoCoords);
+        var to = _transform.ToMapCoordinates(target);
+        if (from.MapId != to.MapId)
+            return false;
 
-            if (!_hive.FromSameHive(xeno.Owner, flammable.Owner) ||
-                !_flammable.IsOnFire((flammable.Owner, null)))
-            {
-                continue;
-            }
+        var delta = to.Position - from.Position;
+        if (delta.LengthSquared() == 0)
+            return false;
 
-            found = flammable.Owner;
-            return true;
-        }
+        forward = Math.Abs(delta.X) >= Math.Abs(delta.Y)
+            ? new Vector2(Math.Sign(delta.X), 0)
+            : new Vector2(0, Math.Sign(delta.Y));
+        side = new Vector2(-forward.Y, forward.X);
 
-        foreach (var flammable in _nearbyFlammables)
-        {
-            if (flammable.Owner == xeno.Owner || TerminatingOrDeleted(flammable.Owner))
-                continue;
-
-            if (!_xeno.CanAbilityAttackTarget(xeno, flammable.Owner))
-                continue;
-
-            found = flammable.Owner;
-            return true;
-        }
-
-        return false;
+        return forward != Vector2.Zero;
     }
 
     private void OnSelfImmolateAction(Entity<XenoHeatshieldComponent> xeno, ref XenoSelfImmolateActionEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Heatshield/XenoHeatshieldSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Heatshield/XenoHeatshieldSystem.cs
@@ -12,6 +12,8 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Weapons.Melee.Events;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
@@ -20,6 +22,11 @@ namespace Content.Shared._RMC14.Xenonids.Heatshield;
 
 public sealed partial class XenoHeatshieldSystem : EntitySystem
 {
+    private const string FireSpewEffectPrototype = "RMCEffectXenoFireSpew";
+    private static readonly SoundSpecifier FireSpewSound = new SoundCollectionSpecifier("RMCFlamerShoot",
+        AudioParams.Default.WithVolume(-6f).WithVariation(0.05f));
+
+    [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
     [Dependency] private EntityLookupSystem _entityLookup = default!;
     [Dependency] private SharedRMCFlammableSystem _flammable = default!;
@@ -117,9 +124,11 @@ public sealed partial class XenoHeatshieldSystem : EntitySystem
             return false;
 
         var center = _rmcMap.SnapToGrid(xenoCoords.Offset(forward));
-        AddBileSprayTargets(xeno, center.Offset(-side));
+        var left = center.Offset(-side);
+        var right = center.Offset(side);
+        AddBileSprayTargets(xeno, left);
         AddBileSprayTargets(xeno, center);
-        AddBileSprayTargets(xeno, center.Offset(side));
+        AddBileSprayTargets(xeno, right);
 
         if (_bileSprayTargets.Count == 0)
             return false;
@@ -128,6 +137,14 @@ public sealed partial class XenoHeatshieldSystem : EntitySystem
             return true;
 
         args.Handled = true;
+        if (_flammable.IsOnFire((xeno.Owner, null)))
+        {
+            _audio.PlayPredicted(FireSpewSound, xeno, xeno);
+            SpawnAtPosition(FireSpewEffectPrototype, left);
+            SpawnAtPosition(FireSpewEffectPrototype, center);
+            SpawnAtPosition(FireSpewEffectPrototype, right);
+        }
+
         foreach (var bileTarget in _bileSprayTargets)
         {
             if (CanUseBileOnEntity(xeno, bileTarget))

--- a/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
@@ -10,7 +10,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 namespace Content.Shared._RMC14.Xenonids.Hive;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
-[Access(typeof(SharedXenoHiveSystem), typeof(SharedXenoPylonSystem), typeof(XenoTunnelSystem))]
+[Access(typeof(SharedXenoHiveSystem), typeof(SharedXenoConstructionSystem), typeof(SharedXenoPylonSystem), typeof(XenoTunnelSystem))]
 public sealed partial class HiveComponent : Component
 {
     [DataField, AutoNetworkedField]
@@ -25,6 +25,15 @@ public sealed partial class HiveComponent : Component
 
     [DataField, AutoNetworkedField]
     public Dictionary<EntProtoId, int> HiveStructureSlots = new() { ["HiveCoreXeno"] = 1, ["HiveClusterXeno"] = 8, ["HivePylonXeno"] = 2, ["HiveEggMorpherXeno"] = 6, ["HiveRecoveryNodeXeno"] = 6, ["HivePlasmaTreeXeno"] = 3 };
+
+    [DataField, AutoNetworkedField]
+    public int MaxInstantBuilds = 200;
+
+    [DataField, AutoNetworkedField]
+    public int InstantBuildsRemaining = 200;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan InstantBuildDuration = TimeSpan.FromMinutes(30);
 
     [DataField, AutoNetworkedField]
     public Dictionary<TimeSpan, List<EntProtoId>> Unlocks = new();

--- a/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
@@ -115,6 +115,7 @@ public abstract partial class SharedXenoHiveSystem : EntitySystem
 
     private void OnMapInit(Entity<HiveComponent> ent, ref MapInitEvent args)
     {
+        ent.Comp.InstantBuildsRemaining = ent.Comp.MaxInstantBuilds;
         ent.Comp.AnnouncedUnlocks.Clear();
         ent.Comp.Unlocks.Clear();
         ent.Comp.AnnouncementsLeft.Clear();

--- a/Content.Shared/_RMC14/Xenonids/Reaper/XenoReaperComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Reaper/XenoReaperComponent.cs
@@ -22,19 +22,16 @@ public sealed partial class XenoReaperComponent : Component
     public int MeleeGain = 5;
 
     [DataField, AutoNetworkedField]
-    public int PassiveDrain = 1;
+    public int PassiveGain = 2;
 
     [DataField, AutoNetworkedField]
-    public TimeSpan PassiveDrainEvery = TimeSpan.FromSeconds(4);
+    public TimeSpan PassiveGainEvery = TimeSpan.FromSeconds(1);
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
-    public TimeSpan NextPassiveDrainAt;
+    public TimeSpan NextPassiveGainAt;
 
     [DataField, AutoNetworkedField]
-    public int HighFleshResinDrainThreshold = 300;
-
-    [DataField, AutoNetworkedField]
-    public int HighFleshResinDrain = 0;
+    public int PassiveGainMaxFleshResin = 300;
 
     [DataField, AutoNetworkedField]
     public int FleshHarvestGain = 150;
@@ -50,12 +47,6 @@ public sealed partial class XenoReaperComponent : Component
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier RaptureSound = new SoundCollectionSpecifier("AlienClaw");
-
-    [DataField, AutoNetworkedField]
-    public TimeSpan DrainPauseAfterAbility = TimeSpan.FromSeconds(10);
-
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
-    public TimeSpan PauseDrainUntil;
 
     [DataField, AutoNetworkedField]
     public int FleshBloomCost = 120;

--- a/Content.Shared/_RMC14/Xenonids/Reaper/XenoReaperSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Reaper/XenoReaperSystem.cs
@@ -80,6 +80,8 @@ public sealed partial class XenoReaperSystem : EntitySystem
 
     private void OnReaperMapInit(Entity<XenoReaperComponent> xeno, ref MapInitEvent args)
     {
+        xeno.Comp.NextPassiveGainAt = _timing.CurTime + xeno.Comp.PassiveGainEvery;
+        Dirty(xeno);
         UpdateFleshAlert(xeno);
     }
 
@@ -138,7 +140,6 @@ public sealed partial class XenoReaperSystem : EntitySystem
         EnsureComp<XenoFleshHarvestedComponent>(target);
         RipLimbsFromCorpse(target);
         AddFleshResin(xeno, xeno.Comp.FleshHarvestGain);
-        PauseDrain(xeno);
     }
 
     private void OnRaptureAction(Entity<XenoReaperComponent> xeno, ref XenoRaptureActionEvent args)
@@ -156,7 +157,6 @@ public sealed partial class XenoReaperSystem : EntitySystem
             SpawnAttachedTo(xeno.Comp.RaptureEffect, args.Target.ToCoordinates());
 
         AddFleshResin(xeno, xeno.Comp.RaptureGain);
-        PauseDrain(xeno);
     }
 
     private void OnFleshBloomAction(Entity<XenoReaperComponent> xeno, ref XenoFleshBloomActionEvent args)
@@ -200,7 +200,6 @@ public sealed partial class XenoReaperSystem : EntitySystem
             return;
 
         args.Handled = true;
-        PauseDrain(xeno);
 
         if (_net.IsClient)
             return;
@@ -226,7 +225,6 @@ public sealed partial class XenoReaperSystem : EntitySystem
             return;
 
         args.Handled = true;
-        PauseDrain(xeno);
 
         if (_net.IsServer)
             TryStartRedGasStepDoAfter(xeno, ToNetPath(path), 0);
@@ -277,7 +275,6 @@ public sealed partial class XenoReaperSystem : EntitySystem
         _movementSpeed.RefreshMovementSpeedModifiers(args.Target);
         _armor.UpdateArmorValue((args.Target, null));
         _popup.PopupClient(Loc.GetString("cm-xeno-reaper-carrion-mantle"), args.Target, xeno);
-        PauseDrain(xeno);
     }
 
     private void OnCarrionMantleGetArmor(Entity<XenoCarrionMantleComponent> ent, ref CMGetArmorEvent args)
@@ -305,25 +302,19 @@ public sealed partial class XenoReaperSystem : EntitySystem
         var query = EntityQueryEnumerator<XenoReaperComponent>();
         while (query.MoveNext(out var uid, out var reaper))
         {
-            if (time < reaper.PauseDrainUntil)
-            {
-                reaper.NextPassiveDrainAt = time + reaper.PassiveDrainEvery;
-                Dirty(uid, reaper);
-                continue;
-            }
-
-            if (time < reaper.NextPassiveDrainAt)
+            if (time < reaper.NextPassiveGainAt)
                 continue;
 
-            reaper.NextPassiveDrainAt = time + reaper.PassiveDrainEvery;
-            if (reaper.FleshResin <= reaper.HighFleshResinDrainThreshold)
+            reaper.NextPassiveGainAt = time + reaper.PassiveGainEvery;
+            var passiveCap = Math.Min(reaper.MaxFleshResin, reaper.PassiveGainMaxFleshResin);
+            if (passiveCap <= 0 || reaper.FleshResin >= passiveCap)
                 continue;
 
-            var drain = Math.Max(0, reaper.PassiveDrain + reaper.HighFleshResinDrain);
-            if (drain == 0)
+            var gain = Math.Max(0, reaper.PassiveGain);
+            if (gain == 0)
                 continue;
 
-            reaper.FleshResin = Math.Max(reaper.HighFleshResinDrainThreshold, reaper.FleshResin - drain);
+            reaper.FleshResin = Math.Min(passiveCap, reaper.FleshResin + gain);
             Dirty(uid, reaper);
             UpdateFleshAlert((uid, reaper));
         }
@@ -687,12 +678,6 @@ public sealed partial class XenoReaperSystem : EntitySystem
         Dirty(reaper);
         UpdateFleshAlert(reaper);
         return true;
-    }
-
-    private void PauseDrain(Entity<XenoReaperComponent> reaper)
-    {
-        reaper.Comp.PauseDrainUntil = _timing.CurTime + reaper.Comp.DrainPauseAfterAbility;
-        Dirty(reaper);
     }
 
     private void UpdateFleshAlert(Entity<XenoReaperComponent> reaper)

--- a/Content.Tests/Shared/_RMC14/Dropship/DropshipImpactEffectRotationTest.cs
+++ b/Content.Tests/Shared/_RMC14/Dropship/DropshipImpactEffectRotationTest.cs
@@ -1,0 +1,29 @@
+using Content.Shared._RMC14.Dropship.Weapon;
+using NUnit.Framework;
+using Robust.Shared.Maths;
+
+namespace Content.Tests.Shared._RMC14.Dropship;
+
+[TestFixture]
+public sealed class DropshipImpactEffectRotationTest
+{
+    [Test]
+    public void OccluderImpactEffectsRoundRandomRotationToCardinal()
+    {
+        var rotation = SharedDropshipWeaponSystem.GetImpactEffectRotation(
+            Angle.FromDegrees(45),
+            hasOccluder: true);
+
+        Assert.That(rotation.GetDir(), Is.EqualTo(Direction.East));
+    }
+
+    [Test]
+    public void NonOccluderImpactEffectsKeepRandomRotation()
+    {
+        var rotation = SharedDropshipWeaponSystem.GetImpactEffectRotation(
+            Angle.FromDegrees(45),
+            hasOccluder: false);
+
+        Assert.That(rotation, Is.EqualTo(Angle.FromDegrees(45)));
+    }
+}

--- a/Resources/Locale/en-US/_CMU14/medical/reagents.ftl
+++ b/Resources/Locale/en-US/_CMU14/medical/reagents.ftl
@@ -1,5 +1,5 @@
 cmu-medical-heal-organ-guidebook            = Heals { $amount } HP per cycle on the patient's { $organ }.
-cmu-medical-pain-suppression-guidebook       = Suppresses { $percent }% of pain accumulation, masks { $tiers } pain tier(s), and adds { $decay } pain/sec decay for { $seconds } seconds per unit. Strongest active painkiller profile wins.
+cmu-medical-pain-suppression-guidebook       = Suppresses { $percent }% of pain accumulation, masks { $tiers } pain tier(s), and adds { $decay } pain/sec decay for { $seconds } seconds per unit. Effect weakens by { $decrease } per max-pain fraction; non-additive profiles keep the strongest active profile.
 cmu-medical-bone-regen-boost-guidebook       = Multiplies bone healing rate by { $multiplier } while active.
 cmu-medical-restart-heart-guidebook          = { $chance }% chance per cycle to restart a stopped heart (only on hearts that are not yet at the Dead stage).
 

--- a/Resources/Locale/en-US/_RMC14/chat/pain-emotes.ftl
+++ b/Resources/Locale/en-US/_RMC14/chat/pain-emotes.ftl
@@ -1,0 +1,8 @@
+rmc-chat-emote-name-pain-grimace = Grimace
+rmc-chat-emote-msg-pain-grimace = grimaces in pain.
+
+rmc-chat-emote-name-trouble-eye-open = Trouble Opening Eyes
+rmc-chat-emote-msg-trouble-eye-open = struggles to keep {POSS-ADJ($entity)} eyes open.
+
+rmc-chat-emote-name-pain-trouble-standing = Trouble Standing
+rmc-chat-emote-msg-pain-trouble-standing = struggles to stay standing.

--- a/Resources/Prototypes/_AU14/Entities/Weapons/HAZOPS/gau19e2.yml
+++ b/Resources/Prototypes/_AU14/Entities/Weapons/HAZOPS/gau19e2.yml
@@ -85,7 +85,7 @@
     - range: 12
       falloff: 9999
       ignoreModifiers: true
-    - range: 7
+    - range: 4.5
       falloff: 4
 
 - type: Tag

--- a/Resources/Prototypes/_AU14/Entities/Weapons/UPP/rfvs37.yml
+++ b/Resources/Prototypes/_AU14/Entities/Weapons/UPP/rfvs37.yml
@@ -81,7 +81,7 @@
     - range: 10
       falloff: 9999
       ignoreModifiers: true
-    - range: 7
+    - range: 4.5
       falloff: 4
   - type: RMCProjectileAccuracy
     accuracy: 105

--- a/Resources/Prototypes/_CMU14/Medical/reagents/painkillers.yml
+++ b/Resources/Prototypes/_CMU14/Medical/reagents/painkillers.yml
@@ -41,6 +41,11 @@
         damage:
           types:
             Poison: 1
+      - !type:Drunk
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        boozePower: 5
 
 - type: reagent
   parent: CMReagentMedicine
@@ -71,3 +76,8 @@
         damage:
           types:
             Poison: 2
+      - !type:Drunk
+        conditions:
+        - !type:ReagentThreshold
+          min: 20
+        boozePower: 8

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_construction_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_construction_actions.yml
@@ -66,6 +66,7 @@
     checkStructureSelected: true
     checkWeeds: true
     canUpgrade: true
+  - type: XenoHiveInstantBuildAction
   - type: RMCDazeableAction
 
 - type: entity
@@ -98,6 +99,7 @@
     checkStructureSelected: true
     checkWeeds: true
     canUpgrade: false
+  - type: XenoHiveInstantBuildAction
   - type: RMCDazeableAction
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_utility_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_utility_actions.yml
@@ -434,7 +434,7 @@
   id: ActionXenoVomitBile
   parent: ActionXenoBase
   name: Vomit Bile (40)
-  description: Extinguishes a nearby hivemate or coats an enemy in volatile bile.
+  description: Extinguishes a nearby hivemate or sprays volatile bile over enemies in the three tiles in front of you.
   components:
   - type: Action
     itemIconStyle: NoItem

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_utility_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_utility_actions.yml
@@ -443,7 +443,7 @@
       state: xeno_spit
     useDelay: 8
   - type: TargetAction
-    range: 1.5
+    range: 1.8
     checkCanAccess: false
   - type: EntityTargetAction
     targetCheckCanInteract: false

--- a/Resources/Prototypes/_RMC14/Effects/fire.yml
+++ b/Resources/Prototypes/_RMC14/Effects/fire.yml
@@ -1,0 +1,21 @@
+- type: entity
+  parent: RMCBaseEffect
+  id: RMCEffectXenoFireSpew
+  name: fire spew
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: _RMC14/Effects/fire.rsi
+    noRot: true
+    drawdepth: WallTops
+    layers:
+    - state: red_4
+  - type: PointLight
+    radius: 3
+    color: "#bf6d02"
+  - type: TimedDespawn
+    lifetime: 0.6
+  - type: EffectVisuals
+  - type: Tag
+    tags:
+    - HideContextMenu

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -115,6 +115,7 @@
   - type: CMUHumanMedical
   - type: HitLocation
   - type: PainShock
+  - type: CMUPainFeedback
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: null

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34_flamer.yml
@@ -33,6 +33,8 @@
     - FullAuto
     soundGunshot:
       collection: RMCFlamerShoot
+  - type: UseDelay
+    delay: 2
   - type: ShootUseDelay
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34t_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34t_flamer.yml
@@ -5,7 +5,7 @@
   description: An improved version of the M34 incinerator unit, the M34-T model is capable of dispersing a larger variety of fuel types.
   components:
   - type: Corrodible
-    isCorrodible: false
+    isCorrodible: true
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Guns/Flamethrower/m34t.rsi
   - type: Item
@@ -13,7 +13,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Weapons/Guns/Flamethrower/m34t.rsi
   - type: UseDelay
-    delay: 0.5
+    delay: 3
   - type: AttachableHolder # NOTE: The nozzle is only for the base M34.
     slots:
       rmc-aslot-rail:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
@@ -81,7 +81,7 @@
     soundGunshot:
       path: /Audio/_RMC14/Weapons/Guns/Gunshots/m5_shoot.ogg
   - type: Corrodible
-    isCorrodible: false
+    isCorrodible: true
   - type: RMCMagneticItem
 
 # 84mm HE

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SmartGuns/smart_gun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SmartGuns/smart_gun.yml
@@ -459,7 +459,7 @@
     - range: 12
       falloff: 9999
       ignoreModifiers: true
-    - range: 7
+    - range: 4.5
       falloff: 4
   - type: RMCProjectileAccuracy
     accuracy: 105

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -148,6 +148,13 @@
       effects:
       - !type:Electrogenetic
         potency: 2
+      - !type:CMUApplyPainSuppressionEffect
+        accumulationSuppression: 0.15
+        tierSuppression: 1
+        decayBonus: 0.25
+        reductionDecreaseRate: 0
+        durationPerUnit: 20
+        additive: true
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -183,6 +190,13 @@
         damage:
           types:
             Asphyxiation: -1
+      - !type:CMUApplyPainSuppressionEffect
+        accumulationSuppression: 0.3
+        tierSuppression: 2
+        decayBonus: 0.5
+        reductionDecreaseRate: 0
+        durationPerUnit: 8
+        additive: true
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/_RMC14/Reagents/toxins.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/toxins.yml
@@ -182,16 +182,16 @@
   toxin: true
   metabolisms:
     Poison:
-      metabolismRate: 0.2
+      metabolismRate: 0.4
       effects:
       - !type:Biocidic
-        potency: 2
+        potency: 4
       - !type:AdjustReagent
         reagent: CMBicaridine
-        amount: -0.2
+        amount: -0.4
       - !type:AdjustReagent
         reagent: CMMeralyne
-        amount: -0.2
+        amount: -0.4
 
 - type: reagent
   parent: CMReagent
@@ -204,16 +204,16 @@
   toxin: true
   metabolisms:
     Poison:
-      metabolismRate: 0.2
+      metabolismRate: 0.4
       effects:
       - !type:Corrosive
-        potency: 2
+        potency: 4
       - !type:AdjustReagent
         reagent: CMKelotane
-        amount: -0.2
+        amount: -0.4
       - !type:AdjustReagent
         reagent: CMDermaline
-        amount: -0.2
+        amount: -0.4
 
 - type: reagent
   parent: CMReagent
@@ -226,21 +226,21 @@
   toxin: true
   metabolisms:
     Poison:
-      metabolismRate: 0.2
+      metabolismRate: 0.4
       effects:
       - !type:RMCAlchemistPain
-        potency: 4
+        potency: 8
       - !type:Jitter
         probability: 0.1
       - !type:AdjustReagent
         reagent: CMUParacetamol
-        amount: -0.2
+        amount: -0.4
       - !type:AdjustReagent
         reagent: CMUTramadol
-        amount: -0.2
+        amount: -0.4
       - !type:AdjustReagent
         reagent: CMUOxycodone
-        amount: -0.2
+        amount: -0.4
 
 - type: reagent
   parent: CMReagent
@@ -253,12 +253,12 @@
   toxin: true
   metabolisms:
     Poison:
-      metabolismRate: 0.2
+      metabolismRate: 0.4
       effects:
       - !type:Corrosive
-        potency: 2
+        potency: 4
       - !type:AdjustTemperature
-        amount: 6000
+        amount: 12000
 
 - type: reagent
   parent: CMReagent
@@ -271,10 +271,22 @@
   toxin: true
   metabolisms:
     Poison:
-      metabolismRate: 0.2
+      metabolismRate: 0.4
       effects:
       - !type:Hemolytic
-        potency: 1
+        potency: 2
+      - !type:AdjustReagent
+        reagent: CMDexalin
+        amount: -0.4
+      - !type:AdjustReagent
+        reagent: CMDexalinPlus
+        amount: -0.4
+      - !type:AdjustReagent
+        reagent: CMInaprovaline
+        amount: -0.4
+      - !type:AdjustReagent
+        reagent: RMCIron
+        amount: -0.4
 
 - type: reagent
   parent: CMReagent
@@ -287,16 +299,16 @@
   toxin: true
   metabolisms:
     Poison:
-      metabolismRate: 0.2
+      metabolismRate: 0.4
       effects:
       - !type:AdjustTemperature
-        amount: -6000
+        amount: -12000
       - !type:AdjustReagent
         reagent: CMCryoxadone
-        amount: -0.2
+        amount: -0.4
       - !type:AdjustReagent
         reagent: CMClonexadone
-        amount: -0.2
+        amount: -0.4
 
 - type: reagent
   parent: CMReagent
@@ -309,7 +321,7 @@
   toxin: true
   metabolisms:
     Poison:
-      metabolismRate: 0.2
+      metabolismRate: 0.4
       effects:
       - !type:RMCAlchemistPurgeNonToxins
-        amount: 0.2
+        amount: 0.4

--- a/Resources/Prototypes/_RMC14/Voice/rmc_pain_emotes.yml
+++ b/Resources/Prototypes/_RMC14/Voice/rmc_pain_emotes.yml
@@ -1,0 +1,14 @@
+- type: emote
+  id: PainGrimace
+  name: rmc-chat-emote-name-pain-grimace
+  chatMessages: ["rmc-chat-emote-msg-pain-grimace"]
+
+- type: emote
+  id: TroubleEyeOpen
+  name: rmc-chat-emote-name-trouble-eye-open
+  chatMessages: ["rmc-chat-emote-msg-trouble-eye-open"]
+
+- type: emote
+  id: TroubleStanding
+  name: rmc-chat-emote-name-pain-trouble-standing
+  chatMessages: ["rmc-chat-emote-msg-pain-trouble-standing"]


### PR DESCRIPTION
:cl:
  add: Heatshield Vomit Bile now spews fire in 3 tiles infront of it
  add: Added a flamer burst sound to Heatshield’s burning Vomit Bile spray.
  tweak: Increased Heatshield Vomit Bile targeting range by 20%, from 1.5 to 1.8.

  add: Reaper now passively gains flesh resin up to 300.
  tweak: Reaper passive flesh gain is 2 flesh per second instead of draining stored flesh.
  fix: Reapers Red mist no longer gives toxin to synths

  tweak: Set M240 use delay to 2s, M34-T use delay to 3s, and smartgun falloff start to 4.5 tiles.
  fix: Made the M34/M34-T flamer and SMAW meltable.   

  tweak: Join Xeno abandoned-body filtering now allows actual hive-core lesser drones while keeping non-drone lesser xeno
bodies excluded.
  fix: Larva no longer appear as normal ghost roles, and ghosted lesser drones can be offered through Join Xeno.

  add: Alchemist injections now apply immediate debuffs: Noctine dazes and stutters, Pyrinine dazes, Crynine slows.
  tweak: Alchemist manual and melee chemical generation are now doubled.
  tweak: Alchemist toxin effects now apply over ~50 seconds with doubled potency and purge rates.
  tweak: Vapinine now purges blood and oxygen support chemicals.
  fix: Injected Alchemist mixtures now apply their intended immediate combat effects to human targets.
  
  add: Xeno hives now get a shared 200-use instant-build pool for the first 30 minutes of the round.
  tweak: Secrete structure actions show the hive’s remaining instant builds in the lower-right while available.
  fix: Hive instant builds no longer consume plasma and refund their charge if placement fails.
  
  fix: coils opening synth surgery before burn repair.
  fix: synths metabolizing reagents, bleeding, and accepting tourniquets.
  fix: organic wound/TQ/eschar/necrosis/internal bleed state persisting on limbs reattached to synths.
  
  fix: Heart repair surgery now restarts repaired non-dead hearts through the existing heart system.
  fix: Fixed repaired hearts staying stopped and continuing oxygen damage after surgery.
  
  fix: Signal flares created by flare projectiles and air shots now preserve the user's faction for dropship targeting.
  fix: Fixed firemission flare targeting/PVS cleanup so pilots don't stay subscribed to the wrong signal flare target.
  
  add: Severe and shock pain now apply player-facing feedback, including pain visuals, pain emotes, stuttering, drunkenness, and shock slurring.
  add: Inaprovaline and epinephrine now reduce pain, with inaprovaline providing stronger relief.
  tweak: Shock pain blur now ramps faster after shock threshold instead of instantly jumping to full strength.
  tweak: Strong painkiller relief now weakens as pain rises, and tramadol/oxycodone overdoses can cause drunkenness.