### PR TITLE
Battle Buddy - Tracking Fixes & Fireteam QOLs

### DIFF
--- a/Content.Client/_RMC14/Overwatch/OverwatchSquadView.xaml
+++ b/Content.Client/_RMC14/Overwatch/OverwatchSquadView.xaml
@@ -1,4 +1,4 @@
-﻿<controls:OverwatchSquadView
+<controls:OverwatchSquadView
     xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client._RMC14.Overwatch"
     xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
@@ -68,7 +68,7 @@
                         <Button Name="OrbitalBombardmentButton" Access="Public" Text="{Loc rmc-overwatch-console-orbital-bombardment}"
                                 StyleClasses="ActionButton" VerticalAlignment="Top"
                                 Margin="0 10 0 0" MinWidth="250" />
-                        <Button Name="FireteamsButton" Access="Public" Text="Fireteams"
+                        <Button Name="FireteamsButton" Access="Public" Text="{Loc rmc-overwatch-console-fireteams}"
                                 StyleClasses="ActionButton" VerticalAlignment="Top"
                                 Margin="0 10 0 0" MinWidth="250" />
                     </BoxContainer>
@@ -224,7 +224,7 @@
                                     BackgroundColor="#1A1A1A" />
                                 </PanelContainer.PanelOverride>
                                 <BoxContainer Orientation="Horizontal" Margin="5">
-                                    <Label Text="Fireteams" />
+                                    <Label Text="{Loc rmc-overwatch-console-fireteams}" />
                                     <Control HorizontalExpand="True" />
                                 </BoxContainer>
                             </PanelContainer>

--- a/Content.Client/_RMC14/Tracker/SquadLeader/SquadInfoBui.cs
+++ b/Content.Client/_RMC14/Tracker/SquadLeader/SquadInfoBui.cs
@@ -62,7 +62,7 @@ public sealed partial class SquadInfoBui : BoundUserInterface
             : Loc.GetString("rmc-squad-info-squad-leader-name", ("leader", tracker.Fireteams.SquadLeader));
         _window.SquadLeaderLabel.Text = squadLeader;
         _window.ChangeTrackerButton.Visible = isSquadLeader;
-        if (isSquadLeader)
+        if (isSquadLeader) // || isOverwatchOperator)
         {
             _window.ChangeTrackerButton.OnPressed += _ => SendPredictedMessage(new SquadLeaderTrackerChangeTrackedMsg());
         }

--- a/Content.Client/_RMC14/Tracker/SquadLeader/SquadInfoBui.cs
+++ b/Content.Client/_RMC14/Tracker/SquadLeader/SquadInfoBui.cs
@@ -55,17 +55,19 @@ public sealed partial class SquadInfoBui : BoundUserInterface
             backgroundColor = ownerMember.BackgroundColor;
         }
 
-        // Only allow the local viewer to change tracker settings if they are the squad leader.
         var isSquadLeader = EntMan.HasComponent<SquadLeaderComponent>(PlayerManager.LocalEntity);
+        var localNetEntity = EntMan.GetNetEntity(PlayerManager.LocalEntity);
+        var isOverwatchOperator = localNetEntity != null && tracker.TemporaryOverwatchEditors.Contains(localNetEntity.Value);
+        var canManageFireteams = isSquadLeader || isOverwatchOperator;
+
         var squadLeader = tracker.Fireteams.SquadLeader == null
             ? Loc.GetString("rmc-squad-info-squad-leader-none")
             : Loc.GetString("rmc-squad-info-squad-leader-name", ("leader", tracker.Fireteams.SquadLeader));
         _window.SquadLeaderLabel.Text = squadLeader;
-        _window.ChangeTrackerButton.Visible = isSquadLeader;
-        if (isSquadLeader) // || isOverwatchOperator)
-        {
-            _window.ChangeTrackerButton.OnPressed += _ => SendPredictedMessage(new SquadLeaderTrackerChangeTrackedMsg());
-        }
+
+        // Changing the client-side tracker is allowed for every client that has the component
+        _window.ChangeTrackerButton.Visible = true;
+        _window.ChangeTrackerButton.OnPressed += _ => SendPredictedMessage(new SquadLeaderTrackerChangeTrackedMsg());
 
         // Get squad objectives from state
         Dictionary<SquadObjectiveType, string> objectives = new();
@@ -108,7 +110,7 @@ public sealed partial class SquadInfoBui : BoundUserInterface
 
             var container = new SquadFireteamContainer();
             // Show edit nickname button; server will validate permissions when message is sent.
-            container.EditNicknameButton.Visible = true;
+            container.EditNicknameButton.Visible = canManageFireteams;
             var fireteamIndex = i;
             container.EditNicknameButton.OnPressed += _ =>
             {
@@ -132,11 +134,11 @@ public sealed partial class SquadInfoBui : BoundUserInterface
                 : Loc.GetString("rmc-squad-info-team-leader-name", ("leader", fireteam.Leader.Value.Name));
             container.LeaderLabel.Text = teamLeader;
 
-            var fireatemIndex = i;
+            var fireteamIdx = i;
             container.RemoveLeaderButton.OnPressed +=
-                _ => SendPredictedMessage(new SquadLeaderTrackerDemoteFireteamLeaderMsg(fireatemIndex));
-            // Allow Overwatch to remove a fireteam leader too; only hide tracker-mode change for non-leaders.
-            container.RemoveLeaderButton.Visible = fireteam.Leader != null;
+                _ => SendPredictedMessage(new SquadLeaderTrackerDemoteFireteamLeaderMsg(fireteamIdx));
+            // Hide tracker-mode clientside-change for non-leaders, serverside verifies if OW or SL.
+            container.RemoveLeaderButton.Visible = fireteam.Leader != null && canManageFireteams;
             var fireteamLabel = Loc.GetString("rmc-squad-info-fireteam", ("fireteam", i + 1));
             if (!string.IsNullOrWhiteSpace(fireteam.Nickname))
                 fireteamLabel += $": {fireteam.Nickname}";
@@ -163,7 +165,7 @@ public sealed partial class SquadInfoBui : BoundUserInterface
                 };
 
                 // Allow Overwatch actors to promote as well; server will validate permission.
-                promoteButton.Visible = true;
+                promoteButton.Visible = canManageFireteams;
                 promoteButton.OnPressed += _ =>
                     SendPredictedMessage(new SquadLeaderTrackerPromoteFireteamLeaderMsg(member.Id));
 
@@ -182,7 +184,7 @@ public sealed partial class SquadInfoBui : BoundUserInterface
                 };
 
                 // Allow Overwatch actors to unassign members too; server will validate permission.
-                unassignButton.Visible = true;
+                unassignButton.Visible = canManageFireteams;
                 unassignButton.OnPressed += _ =>
                     SendPredictedMessage(new SquadLeaderTrackerUnassignFireteamMsg(member.Id));
 

--- a/Content.IntegrationTests/Tests/Minds/GhostRoleTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/GhostRoleTests.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System.Linq;
 using Content.Server.GameTicking;
 using Content.Server.Ghost.Roles;
@@ -398,7 +398,7 @@ public sealed class GhostRoleTests
             Assert.That(ghostTwo, Is.Not.EqualTo(ghostRole));
             Assert.That(session.ContentData()?.Mind, Is.EqualTo(ghostRoleMindId));
 
-            if(adminGhost)
+            if (adminGhost)
             {
                 // aghost case, the ghost role mind should be owned by the ghost role entity,
                 // the ghost role mind is visiting the new ghost

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -646,7 +646,14 @@ public sealed partial class GhostRoleSystem : EntitySystem
             _mindSystem.WipeMind(player);
         }
 
-        var newMind = _mindSystem.CreateMind(player.UserId, Comp<MetaDataComponent>(mob).EntityName);
+        string characterName;
+        if (role.JobProto is { } jobId
+            && _prototype.TryIndex(jobId, out JobPrototype? jobProto)
+            && jobProto.UsePlayerProfile)
+            characterName = GetGhostRoleCharacterName(player, mob);
+        else
+            characterName = Comp<MetaDataComponent>(mob).EntityName;
+        var newMind = _mindSystem.CreateMind(player.UserId, characterName);
 
         Log.Debug($"GhostRoleInternalCreateMindAndTransfer: created mind {newMind.Owner} for player {player.Name} (user {player.UserId}) targeting mob {mob}");
 

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -647,12 +647,14 @@ public sealed partial class GhostRoleSystem : EntitySystem
         }
 
         string characterName;
-        if (role.JobProto is { } jobId
-            && _prototype.TryIndex(jobId, out JobPrototype? jobProto)
-            && jobProto.UsePlayerProfile)
-            characterName = GetGhostRoleCharacterName(player, mob);
-        else
-            characterName = Comp<MetaDataComponent>(mob).EntityName;
+        // I genuinely can't think of a single reason why ghost roles need a player's character name,
+        // Ghost roles should use anonymised names, but I'm going to leave this to re-enable functionality
+        // if (role.JobProto is { } jobId
+        //     && _prototype.TryIndex(jobId, out JobPrototype? jobProto)
+        //     && jobProto.UsePlayerProfile)
+        //     characterName = GetGhostRoleCharacterName(player, mob);
+        // else
+        characterName = Comp<MetaDataComponent>(mob).EntityName;
         var newMind = _mindSystem.CreateMind(player.UserId, characterName);
 
         Log.Debug($"GhostRoleInternalCreateMindAndTransfer: created mind {newMind.Owner} for player {player.Name} (user {player.UserId}) targeting mob {mob}");

--- a/Content.Server/_RMC14/Marines/Orders/MarineOrdersSystem.cs
+++ b/Content.Server/_RMC14/Marines/Orders/MarineOrdersSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Actions;
 using Content.Server.Chat.Systems;
 using Content.Shared._RMC14.Marines.Orders;
+using Content.Shared._RMC14.Marines.Squads;
 using Robust.Shared.Random;
 
 namespace Content.Server._RMC14.Marines.Orders;
@@ -21,17 +22,11 @@ public sealed partial class MarineOrdersSystem : SharedMarineOrdersSystem
     {
         var comp = ent.Comp;
         if (comp.MoveActionEntity != null || comp.HoldActionEntity != null || comp.FocusActionEntity != null) return;
-        if (_skills.GetSkill(ent.Owner, comp.Skill) <= 0) return;
+        if (!HasComp<SquadLeaderComponent>(ent.Owner)
+            && _skills.GetSkill(ent.Owner, comp.Skill) <= 0)
+            return;
 
-        // All the SetUseDelay calls are required because even tho we set the cooldown on all of them once an order
-        // is issued for some reason the order that was pressed uses its delays and does not care about its cooldown
-        // being set.
-        _actions.AddAction(ent, ref comp.MoveActionEntity, comp.MoveAction);
-        _actions.SetUseDelay(comp.MoveActionEntity, comp.Cooldown);
-        _actions.AddAction(ent, ref comp.HoldActionEntity, comp.HoldAction);
-        _actions.SetUseDelay(comp.HoldActionEntity, comp.Cooldown);
-        _actions.AddAction(ent, ref comp.FocusActionEntity, comp.FocusAction);
-        _actions.SetUseDelay(comp.FocusActionEntity, comp.Cooldown);
+        EnsureOrderActions(ent);
     }
 
     private void OnOrdersShutdown(Entity<MarineOrdersComponent> ent, ref ComponentShutdown ev)

--- a/Content.Server/_RMC14/Marines/Orders/MarineOrdersSystem.cs
+++ b/Content.Server/_RMC14/Marines/Orders/MarineOrdersSystem.cs
@@ -21,6 +21,7 @@ public sealed partial class MarineOrdersSystem : SharedMarineOrdersSystem
     {
         var comp = ent.Comp;
         if (comp.MoveActionEntity != null || comp.HoldActionEntity != null || comp.FocusActionEntity != null) return;
+        if (_skills.GetSkill(ent.Owner, comp.Skill) <= 0) return;
 
         // All the SetUseDelay calls are required because even tho we set the cooldown on all of them once an order
         // is issued for some reason the order that was pressed uses its delays and does not care about its cooldown

--- a/Content.Server/_RMC14/Tracker/BattleBuddySystem.cs
+++ b/Content.Server/_RMC14/Tracker/BattleBuddySystem.cs
@@ -1,11 +1,9 @@
-using Content.Shared.Verbs;
+using Content.Shared._RMC14.Dialog;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Tracker.SquadLeader;
-using Content.Shared._RMC14.Dialog;
 using Content.Shared.Database;
-using Robust.Shared.Log;
+using Content.Shared.Verbs;
 using Robust.Shared.Utility;
-using Robust.Shared.GameObjects;
 
 namespace Content.Server._RMC14.Tracker
 {
@@ -14,7 +12,6 @@ namespace Content.Server._RMC14.Tracker
         [Dependency] private SquadLeaderTrackerSystem _trackerSys = default!;
         [Dependency] private ILogManager _log = default!;
         [Dependency] private DialogSystem _dialog = default!;
-
         private ISawmill _sawmill = default!;
 
         public override void Initialize()
@@ -31,7 +28,7 @@ namespace Content.Server._RMC14.Tracker
             var user = args.User;
             var target = args.Target;
 
-            _sawmill.Debug("Checking battle buddy verb conditions for user {0} target {1}", user, target);
+            _sawmill.Debug("Checking battle buddy verb conditions for user={0} target={1}", user, target);
 
             if (user == target)
             {
@@ -47,7 +44,7 @@ namespace Content.Server._RMC14.Tracker
 
             if (!HasComp<MarineComponent>(user) || !HasComp<MarineComponent>(target))
             {
-                _sawmill.Debug("Skipping: either user or target is not marine");
+                _sawmill.Debug("Skipping: either user or target is not a marine");
                 return;
             }
 
@@ -59,7 +56,7 @@ namespace Content.Server._RMC14.Tracker
 
             if (string.IsNullOrEmpty(userMarine.Faction) || userMarine.Faction != targetMarine.Faction)
             {
-                _sawmill.Debug("Skipping: factions don't match or are empty ({0} vs {1})", userMarine.Faction, targetMarine.Faction);
+                _sawmill.Debug("Skipping: factions don't match or are empty ('{0}' vs. '{1}')", userMarine.Faction, targetMarine.Faction);
                 return;
             }
 
@@ -78,12 +75,12 @@ namespace Content.Server._RMC14.Tracker
             };
 
             args.Verbs.Add(verb);
-            _sawmill.Info("Added 'Invite as buddy' verb for {0} -> {1}", user, target);
+            _sawmill.Debug("Added 'Invite as buddy' verb for {0} -> {1}", user, target);
         }
 
         private void SendBuddyRequest(EntityUid requester, EntityUid target)
         {
-            _sawmill.Debug("SendBuddyRequest: requester={0} target={1}", requester, target);
+            _sawmill.Debug("SendBuddyRequest: requester={0} -> target={1}", requester, target);
             var options = new List<DialogOption>
             {
                 new DialogOption(Loc.GetString("Accept"), new BattleBuddyAcceptEvent(GetNetEntity(requester), GetNetEntity(target))),
@@ -93,10 +90,8 @@ namespace Content.Server._RMC14.Tracker
             var title = Loc.GetString("Battle Buddy Invitation");
             var message = Loc.GetString($"{Name(requester)} has invited you to be their battle buddy.");
 
-
-            // Open the options UI for the invited player (target). The 'actor' parameter decides which client's UI opens.
             _dialog.OpenOptions(target, target, title, options, message);
-            _sawmill.Info("Sent battle buddy request from {0} to {1}", requester, target);
+            _sawmill.Info("Sent battle buddy request from {0} -> {1}", requester, target);
         }
 
         private void OnBattleBuddyAccept(BattleBuddyAcceptEvent ev)

--- a/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Evasion;
+using Content.Shared._RMC14.Marines.Squads;
 using Content.Shared._CMU14.Medical.StatusEffects;
 using Content.Shared._CMU14.Yautja;
 using Content.Shared._RMC14.Marines.Skills;
@@ -55,6 +56,25 @@ public abstract partial class SharedMarineOrdersSystem : EntitySystem
         SubscribeLocalEvent<MoveOrderComponent, DidUnequipEvent>(OnMoveOrderDidUnequip);
 
         SubscribeLocalEvent<HoldOrderComponent, DamageModifyEvent>(OnDamageModify);
+    }
+
+    private void OnMoveOrderDidEquip(Entity<MoveOrderComponent> ent, ref DidEquipEvent args) => _movementSpeed.RefreshMovementSpeedModifiers(ent);
+
+    private void OnMoveOrderDidUnequip(Entity<MoveOrderComponent> ent, ref DidUnequipEvent args) => _movementSpeed.RefreshMovementSpeedModifiers(ent);
+
+    protected virtual void OnAction(Entity<MarineOrdersComponent> orders, ref FocusActionEvent args) => OnAction<FocusOrderComponent>(orders, args);
+
+    protected virtual void OnAction(Entity<MarineOrdersComponent> orders, ref HoldActionEvent args) => OnAction<HoldOrderComponent>(orders, args);
+
+    protected virtual void OnAction(Entity<MarineOrdersComponent> orders, ref MoveActionEvent args) => OnAction<MoveOrderComponent>(orders, args);
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        RemoveExpired<MoveOrderComponent>();
+        RemoveExpired<FocusOrderComponent>();
+        RemoveExpired<HoldOrderComponent>();
     }
 
     private void OnDamageModify(Entity<HoldOrderComponent> orders, ref DamageModifyEvent args)
@@ -127,31 +147,6 @@ public abstract partial class SharedMarineOrdersSystem : EntitySystem
         args.Evasion += entity.Comp.Received[0].Multiplier * entity.Comp.EvasionModifier;
     }
 
-    private void OnMoveOrderDidEquip(Entity<MoveOrderComponent> ent, ref DidEquipEvent args)
-    {
-        _movementSpeed.RefreshMovementSpeedModifiers(ent);
-    }
-
-    private void OnMoveOrderDidUnequip(Entity<MoveOrderComponent> ent, ref DidUnequipEvent args)
-    {
-        _movementSpeed.RefreshMovementSpeedModifiers(ent);
-    }
-
-    protected virtual void OnAction(Entity<MarineOrdersComponent> orders, ref FocusActionEvent args)
-    {
-        OnAction<FocusOrderComponent>(orders, args);
-    }
-
-    protected virtual void OnAction(Entity<MarineOrdersComponent> orders, ref HoldActionEvent args)
-    {
-        OnAction<HoldOrderComponent>(orders, args);
-    }
-
-    protected virtual void OnAction(Entity<MarineOrdersComponent> orders, ref MoveActionEvent args)
-    {
-        OnAction<MoveOrderComponent>(orders, args);
-    }
-
     private void OnAction<T>(Entity<MarineOrdersComponent> orders, InstantActionEvent args) where T : IOrderComponent, new()
     {
         if (args.Handled)
@@ -168,9 +163,11 @@ public abstract partial class SharedMarineOrdersSystem : EntitySystem
             return false;
 
         var leadershipSkill = _skills.GetSkill(orders.Owner, orders.Comp.Skill);
-        if (leadershipSkill <= 0)
+        if (leadershipSkill <= 0 && !HasComp<SquadLeaderComponent>(orders.Owner))
             return false;
-        var duration = orders.Comp.Duration * (leadershipSkill + 1);
+
+        var level = Math.Max(1, leadershipSkill);
+        var duration = orders.Comp.Duration * (level + 1);
 
         _actions.SetCooldown(orders.Comp.FocusActionEntity, orders.Comp.Cooldown);
         _actions.SetCooldown(orders.Comp.MoveActionEntity, orders.Comp.Cooldown);
@@ -187,7 +184,7 @@ public abstract partial class SharedMarineOrdersSystem : EntitySystem
             if (HasComp<YautjaComponent>(receiver.Owner))
                 continue;
 
-            AddOrder<T>(receiver, leadershipSkill, duration);
+            AddOrder<T>(receiver, level, duration);
         }
 
         // Order Handler, checks which order should be played - server side only
@@ -208,6 +205,31 @@ public abstract partial class SharedMarineOrdersSystem : EntitySystem
         }
 
         return true;
+    }
+
+    public void StartActionUseDelay(Entity<MarineOrdersComponent> orders)
+    {
+        _actions.StartUseDelay(orders.Comp.HoldActionEntity);
+        _actions.StartUseDelay(orders.Comp.MoveActionEntity);
+        _actions.StartUseDelay(orders.Comp.FocusActionEntity);
+    }
+
+    // All the SetUseDelay calls are required because even tho we set the cooldown on all of them once an order
+    // is issued for some reason the order that was pressed uses its delays and does not care about its cooldown
+    // being set.
+    public void EnsureOrderActions(Entity<MarineOrdersComponent> ent)
+    {
+        var comp = ent.Comp;
+        if (comp.MoveActionEntity == null)
+            _actions.AddAction(ent, ref comp.MoveActionEntity, comp.MoveAction);
+        if (comp.HoldActionEntity == null)
+            _actions.AddAction(ent, ref comp.HoldActionEntity, comp.HoldAction);
+        if (comp.FocusActionEntity == null)
+            _actions.AddAction(ent, ref comp.FocusActionEntity, comp.FocusAction);
+
+        _actions.SetUseDelay(comp.MoveActionEntity, comp.Cooldown);
+        _actions.SetUseDelay(comp.HoldActionEntity, comp.Cooldown);
+        _actions.SetUseDelay(comp.FocusActionEntity, comp.Cooldown);
     }
 
     private SoundSpecifier? GetMoveSound(Entity<MarineOrdersComponent> orders)
@@ -318,21 +340,5 @@ public abstract partial class SharedMarineOrdersSystem : EntitySystem
             if (comp.Received.Count == 0)
                 RemCompDeferred<T>(uid);
         }
-    }
-
-    public void StartActionUseDelay(Entity<MarineOrdersComponent> orders)
-    {
-        _actions.StartUseDelay(orders.Comp.HoldActionEntity);
-        _actions.StartUseDelay(orders.Comp.MoveActionEntity);
-        _actions.StartUseDelay(orders.Comp.FocusActionEntity);
-    }
-
-    public override void Update(float frameTime)
-    {
-        base.Update(frameTime);
-
-        RemoveExpired<MoveOrderComponent>();
-        RemoveExpired<FocusOrderComponent>();
-        RemoveExpired<HoldOrderComponent>();
     }
 }

--- a/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
@@ -27,8 +27,8 @@ public abstract partial class SharedMarineOrdersSystem : EntitySystem
     [Dependency] private MovementSpeedModifierSystem _movementSpeed = default!;
     [Dependency] private INetManager _net = default!;
     [Dependency] private SharedPainShockSystem _pain = default!;
-    [Dependency] private SkillsSystem _skills = default!;
     [Dependency] private IGameTiming _timing = default!;
+    [Dependency] protected SkillsSystem _skills = default!;
 
     private readonly HashSet<Entity<MarineComponent>> _receivers = new();
 
@@ -163,14 +163,14 @@ public abstract partial class SharedMarineOrdersSystem : EntitySystem
 
     private bool HandleAction<T>(Entity<MarineOrdersComponent> orders) where T : IOrderComponent, new()
     {
-        if (!TryComp(orders, out TransformComponent? xform) ||
-            _mobState.IsDead(orders))
-        {
+        if (!TryComp(orders, out TransformComponent? xform)
+            || _mobState.IsDead(orders))
             return false;
-        }
 
-        var level = Math.Max(1, _skills.GetSkill(orders.Owner, orders.Comp.Skill));
-        var duration = orders.Comp.Duration * (level + 1);
+        var leadershipSkill = _skills.GetSkill(orders.Owner, orders.Comp.Skill);
+        if (leadershipSkill <= 0)
+            return false;
+        var duration = orders.Comp.Duration * (leadershipSkill + 1);
 
         _actions.SetCooldown(orders.Comp.FocusActionEntity, orders.Comp.Cooldown);
         _actions.SetCooldown(orders.Comp.MoveActionEntity, orders.Comp.Cooldown);
@@ -187,11 +187,11 @@ public abstract partial class SharedMarineOrdersSystem : EntitySystem
             if (HasComp<YautjaComponent>(receiver.Owner))
                 continue;
 
-            AddOrder<T>(receiver, level, duration);
+            AddOrder<T>(receiver, leadershipSkill, duration);
         }
 
         // Order Handler, checks which order should be played - server side only
-        if (_net.IsServer && (typeof(T) == typeof(MoveOrderComponent) || typeof(T) == typeof(FocusOrderComponent)|| typeof(T) == typeof(HoldOrderComponent)))
+        if (_net.IsServer && (typeof(T) == typeof(MoveOrderComponent) || typeof(T) == typeof(FocusOrderComponent) || typeof(T) == typeof(HoldOrderComponent)))
         {
             SoundSpecifier? sound = null;
             if (typeof(T) == typeof(MoveOrderComponent))

--- a/Content.Shared/_RMC14/Marines/Squads/SquadSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Squads/SquadSystem.cs
@@ -4,12 +4,12 @@ using System.Linq;
 using Content.Shared._RMC14.Admin;
 using Content.Shared._RMC14.Chat;
 using Content.Shared._RMC14.Commendations;
-using Content.Shared._RMC14.Recommendation;
 using Content.Shared._RMC14.Cryostorage;
 using Content.Shared._RMC14.Inventory;
 using Content.Shared._RMC14.Marines.Announce;
 using Content.Shared._RMC14.Marines.Orders;
 using Content.Shared._RMC14.Pointing;
+using Content.Shared._RMC14.Recommendation;
 using Content.Shared._RMC14.Roles;
 using Content.Shared._RMC14.Tracker;
 using Content.Shared.Access.Components;
@@ -19,6 +19,7 @@ using Content.Shared.Clothing;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.Dataset;
+using Content.Shared.GameTicking;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Inventory;
 using Content.Shared.Mind;
@@ -32,7 +33,6 @@ using Content.Shared.Radio.EntitySystems;
 using Content.Shared.Roles;
 using Content.Shared.Roles.Jobs;
 using Content.Shared.Storage;
-using Content.Shared.GameTicking;
 using Content.Shared.Whitelist;
 using Robust.Client.GameObjects;
 using Robust.Shared.Network;
@@ -507,6 +507,8 @@ public sealed partial class SquadSystem : EntitySystem
         if (!Resolve(team, ref team.Comp))
             return;
 
+        DemoteSquadLeader(marine); // clean up old Squad Leader data
+
         var member = EnsureComp<SquadMemberComponent>(marine);
         var oldSquadId = member.Squad;
         var role = job ?? _originalRoleQuery.CompOrNull(marine)?.Job;
@@ -517,14 +519,10 @@ public sealed partial class SquadSystem : EntitySystem
         {
             oldSquadCheck.Members.Remove(marine);
 
-            if (role != null)
-            {
-                if (oldSquadCheck.Roles.TryGetValue(role.Value, out var oldJobs) &&
-                    oldJobs > 0)
-                {
-                    oldSquadCheck.Roles[role.Value] = oldJobs - 1;
-                }
-            }
+            if (role != null
+                && oldSquadCheck.Roles.TryGetValue(role.Value, out var oldJobs)
+                && oldJobs > 0)
+                oldSquadCheck.Roles[role.Value] = oldJobs - 1;
         }
 
         member.Squad = team;
@@ -538,14 +536,10 @@ public sealed partial class SquadSystem : EntitySystem
         grant.AccessLevels = team.Comp.AccessLevels;
 
         if (_prototypes.TryIndex(job, out var jobProto))
-        {
             grant.RoleName = $"{Name(team)} {jobProto.LocalizedName}";
-        }
-        else if (_mind.TryGetMind(marine, out var mindId, out _) &&
-                 _job.MindTryGetJobName(mindId, out var name))
-        {
+        else if (_mind.TryGetMind(marine, out var mindId, out _)
+            && _job.MindTryGetJobName(mindId, out var name))
             MarineSetTitle(marine, $"{Name(team)} {name}");
-        }
 
         Dirty(marine, grant);
 
@@ -581,7 +575,6 @@ public sealed partial class SquadSystem : EntitySystem
         ProtoId<RadioChannelPrototype>? newRadio = team.Comp.Radio;
         AdjustCommonKeyForMember(marine, oldRadio, newRadio);
     }
-
 
     private void AdjustCommonKeyForMember(EntityUid marine, ProtoId<RadioChannelPrototype>? removeRadio, ProtoId<RadioChannelPrototype>? addRadio)
     {
@@ -640,7 +633,7 @@ public sealed partial class SquadSystem : EntitySystem
 
     public void RemoveSquad(EntityUid marine, ProtoId<JobPrototype>? job)
     {
-        RemComp<SquadLeaderComponent>(marine);
+        DemoteSquadLeader(marine);
         if (!TryComp<SquadMemberComponent>(marine, out var member))
             return;
 
@@ -655,14 +648,9 @@ public sealed partial class SquadSystem : EntitySystem
         {
             oldSquad.Members.Remove(marine);
 
-            if (role != null)
-            {
-                if (oldSquad.Roles.TryGetValue(role.Value, out var oldJobs) &&
-                    oldJobs > 0)
-                {
-                    oldSquad.Roles[role.Value] = oldJobs - 1;
-                }
-            }
+            if (role != null
+                && oldSquad.Roles.TryGetValue(role.Value, out var oldJobs) && oldJobs > 0)
+                oldSquad.Roles[role.Value] = oldJobs - 1;
         }
 
         RemComp<SquadMemberComponent>(marine);
@@ -763,42 +751,10 @@ public sealed partial class SquadSystem : EntitySystem
             return;
         }
 
-        if (Resolve(toPromote, ref toPromote.Comp, false))
-        {
-            var leaders = EntityQueryEnumerator<SquadLeaderComponent, SquadMemberComponent>();
-            while (leaders.MoveNext(out var uid, out var leader, out var otherMember))
-            {
-                if (otherMember.Squad != toPromote.Comp.Squad)
-                    continue;
-
-                if (leader.Headset is { } headset)
-                {
-                    RemComp<SquadLeaderHeadsetComponent>(headset);
-                    if (TryComp(headset, out EncryptionKeyHolderComponent? holder))
-                        _encryptionKey.UpdateChannels(headset, holder);
-                }
-
-                if (TryComp(uid, out MarineComponent? otherMarine) &&
-                    Equals(otherMarine.Icon, leader.Icon))
-                {
-                    _marine.ClearIcon((uid, otherMarine));
-                }
-
-                if (TryComp(uid, out MarineOrdersComponent? otherOrders) &&
-                    !otherOrders.Intrinsic)
-                {
-                    RemCompDeferred<MarineOrdersComponent>(uid);
-                }
-
-                RemComp<SquadLeaderComponent>(uid);
-                RemComp<RMCTrackableComponent>(uid);
-                RemCompDeferred<RMCPointingComponent>(uid);
-            }
-        }
-
         var newLeader = EnsureComp<SquadLeaderComponent>(toPromote);
         newLeader.Icon = icon;
-
+        EnsureComp<RMCTrackableComponent>(toPromote);
+        EnsureComp<RMCPointingComponent>(toPromote);
         EnsureComp<RMCAwardRecommendationComponent>(toPromote);
         _awardRecommendation.SetCanRecommend(toPromote, true);
 
@@ -808,9 +764,6 @@ public sealed partial class SquadSystem : EntitySystem
             Dirty(toPromote, orders);
             _marineOrders.StartActionUseDelay((toPromote, orders));
         }
-
-        EnsureComp<RMCTrackableComponent>(toPromote);
-        EnsureComp<RMCPointingComponent>(toPromote);
 
         var slots = _inventory.GetSlotEnumerator(toPromote.Owner, SlotFlags.EARS);
         while (slots.MoveNext(out var slot))
@@ -841,6 +794,47 @@ public sealed partial class SquadSystem : EntitySystem
             _marineAnnounce.AnnounceSquad(Loc.GetString("rmc-overwatch-console-new-squad-leader-announce", ("leaderName", Name(toPromote))), squadProto.ID);
             _popup.PopupCursor(Loc.GetString("rmc-overwatch-console-new-squad-leader-popup", ("leaderName", Name(toPromote)), ("squadName", Name(squad.Value))), user, PopupType.Medium);
         }
+
+        // Demote after promote, so the squad members are not in a limbo without SL
+        if (Resolve(toPromote, ref toPromote.Comp, false))
+        {
+            var leaders = EntityQueryEnumerator<SquadLeaderComponent, SquadMemberComponent>();
+            while (leaders.MoveNext(out var uid, out var _, out var otherMember))
+            {
+                if (uid == toPromote.Owner)
+                    continue;
+
+                if (otherMember.Squad != toPromote.Comp.Squad)
+                    continue;
+
+                DemoteSquadLeader(uid);
+            }
+        }
+    }
+
+    private void DemoteSquadLeader(EntityUid marine)
+    {
+        if (!TryComp(marine, out SquadLeaderComponent? leader))
+            return;
+
+        if (leader.Headset is { } headset)
+        {
+            RemComp<SquadLeaderHeadsetComponent>(headset);
+            if (TryComp(headset, out EncryptionKeyHolderComponent? holder))
+                _encryptionKey.UpdateChannels(headset, holder);
+        }
+
+        if (TryComp(marine, out MarineComponent? otherMarine)
+            && Equals(otherMarine.Icon, leader.Icon))
+            _marine.ClearIcon((marine, otherMarine));
+
+        if (TryComp(marine, out MarineOrdersComponent? otherOrders) && !otherOrders.Intrinsic)
+            RemCompDeferred<MarineOrdersComponent>(marine);
+
+        RemComp<SquadLeaderComponent>(marine);
+        RemComp<RMCTrackableComponent>(marine);
+        RemCompDeferred<RMCPointingComponent>(marine);
+        _awardRecommendation.SetCanRecommend(marine, false);
     }
 
     public bool AreInSameSquad(Entity<SquadMemberComponent?> one, Entity<SquadMemberComponent?> two)

--- a/Content.Shared/_RMC14/Marines/Squads/SquadSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Squads/SquadSystem.cs
@@ -765,6 +765,8 @@ public sealed partial class SquadSystem : EntitySystem
             _marineOrders.StartActionUseDelay((toPromote, orders));
         }
 
+        _marineOrders.EnsureOrderActions((toPromote.Owner, orders));
+
         var slots = _inventory.GetSlotEnumerator(toPromote.Owner, SlotFlags.EARS);
         while (slots.MoveNext(out var slot))
         {

--- a/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerSystem.cs
+++ b/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerSystem.cs
@@ -2,11 +2,13 @@ using Content.Shared._RMC14.Dialog;
 using Content.Shared._RMC14.Marines.Roles.Ranks;
 using Content.Shared._RMC14.Marines.Skills.Pamphlets;
 using Content.Shared._RMC14.Marines.Squads;
+using Content.Shared._RMC14.Overwatch;
 using Content.Shared._RMC14.Roles;
 using Content.Shared._RMC14.Vendors;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Alert;
 using Content.Shared.Database;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Robust.Shared.Map;
@@ -14,8 +16,6 @@ using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
-using Content.Shared._RMC14.Overwatch;
-using Content.Shared.IdentityManagement;
 
 namespace Content.Shared._RMC14.Tracker.SquadLeader;
 
@@ -34,21 +34,18 @@ public sealed partial class SquadLeaderTrackerSystem : EntitySystem
     [Dependency] private TrackerSystem _tracker = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private SharedUserInterfaceSystem _ui = default!;
-
-    // New: logging
     [Dependency] private ILogManager _logManager = default!;
-    private ISawmill _sawmill = default!;
 
-    private readonly Dictionary<EntityUid, MapCoordinates> _squadLeaders = new();
+    private readonly Dictionary<EntityUid, MapCoordinates> _squadLeaders = [];
     private readonly Dictionary<EntityUid, MapCoordinates>?[] _fireteamLeaders =
         new Dictionary<EntityUid, MapCoordinates>?[3];
-
     private EntityQuery<FireteamLeaderComponent> _fireteamLeaderQuery;
     private EntityQuery<FireteamMemberComponent> _fireteamMemberQuery;
     private EntityQuery<OriginalRoleComponent> _originalRoleQuery;
     private EntityQuery<SquadLeaderTrackerComponent> _squadLeaderTrackerQuery;
     private EntityQuery<SquadMemberComponent> _squadMemberQuery;
 
+    private ISawmill _sawmill = default!;
     private const string SquadTrackerCategory = "SquadTracker";
     private const string SquadLeaderMode = "SquadLeader";
     private const string FireteamLeader = "FireteamLeader";
@@ -90,7 +87,6 @@ public sealed partial class SquadLeaderTrackerSystem : EntitySystem
                 subs.Event<SquadLeaderTrackerSetFireteamNicknameMsg>(OnSetFireteamNicknameMsg);
             });
 
-        // Initialize sawmill for logging
         _sawmill = _logManager.GetSawmill("squadleader");
     }
 
@@ -173,7 +169,7 @@ public sealed partial class SquadLeaderTrackerSystem : EntitySystem
         if (_net.IsClient)
             return;
 
-        Dictionary<SquadObjectiveType, string> objectives = new();
+        Dictionary<SquadObjectiveType, string> objectives = [];
         if (_squadMemberQuery.TryComp(ent, out var squadMember) &&
             squadMember.Squad != null &&
             TryComp(squadMember.Squad.Value, out SquadTeamComponent? squadTeam))
@@ -387,7 +383,7 @@ public sealed partial class SquadLeaderTrackerSystem : EntitySystem
             return;
 
         // Diagnostic logging to help trace who is attempting to set a nickname and why it may be rejected.
-        Log.Debug($"OnSetFireteamNicknameMsg called: TrackerOwner={ent.Owner} Index={args.Index} Nick='{args.Nickname}' Actor={args.Actor}");
+        _sawmill.Debug($"OnSetFireteamNicknameMsg called: TrackerOwner={ent.Owner} Index={args.Index} Nick='{args.Nickname}' Actor={args.Actor}");
 
         if (args.Index < 0 || args.Index >= ent.Comp.Fireteams.Fireteams.Length)
             return;
@@ -425,7 +421,7 @@ public sealed partial class SquadLeaderTrackerSystem : EntitySystem
         if (!isOverwatchOperator && ent.Comp.TemporaryOverwatchEditors.Contains(actorNet))
             isOverwatchOperator = true;
 
-        Log.Debug($"OnSetFireteamNicknameMsg permission: isSquadLeader={isSquadLeader} isOverwatchOperator={isOverwatchOperator}");
+        _sawmill.Debug($"OnSetFireteamNicknameMsg permission: isSquadLeader={isSquadLeader} isOverwatchOperator={isOverwatchOperator}");
 
         if (!isSquadLeader && !isOverwatchOperator)
             return;
@@ -441,7 +437,7 @@ public sealed partial class SquadLeaderTrackerSystem : EntitySystem
         const int maxLen = 64;
         if (nickname != null && nickname.Length > maxLen)
         {
-            nickname = nickname.Substring(0, maxLen);
+            nickname = nickname[..maxLen];
         }
 
         ft.Nickname = nickname;
@@ -585,11 +581,11 @@ public sealed partial class SquadLeaderTrackerSystem : EntitySystem
                 {
                     if (TryGetEntity(fireteam.Leader?.Id, out var fireteamLeaderUid))
                     {
-                        if (fireteamLeaderUid != member)
+                        if (fireteamLeaderUid != member && tempTracker.Mode == default)
                         {
                             SetTarget((member, tempTracker), fireteamLeaderUid);
-                            // ProtoId<TrackerModePrototype> mode = "FireteamLeader";
-                            // SetMode((member, tempTracker), mode);
+                            ProtoId<TrackerModePrototype> mode = "FireteamLeader";
+                            SetMode((member, tempTracker), mode);
                         }
                     }
                 }
@@ -794,7 +790,7 @@ public sealed partial class SquadLeaderTrackerSystem : EntitySystem
             // Swap target to the new SquadLeader after it is swapped.
             if (tracker.Target != null && tracker.Mode == SquadLeaderMode && !HasComp<SquadLeaderComponent>(tracker.Target))
             {
-                _sawmill.Debug("BattleBuddy for {0} is invalid: {1}");
+                _sawmill.Debug("SquadLeader tracker target is no longer a squad leader: target={0}, uid={1}", tracker.Target, uid);
 
                 if (_squadMemberQuery.TryComp(tracker.Target.Value, out var target) &&
                     target.Squad is { } targetSquad &&
@@ -845,11 +841,14 @@ public sealed partial class SquadLeaderTrackerSystem : EntitySystem
             }
 
             // New: BattleBuddy mode - if set, point towards your battle buddy
+            // When a new team is formed, unlinked buddies get their state reset (SetBattleBuddy)
             if (tracker.Mode == "BattleBuddy" && tracker.BattleBuddy != null)
             {
                 var buddy = tracker.BattleBuddy.Value;
                 if (TerminatingOrDeleted(buddy))
                 {
+                    tracker.BattleBuddy = null;
+                    Dirty(uid, tracker);
                 }
                 else
                 {
@@ -911,29 +910,41 @@ public sealed partial class SquadLeaderTrackerSystem : EntitySystem
 
     public void SetBattleBuddy(EntityUid a, EntityUid b)
     {
-        _sawmill.Debug("SetBattleBuddy called for {0} and {1}", a, b);
-        if (a == b)
-        {
-            _sawmill.Debug("SetBattleBuddy aborted: same entity");
+        if (a == b) return;
+        if (!TryComp<SquadLeaderTrackerComponent>(a, out var compA) || !TryComp<SquadLeaderTrackerComponent>(b, out var compB))
             return;
+        if (compA.BattleBuddy == b && compB.BattleBuddy == a)
+            return;
+
+        // Clean up previous battlebuddy (c and d)
+        if (compA.BattleBuddy != null)
+        {
+            var compC = compA.BattleBuddy.Value;
+            if (TryComp<SquadLeaderTrackerComponent>(compC, out var oldCompC))
+            {
+                oldCompC.BattleBuddy = null;
+                oldCompC.Mode = default;
+                Dirty(compC, oldCompC);
+            }
         }
 
-        if (!TryComp<SquadLeaderTrackerComponent>(a, out var compA) || !TryComp<SquadLeaderTrackerComponent>(b, out var compB))
+        if (compB.BattleBuddy != null)
         {
-            _sawmill.Debug("SetBattleBuddy aborted: missing tracker component on either {0} or {1}", a, b);
-            return;
+            var compD = compB.BattleBuddy.Value;
+            if (TryComp<SquadLeaderTrackerComponent>(compD, out var oldCompD))
+            {
+                oldCompD.BattleBuddy = null;
+                oldCompD.Mode = default;
+                Dirty(compD, oldCompD);
+            }
         }
 
         compA.BattleBuddy = b;
         compB.BattleBuddy = a;
-
         Dirty(a, compA);
         Dirty(b, compB);
 
-        var nameA = Name(a);
-        var nameB = Name(b);
-
-        _sawmill.Info("Set battle buddies: {0} <-> {1}", nameA, nameB);
+        _sawmill.Debug("Set battle buddies: {0} <-> {1}", Name(a), Name(b));
     }
 
     // Handle squad updates (e.g., fireteam nickname changes) and push those changes to any

--- a/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerSystem.cs
+++ b/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerSystem.cs
@@ -159,7 +159,7 @@ public sealed partial class SquadLeaderTrackerSystem : EntitySystem
     private void OnRemove(Entity<SquadLeaderTrackerComponent> ent, ref ComponentRemove args)
     {
         _prototypeManager.TryIndex(ent.Comp.Mode, out var trackerMode);
-        if(trackerMode == null)
+        if (trackerMode == null)
             return;
 
         _alerts.ClearAlert(ent, trackerMode.Alert);
@@ -186,10 +186,10 @@ public sealed partial class SquadLeaderTrackerSystem : EntitySystem
 
     private void OnSquadLeaderTrackerChangeMode(Entity<SquadLeaderTrackerComponent> ent, ref SquadLeaderTrackerChangeModeEvent args)
     {
-        if(!_timing.IsFirstTimePredicted)
+        if (!_timing.IsFirstTimePredicted)
             return;
 
-        if(!TryFindTargets(args.Mode, out var options, out var trackingOptions))
+        if (!TryFindTargets(args.Mode, out var options, out var trackingOptions))
             return;
 
         // Remove targets that are not in the same squad as the tracking entity.
@@ -587,9 +587,9 @@ public sealed partial class SquadLeaderTrackerSystem : EntitySystem
                     {
                         if (fireteamLeaderUid != member)
                         {
-                            ProtoId<TrackerModePrototype> mode = "FireteamLeader";
                             SetTarget((member, tempTracker), fireteamLeaderUid);
-                            SetMode((member, tempTracker), mode);
+                            // ProtoId<TrackerModePrototype> mode = "FireteamLeader";
+                            // SetMode((member, tempTracker), mode);
                         }
                     }
                 }
@@ -650,7 +650,7 @@ public sealed partial class SquadLeaderTrackerSystem : EntitySystem
         _alerts.ClearAlertCategory(ent, SquadTrackerCategory);
 
         _prototypeManager.TryIndex(ent.Comp.Mode, out var trackerMode);
-        if(trackerMode == null)
+        if (trackerMode == null)
             return;
 
         var alert = trackerMode.Alert;

--- a/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerSystem.cs
+++ b/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerSystem.cs
@@ -657,7 +657,9 @@ public sealed partial class SquadLeaderTrackerSystem : EntitySystem
         var severity = TrackerSystem.CenterSeverity;
 
         if (ent.Comp.Mode == SquadLeaderMode)
-            alert += squad;
+            alert = _prototypeManager.HasIndex<AlertPrototype>(alert + squad)
+            ? alert + squad
+            : "SquadTrackerFallback"; // this tracker is named: BUG - Fallback Tracker
 
         if (coordinates != null)
             severity = _tracker.GetAlertSeverity(ent.Owner, coordinates.Value);

--- a/Resources/Locale/en-US/_RMC14/overwatch.ftl
+++ b/Resources/Locale/en-US/_RMC14/overwatch.ftl
@@ -10,6 +10,7 @@ rmc-overwatch-console-hide-squad-info = Hide Squad Info
 rmc-overwatch-console-squad-monitor = Squad Monitor
 rmc-overwatch-console-supply-drop = Supply Drop
 rmc-overwatch-console-orbital-bombardment = Orbital Bombardment
+rmc-overwatch-console-fireteams = Fireteams
 rmc-overwatch-console-monitor = Monitor
 rmc-overwatch-console-shown-all = Shown: all
 rmc-overwatch-console-show-dead = Show dead

--- a/Resources/Prototypes/_AU14/Entities/Clothing/Headset/thirdpartyheadsets.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Headset/thirdpartyheadsets.yml
@@ -20,6 +20,8 @@
     trackerModes:
     - SquadLeader
     - USArmyCommandingOfficer
+    - BattleBuddy
+    - PrimaryLandingZone
 
 - type: entity
   parent: AU14HeadsetGovforCommand
@@ -65,6 +67,8 @@
     defaultMode: SquadLeader
     trackerModes:
     - SquadLeader
+    - BattleBuddy
+    - PrimaryLandingZone
 
 - type: entity
   parent: AU14HeadsetGovforCommand
@@ -108,3 +112,5 @@
     defaultMode: SquadLeader
     trackerModes:
     - SquadLeader
+    - PrimaryLandingZone
+    - BattleBuddy

--- a/Resources/Prototypes/_AU14/thirdParties/GROM/BaseGrom.yml
+++ b/Resources/Prototypes/_AU14/thirdParties/GROM/BaseGrom.yml
@@ -93,7 +93,7 @@
   parent: AU14BeltHolsterPistolUPP
   id: AU14BeltHolsterPistolUPPFull
   suffix: Full, T74, GROM
-  components: 
+  components:
   - type: StorageFill
     contents:
     - id: RMCWeaponPistolT74
@@ -104,7 +104,7 @@
   parent: RMCOuterClothingExternalWebbing
   id: RMCOuterClothingExternalWebbingBrownFull
   suffix: Full, Crowbar
-  components: 
+  components:
   - type: StorageFill
     contents:
     - id: RMCTacticalPrybar
@@ -113,7 +113,7 @@
   parent: AU14WebbingDropPouchUPP
   id: AU14WebbingDropPouchUPPFull
   suffix: Full, GROM
-  components: 
+  components:
   - type: StorageFill
     contents:
     - id: AU14MREUPP
@@ -123,7 +123,7 @@
   parent: RMCSatchelSPP
   id: RMCSatchelSPPFull
   suffix: Full, GROM
-  components: 
+  components:
   - type: StorageFill
     contents:
     - id: RMCRadioHandheldColony
@@ -136,7 +136,7 @@
   parent: RMCSatchelSPP
   id: RMCSatchelSPPFullMarksman
   suffix: Full, GROM
-  components: 
+  components:
   - type: StorageFill
     contents:
     - id: RMCRadioHandheldColony
@@ -150,7 +150,7 @@
   parent: RMCSatchelSPP
   id: RMCSatchelSPPFullMachinegunner
   suffix: Full, GROM
-  components: 
+  components:
   - type: StorageFill
     contents:
     - id: RMCRadioHandheldColony
@@ -159,7 +159,7 @@
   parent: RMCPouchCommand
   id: RMCPouchCommandFull
   suffix: Full, GROM
-  components: 
+  components:
   - type: StorageFill
     contents:
     - id: RMCWeaponRevolverZHNK72
@@ -168,7 +168,7 @@
   parent: AU14ShotgunShellLoadingRigUPP
   id: AU14ShotgunShellLoadingRigUPPFull
   suffix: Full, GROM
-  components: 
+  components:
   - type: StorageFill
     contents:
     - id: RMCShellShotgunHeavySlugs
@@ -178,7 +178,7 @@
   parent: AU14BeltMedicalUPP
   id: AU14BeltMedicalUPPFull
   suffix: Full, GROM
-  components: 
+  components:
   - type: StorageFill
     contents:
     - id: CMBurnKit10
@@ -195,7 +195,7 @@
   parent: AU14BeltMedicalUPP
   id: AU14BeltMedicalUPPFullSupportTech
   suffix: Full, GROM
-  components: 
+  components:
   - type: StorageFill
     contents:
     - id: CMSurgicalLine
@@ -210,7 +210,7 @@
   parent: AU14PouchPistolAlt
   id: AU14PouchPistolAltFull
   suffix: Full, GROM, T74
-  components: 
+  components:
   - type: StorageFill
     contents:
     - id: RMCWeaponPistolT74
@@ -220,7 +220,7 @@
   parent: AU14BeltSmartGunOperatorPistolUPP
   id: AU14BeltSmartGunOperatorPistolUPPFull
   suffix: Full, GROM, T74
-  components: 
+  components:
   - type: StorageFill
     contents:
     - id: RMCWeaponPistolT74
@@ -233,7 +233,7 @@
   parent: RMCPouchMagazine
   id: RMCPouchMagazineUPPFull
   suffix: Full, GROM, AG80
-  components: 
+  components:
   - type: StorageFill
     contents:
     - id: AU14MagazineRifleAG80
@@ -261,3 +261,5 @@
     trackerModes:
     - GROMCommandingOfficer
     - SquadLeader
+    - BattleBuddy
+    - PrimaryLandingZone

--- a/Resources/Prototypes/_RMC14/Alerts/alerts.yml
+++ b/Resources/Prototypes/_RMC14/Alerts/alerts.yml
@@ -109,12 +109,63 @@
 - type: alert
   parent: SquadTracker
   id: SquadTrackerCorporate
-  category: SquadTracker
 
 - type: alert
   parent: SquadTracker
+  id: SquadTrackerLandingZone
+  icons:
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackoff
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-direct_lz
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-south_lz
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southeast_lz
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-east_lz
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northeast_lz
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-north_lz
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northwest_lz
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-west_lz
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southwest_lz
+  description: Tracks the Primary Landing Zone
+
+- type: alert
+  parent: SquadTracker
+  id: SquadTrackerTeamLeader
+  icons:
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackoff
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-direct_tl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-south_tl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southeast_tl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-east_tl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northeast_tl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-north_tl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northwest_tl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-west_tl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southwest_tl
+  description: Tracks the Team Leader
+
+# ├──[ GOVFOR ]──────────────────────────────────────────────────────┤
+- type: alert
+  parent: SquadTracker
   id: SquadTrackerAlpha
-  category: SquadTracker
   icons:
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
     state: trackoff
@@ -141,7 +192,6 @@
 - type: alert
   id: SquadTrackerBravo
   parent: SquadTracker
-  category: SquadTracker
   icons:
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
     state: trackoff
@@ -168,7 +218,6 @@
 - type: alert
   parent: SquadTracker
   id: SquadTrackerCharlie
-  category: SquadTracker
   icons:
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
     state: trackoff
@@ -193,171 +242,30 @@
   description: Tracks the Charlie Squad Leader.
 
 - type: alert
-  parent: SquadTracker
-  id: SquadTrackerDelta
-  category: SquadTracker
-  icons:
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackoff
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-direct_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-south_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southeast_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-east_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northeast_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-north_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northwest_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-west_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southwest_dsl
-  description: Tracks the Delta Squad Leader.
+  parent: SquadTrackerEcho
+  id: SquadTrackerAuxiliary
+  description: Tracks the Auxiliary Squad Leader.
+
+# ├──[ OPFOR ]───────────────────────────────────────────────────────┤
+- type: alert
+  parent: SquadTrackerDelta
+  id: SquadTrackerTango
+  description: Tracks the Tango Squad Leader.
 
 - type: alert
-  parent: SquadTracker
-  id: SquadTrackerEcho
-  category: SquadTracker
-  icons:
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackoff
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-direct_esl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-south_esl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southeast_esl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-east_esl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northeast_esl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-north_esl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northwest_esl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-west_esl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southwest_esl
-  description: Tracks the Echo Squad Leader.
+  parent: SquadTrackerEcho
+  id: SquadTrackerSierra
+  description: Tracks the Sierra Squad Leader.
 
 - type: alert
-  parent: SquadTracker
-  id: SquadTrackerFoxtrot
-  category: SquadTracker
-  icons:
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackoff
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-direct_fsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-south_fsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southeast_fsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-east_fsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northeast_fsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-north_fsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northwest_fsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-west_fsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southwest_fsl
-  description: Tracks the Foxtrot Squad Leader.
+  parent: SquadTrackerFoxtrot
+  id: SquadTrackerUniform
+  description: Tracks the Uniform Squad Leader.
 
-- type: alert
-  parent: SquadTracker
-  id: SquadTrackerIntel
-  category: SquadTracker
-  icons:
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackoff
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-direct_isl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-south_isl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southeast_isl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-east_isl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northeast_isl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-north_isl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northwest_isl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-west_isl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southwest_isl
-  description: Tracks the Foxtrot Squad Leader.
-
-- type: alert
-  parent: SquadTracker
-  id: SquadTrackerSunRiders
-  category: SquadTracker
-  icons:
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackoff
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-direct_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-south_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southeast_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-east_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northeast_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-north_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northwest_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-west_dsl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southwest_dsl
-  description: Tracks the Sun Riders Section Sergeant.
-
-- type: alert
-  parent: SquadTracker
-  id: SquadTrackerRecon
-  category: SquadTracker
-  icons:
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackoff
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-direct_fosl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-south_fosl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southeast_fosl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-east_fosl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northeast_fosl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-north_fosl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northwest_fosl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-west_fosl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southwest_fosl
-  description: Tracks the FORECON Squad Leader.
-
+# ├──[ LEGACY TRACKERS ]─────────────────────────────────────────────┤
 - type: alert
   parent: SquadTracker
   id: SquadTrackerCommandingOfficer
-  category: SquadTracker
   icons:
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
     state: trackoff
@@ -384,7 +292,6 @@
 - type: alert
   parent: SquadTracker
   id: SquadTrackerExecutiveOfficer
-  category: SquadTracker
   icons:
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
     state: trackoff
@@ -410,8 +317,163 @@
 
 - type: alert
   parent: SquadTracker
+  id: SquadTrackerIntel
+  icons:
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackoff
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-direct_isl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-south_isl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southeast_isl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-east_isl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northeast_isl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-north_isl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northwest_isl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-west_isl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southwest_isl
+  description: Tracks the Intel Squad Leader.
+
+- type: alert
+  parent: SquadTracker
+  id: SquadTrackerDelta
+  icons:
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackoff
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-direct_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-south_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southeast_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-east_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northeast_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-north_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northwest_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-west_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southwest_dsl
+  description: Tracks the Delta Squad Leader.
+
+- type: alert
+  parent: SquadTracker
+  id: SquadTrackerEcho
+  icons:
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackoff
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-direct_esl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-south_esl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southeast_esl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-east_esl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northeast_esl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-north_esl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northwest_esl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-west_esl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southwest_esl
+  description: Tracks the Echo Squad Leader.
+
+- type: alert
+  parent: SquadTracker
+  id: SquadTrackerFoxtrot
+  icons:
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackoff
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-direct_fsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-south_fsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southeast_fsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-east_fsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northeast_fsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-north_fsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northwest_fsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-west_fsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southwest_fsl
+  description: Tracks the Foxtrot Squad Leader.
+
+- type: alert
+  parent: SquadTracker
+  id: SquadTrackerRecon
+  icons:
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackoff
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-direct_fosl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-south_fosl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southeast_fosl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-east_fosl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northeast_fosl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-north_fosl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northwest_fosl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-west_fosl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southwest_fosl
+  description: Tracks the FORECON Squad Leader.
+
+- type: alert
+  parent: SquadTracker
+  id: SquadTrackerSunRiders
+  icons:
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackoff
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-direct_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-south_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southeast_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-east_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northeast_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-north_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northwest_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-west_dsl
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southwest_dsl
+  description: Tracks the Sun Riders Section Sergeant.
+
+- type: alert
+  parent: SquadTracker
   id: SquadTrackerChiefMilitaryPolice
-  category: SquadTracker
   icons:
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
     state: trackoff
@@ -436,36 +498,14 @@
   description: Tracks the Chief Military Police
 
 - type: alert
-  parent: SquadTracker
-  id: SquadTrackerLandingZone
-  category: SquadTracker
-  icons:
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackoff
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-direct_lz
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-south_lz
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southeast_lz
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-east_lz
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northeast_lz
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-north_lz
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northwest_lz
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-west_lz
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southwest_lz
-  description: Tracks the Primary Landing Zone
+  parent: SquadTrackerTeamLeader
+  id: SquadTrackerParaTeamLeader
+  description: Tracks the Paramarine Team Leader
 
+# ├──[ We-Yu PMCs ]──────────────────────────────────────────────────┤
 - type: alert
   parent: SquadTracker
   id: SquadTrackerCorporateLiaison
-  category: SquadTracker
   icons:
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
     state: trackoff
@@ -492,63 +532,7 @@
 
 - type: alert
   parent: SquadTracker
-  id: SquadTrackerTeamLeader
-  category: SquadTracker
-  icons:
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackoff
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-direct_tl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-south_tl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southeast_tl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-east_tl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northeast_tl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-north_tl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northwest_tl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-west_tl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southwest_tl
-  description: Tracks the Team Leader
-  
-- type: alert
-  parent: SquadTracker
-  id: SquadTrackerParaTeamLeader
-  category: SquadTracker
-  icons:
-    - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-      state: trackoff
-    - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-      state: trackon-direct_tl
-    - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-      state: trackon-south_tl
-    - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-      state: trackon-southeast_tl
-    - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-      state: trackon-east_tl
-    - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-      state: trackon-northeast_tl
-    - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-      state: trackon-north_tl
-    - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-      state: trackon-northwest_tl
-    - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-      state: trackon-west_tl
-    - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-      state: trackon-southwest_tl
-  description: Tracks the Paramarine Team Leader
-
-
-- type: alert
-  parent: SquadTracker
   id: SquadTrackerPMCForceLeader
-  category: SquadTracker
   icons:
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
     state: trackoff
@@ -570,41 +554,13 @@
     state: trackon-west_fl
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
     state: trackon-southwest_fl
-  name: We-Ya Squad Tracker
+  name: We-Yu Squad Tracker
   description: Tracks the Force Leader
 
-- type: alert
-  parent: SquadTracker
-  id: SquadTrackerRCMPVESectionLead
-  category: SquadTracker
-  icons:
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackoff
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-direct_sectionlead
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-south_sectionlead
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southeast_sectionlead
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-east_sectionlead
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northeast_sectionlead
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-north_sectionlead
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northwest_sectionlead
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-west_sectionlead
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southwest_sectionlead
-  name: Royal Squad Tracker
-  description: Tracks the Section Leader
-
+# ├──[ ROYAL COMMANDOS ]─────────────────────────────────────────────┤
 - type: alert
   parent: SquadTracker
   id: SquadTrackerRCMPVETroopCommander
-  category: SquadTracker
   icons:
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
     state: trackoff
@@ -631,36 +587,61 @@
 
 - type: alert
   parent: SquadTracker
-  id: SquadTrackerRCMPVETeamLead
-  category: SquadTracker
+  id: SquadTrackerRCMLieutenant
   icons:
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
     state: trackoff
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-direct_teamlead
+    state: trackon-direct_lt
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-south_teamlead
+    state: trackon-south_lt
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southeast_teamlead
+    state: trackon-southeast_lt
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-east_teamlead
+    state: trackon-east_lt
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northeast_teamlead
+    state: trackon-northeast_lt
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-north_teamlead
+    state: trackon-north_lt
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northwest_teamlead
+    state: trackon-northwest_lt
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-west_teamlead
+    state: trackon-west_lt
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southwest_teamlead
+    state: trackon-southwest_lt
   name: Royal Squad Tracker
-  description: Tracks the Team Leader
+  description: Tracks the Lieutenant
+
+- type: alert
+  parent: SquadTracker
+  id: SquadTrackerRCMPVESectionLead
+  icons:
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackoff
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-direct_sectionlead
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-south_sectionlead
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southeast_sectionlead
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-east_sectionlead
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northeast_sectionlead
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-north_sectionlead
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-northwest_sectionlead
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-west_sectionlead
+  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
+    state: trackon-southwest_sectionlead
+  name: Royal Squad Tracker
+  description: Tracks the Section Leader
 
 - type: alert
   parent: SquadTracker
   id: SquadTrackerRCMPVETroopSergeant
-  category: SquadTracker
   icons:
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
     state: trackoff
@@ -688,7 +669,6 @@
 - type: alert
   parent: SquadTracker
   id: SquadTrackerRCMTeamLead
-  category: SquadTracker
   icons:
   - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
     state: trackoff
@@ -714,33 +694,10 @@
   description: Tracks the Team Leader
 
 - type: alert
-  parent: SquadTracker
-  id: SquadTrackerRCMLieutenant
-  category: SquadTracker
-  icons:
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackoff
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-direct_lt
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-south_lt
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southeast_lt
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-east_lt
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northeast_lt
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-north_lt
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northwest_lt
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-west_lt
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southwest_lt
-  name: Royal Squad Tracker
-  description: Tracks the Lieutenant
+  parent: SquadTrackerRCMTeamLead
+  id: SquadTrackerRCMPVETeamLead
 
+# ├──[ HUD INFO ]────────────────────────────────────────────────────┤
 - type: alert
   id: MarineTacMapAlert
   category: Tacmap
@@ -819,89 +776,3 @@
 
 - type: alertCategory
   id: HiveTracker
-
-
-
-
-- type: alert
-  parent: SquadTracker
-  id: SquadTrackerTango
-  category: SquadTracker
-  icons:
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackoff
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-direct_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-south_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southeast_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-east_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northeast_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-north_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northwest_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-west_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southwest_asl
-  description: Tracks the Tango Squad Leader.
-
-
-- type: alert
-  parent: SquadTracker
-  id: SquadTrackerSierra
-  category: SquadTracker
-  icons:
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackoff
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-direct_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-south_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southeast_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-east_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northeast_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-north_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northwest_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-west_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southwest_asl
-  description: Tracks the Tango Squad Leader.
-
-
-- type: alert
-  parent: SquadTracker
-  id: SquadTrackerUniform
-  category: SquadTracker
-  icons:
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackoff
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-direct_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-south_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southeast_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-east_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northeast_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-north_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-northwest_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-west_asl
-  - sprite: /Textures/_RMC14/Interface/Alerts/marine_tracker.rsi
-    state: trackon-southwest_asl
-  description: Tracks the Tango Squad Leader.

--- a/Resources/Prototypes/_RMC14/Alerts/alerts.yml
+++ b/Resources/Prototypes/_RMC14/Alerts/alerts.yml
@@ -108,6 +108,12 @@
 
 - type: alert
   parent: SquadTracker
+  id: SquadTrackerFallback
+  name: BUG - Fallback Tracker
+  description: BUG. If you see this, please make a bug-report.
+
+- type: alert
+  parent: SquadTracker
   id: SquadTrackerCorporate
 
 - type: alert


### PR DESCRIPTION
- **🪲 fixes squad tracker breaking when assigning/reassigning SLs**
- **🪲 fix squad tracker reverting back to FTLs when someone joins team**
- **📋 squad tracker alert for auxiliary tracking**
- **✨ fallback tracker - stops silently breaking when it cant find the tracker**
- ** 📋 localization for Fireteams in OW console**
- **🪲 hide fireteam management buttons for non-SL/OW & show tracker button for everyone**
- **🪲 no clue why ghost roles are allowed to keep player's charname - UsePlayerProfile required now**
- **🔧 orders (move/hold/focus) require at least skill leadership=1**
- **🪲 ghostroletest fix - looking for character name not the mob's name**
- **🪲 orders (move/hold/focus) require leadership=1 OR leading a squad**
- **🩹 ghost roles should always use random names, really don't get why it suddenly was coded to use the player's loadout charname**
- **🩹 BattleBuddy Team cleanup**

## About the PR
- Mostly some refactoring and cleanup of govfor systems mentioned in above commits.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Squad tracker breaking when assigning/reassigning SLs
- fix: Squad tracker reverting back to FTL tracking when someone joins the fireteam
- fix: Squad tracker could previously only be set/changed by the squad leader
- fix: Fireteam management hidden if you can't interact with it (only SL/OW can use it)
- fix: Battle Buddy system would track stale state if your partner found a new buddy
- tweak: Marine Orders (move/hold/focus) only if you have leadership>=1 or assigned SL (duration is based on leadership)
- code: Additional localization support (overwatch.ftl) for the OW consoles
