### PR TITLE
Update larva queue to exclude ghosted lesser drones

### DIFF
--- a/Content.Client/Eye/Blinding/BlurryVisionOverlay.cs
+++ b/Content.Client/Eye/Blinding/BlurryVisionOverlay.cs
@@ -1,5 +1,6 @@
 using Robust.Client.Graphics;
 using Robust.Client.Player;
+using Content.Client.Viewport;
 using Content.Shared.CCVar;
 using Robust.Shared.Maths;
 using Robust.Shared.Timing;
@@ -80,10 +81,16 @@ namespace Content.Client.Eye.Blinding
             if (!_entityManager.TryGetComponent(_playerManager.LocalSession?.AttachedEntity, out EyeComponent? eyeComp))
                 return false;
 
-            if (args.Viewport.Eye != eyeComp.Eye)
+            if (!ShouldDrawForViewportEye(args.Viewport.Eye, eyeComp.Eye))
                 return false;
 
             return _currentMagnitude > 0.01f;
+        }
+
+        internal static bool ShouldDrawForViewportEye(Robust.Shared.Graphics.IEye? viewportEye, Robust.Shared.Graphics.IEye playerEye)
+        {
+            return ReferenceEquals(viewportEye, playerEye) ||
+                   viewportEye is ScalingViewport.ZEye { Depth: 0, BlurCurrentLevel: true };
         }
 
         protected override void Draw(in OverlayDrawArgs args)

--- a/Content.IntegrationTests/_CMU14/Blackfoot/BlackfootPrototypeTest.cs
+++ b/Content.IntegrationTests/_CMU14/Blackfoot/BlackfootPrototypeTest.cs
@@ -19,6 +19,7 @@ using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using Robust.UnitTesting;
@@ -165,6 +166,8 @@ public sealed class BlackfootPrototypeTest
 
             Assert.That(prototypes.TryIndex<EntityPrototype>(FuelPumpId, out var fuelPumpProto), Is.True);
             Assert.That(fuelPumpProto!.TryGetComponent<BlackfootFuelPumpComponent>(out _, factory), Is.True);
+            Assert.That(fuelPumpProto.TryGetComponent<PhysicsComponent>(out var fuelPumpPhysics, factory), Is.True);
+            Assert.That(fuelPumpPhysics!.CanCollide, Is.False);
             AssertMountedPadSupport(prototypes, factory, FuelPumpId);
             AssertPackable(prototypes, factory, FuelPumpId, FuelPumpCrateId);
 

--- a/Content.IntegrationTests/_CMU14/Medical/MechanismWoundsFoundationTest.cs
+++ b/Content.IntegrationTests/_CMU14/Medical/MechanismWoundsFoundationTest.cs
@@ -690,6 +690,50 @@ public sealed class MechanismWoundsFoundationTest
     }
 
     [Test]
+    public async Task NormalExamineShowsSimpleFracturesButHidesHairlines()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var fractureSystem = entMan.System<SharedFractureSystem>();
+            var human = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+
+            try
+            {
+                var leftArm = GetBodyPart(entMan, human, BodyPartType.Arm, BodyPartSymmetry.Left);
+                var rightArm = GetBodyPart(entMan, human, BodyPartType.Arm, BodyPartSymmetry.Right);
+
+                var simple = entMan.EnsureComponent<FractureComponent>(leftArm);
+                fractureSystem.SetSeverity((leftArm, simple), FractureSeverity.Simple);
+
+                var hairline = entMan.EnsureComponent<FractureComponent>(rightArm);
+                fractureSystem.SetSeverity((rightArm, hairline), FractureSeverity.Hairline);
+
+                var examine = new ExaminedEvent(new FormattedMessage(), human, human, true, false);
+                entMan.EventBus.RaiseLocalEvent(human, examine);
+                var text = examine.GetTotalMessage().ToMarkup();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(text, Does.Contain("Left arm"));
+                    Assert.That(text, Does.Contain("simple fracture"));
+                    Assert.That(text, Does.Not.Contain("Right arm"));
+                    Assert.That(text, Does.Not.Contain("hairline fracture"));
+                });
+            }
+            finally
+            {
+                entMan.DeleteEntity(human);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
     public async Task DetailedExamineOrdersHeadTorsoThenLimbsAndUsesMarkup()
     {
         await using var pair = await PoolManager.GetServerClient();

--- a/Content.IntegrationTests/_CMU14/Medical/PainPlayerFeedbackTest.cs
+++ b/Content.IntegrationTests/_CMU14/Medical/PainPlayerFeedbackTest.cs
@@ -16,7 +16,7 @@ namespace Content.IntegrationTests._CMU14.Medical;
 public sealed class PainPlayerFeedbackTest
 {
     [Test]
-    public async Task SeverePainAppliesPlayerFacingFeedback()
+    public async Task SeverePainAppliesBlurOnly()
     {
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
@@ -35,23 +35,19 @@ public sealed class PainPlayerFeedbackTest
         {
             var entMan = server.EntMan;
             var oldStatus = entMan.System<StatusEffectQuerySystem>();
-            var prototypes = server.ResolveDependency<IPrototypeManager>();
             var feedback = entMan.GetComponent<CMUPainFeedbackComponent>(human);
             var damageable = entMan.GetComponent<DamageableComponent>(human);
 
             Assert.Multiple(() =>
             {
-                Assert.That(oldStatus.HasStatusEffect(human, "Stutter"), Is.True);
-                Assert.That(oldStatus.HasStatusEffect(human, "Drunk"), Is.True);
+                Assert.That(oldStatus.HasStatusEffect(human, "Stutter"), Is.False);
+                Assert.That(oldStatus.HasStatusEffect(human, "Drunk"), Is.False);
                 Assert.That(oldStatus.HasStatusEffect(human, "SlurredSpeech"), Is.False);
                 Assert.That(entMan.HasComponent<BlurryVisionComponent>(human), Is.True);
                 Assert.That(entMan.GetComponent<BlurryVisionComponent>(human).Magnitude,
                     Is.EqualTo(feedback.SevereBlurStartAmount));
-                Assert.That(feedback.SevereBlurStartAmount,
-                    Is.LessThanOrEqualTo(0.2f),
-                    "Severe pain should start the cataracts barely visible instead of snapping to the full severe amount.");
-                Assert.That(damageable.Damage.DamageDict["Asphyxiation"], Is.GreaterThan(FixedPoint2.Zero));
-                AssertPainEmotesExist(prototypes, feedback);
+                Assert.That(feedback.SevereBlurStartAmount, Is.LessThan(0.5f));
+                Assert.That(damageable.Damage.DamageDict["Asphyxiation"], Is.EqualTo(FixedPoint2.Zero));
             });
 
             entMan.DeleteEntity(human);
@@ -149,8 +145,7 @@ public sealed class PainPlayerFeedbackTest
                 Assert.That(oldStatus.HasStatusEffect(human, "Stutter"), Is.False);
                 Assert.That(oldStatus.HasStatusEffect(human, "Drunk"), Is.False);
                 Assert.That(oldStatus.HasStatusEffect(human, "SlurredSpeech"), Is.False);
-                Assert.That(entMan.HasComponent<BlurryVisionComponent>(human), Is.True);
-                Assert.That(entMan.GetComponent<BlurryVisionComponent>(human).Magnitude, Is.EqualTo(0.02f).Within(0.001f));
+                Assert.That(entMan.HasComponent<BlurryVisionComponent>(human), Is.False);
                 Assert.That(damageable.Damage.DamageDict["Asphyxiation"], Is.EqualTo(FixedPoint2.Zero));
             });
 
@@ -171,7 +166,7 @@ public sealed class PainPlayerFeedbackTest
         {
             var entMan = server.EntMan;
             human = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
-            SetPainValue(entMan, human, (FixedPoint2)61);
+            SetPainValue(entMan, human, (FixedPoint2)84);
         });
 
         await pair.RunTicksSync(pair.SecondsToTicks(2));
@@ -181,15 +176,15 @@ public sealed class PainPlayerFeedbackTest
             var entMan = server.EntMan;
             var feedback = entMan.GetComponent<CMUPainFeedbackComponent>(human);
             var blur = entMan.GetComponent<BlurryVisionComponent>(human).Magnitude;
-            const float expectedProgress = (61f - 60f) / (85f - 60f);
+            const float expectedProgress = (84f - 60f) / (85f - 60f);
             var expected = feedback.SevereBlurStartAmount +
-                (feedback.ShockBlurStartAmount - feedback.SevereBlurStartAmount) * expectedProgress;
+                (feedback.SevereBlurAmount - feedback.SevereBlurStartAmount) * expectedProgress;
 
             Assert.Multiple(() =>
             {
                 Assert.That(blur, Is.EqualTo(expected).Within(0.01f));
                 Assert.That(blur, Is.GreaterThan(feedback.SevereBlurStartAmount));
-                Assert.That(blur, Is.LessThan(0.2f));
+                Assert.That(blur, Is.LessThan(0.5f));
             });
 
             entMan.DeleteEntity(human);
@@ -218,6 +213,7 @@ public sealed class PainPlayerFeedbackTest
         {
             var entMan = server.EntMan;
             var feedback = entMan.GetComponent<CMUPainFeedbackComponent>(human);
+            var prototypes = server.ResolveDependency<IPrototypeManager>();
             var blur = entMan.GetComponent<BlurryVisionComponent>(human).Magnitude;
             const float expectedProgress = (90f - 85f) / (95f - 85f);
             var expected = feedback.ShockBlurStartAmount +
@@ -228,6 +224,7 @@ public sealed class PainPlayerFeedbackTest
                 Assert.That(blur, Is.EqualTo(expected).Within(0.01f));
                 Assert.That(blur, Is.GreaterThan(feedback.ShockBlurStartAmount));
                 Assert.That(blur, Is.LessThan(feedback.ShockBlurAmount));
+                AssertPainEmotesExist(prototypes, feedback);
             });
 
             entMan.DeleteEntity(human);
@@ -307,9 +304,9 @@ public sealed class PainPlayerFeedbackTest
             Assert.Multiple(() =>
             {
                 Assert.That(shockDamage, Is.GreaterThan(severeDamage));
-                Assert.That(oldStatus.TryGetTime(severe, "Drunk", out var severeDrunkTime), Is.True);
+                Assert.That(oldStatus.TryGetTime(severe, "Drunk", out _), Is.False);
                 Assert.That(oldStatus.TryGetTime(shock, "Drunk", out var shockDrunkTime), Is.True);
-                Assert.That(shockDrunkTime!.Value.Item2, Is.GreaterThan(severeDrunkTime!.Value.Item2));
+                Assert.That(shockDrunkTime!.Value.Item2, Is.GreaterThan(TimeSpan.Zero));
                 Assert.That(oldStatus.HasStatusEffect(shock, "SlurredSpeech"), Is.True);
                 Assert.That(oldStatus.HasStatusEffect(shock, "Stutter"), Is.True);
                 Assert.That(shockBlur, Is.GreaterThan(severeBlur));

--- a/Content.IntegrationTests/_CMU14/Medical/PainShockReworkTest.cs
+++ b/Content.IntegrationTests/_CMU14/Medical/PainShockReworkTest.cs
@@ -1,4 +1,5 @@
 using Content.Shared._CMU14.Medical;
+using Content.Shared._CMU14.Medical.BodyPart;
 using Content.Shared._CMU14.Medical.Bones;
 using Content.Shared._CMU14.Medical.EntityEffects;
 using Content.Shared._CMU14.Medical.Organs;
@@ -14,6 +15,7 @@ using Content.Shared.Body.Part;
 using Content.Shared.Body.Prototypes;
 using Content.Shared.Body.Systems;
 using Content.Shared.Chemistry.Reagent;
+using Content.Shared.DoAfter;
 using Content.Shared.EntityEffects;
 using Content.Shared.EntityEffects.EffectConditions;
 using Content.Shared.EntityEffects.Effects;
@@ -282,6 +284,181 @@ public sealed class PainShockReworkTest
             {
                 entMan.DeleteEntity(patient);
                 entMan.DeleteEntity(user);
+                entMan.DeleteEntity(tool);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ShrapnelExtractionAlternativeVerbRequiresHeldExtractor()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var hands = entMan.System<SharedHandsSystem>();
+            var shrapnel = entMan.System<SharedCMUShrapnelSystem>();
+            var verbs = entMan.System<VerbSystem>();
+            var patient = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            var user = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            var tool = entMan.SpawnEntity("KitchenKnife", MapCoordinates.Nullspace);
+
+            try
+            {
+                var part = GetFirstPart(entMan, patient);
+                shrapnel.AddShrapnel(part, 2, 12f);
+
+                var withoutTool = verbs.GetLocalVerbs(patient, user, typeof(AlternativeVerb), force: true);
+                Assert.That(ContainsVerb(withoutTool, "Remove shrapnel"), Is.False);
+
+                Assert.That(hands.TryPickupAnyHand(user, tool, checkActionBlocker: false), Is.True);
+
+                var withTool = verbs.GetLocalVerbs(patient, user, typeof(AlternativeVerb), force: true);
+                Assert.That(ContainsVerb(withTool, "Remove shrapnel"), Is.True);
+            }
+            finally
+            {
+                entMan.DeleteEntity(patient);
+                entMan.DeleteEntity(user);
+                entMan.DeleteEntity(tool);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task UseInHandExtractorStartsSelfShrapnelRemoval()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var hands = entMan.System<SharedHandsSystem>();
+            var shrapnel = entMan.System<SharedCMUShrapnelSystem>();
+            var human = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            var tool = entMan.SpawnEntity("KitchenKnife", MapCoordinates.Nullspace);
+
+            try
+            {
+                var part = GetFirstPart(entMan, human);
+                shrapnel.AddShrapnel(part, 2, 12f);
+
+                Assert.That(hands.TryPickupAnyHand(human, tool, checkActionBlocker: false), Is.True);
+                Assert.That(hands.TryUseItemInHand(human), Is.True);
+                Assert.That(entMan.TryGetComponent<DoAfterComponent>(human, out var doAfter), Is.True);
+                Assert.That(HasActiveShrapnelExtractionDoAfter(doAfter!), Is.True);
+            }
+            finally
+            {
+                entMan.DeleteEntity(human);
+                entMan.DeleteEntity(tool);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ShrapnelExtractionDoAfterRepeatsUntilFragmentsAreGone()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var shrapnel = entMan.System<SharedCMUShrapnelSystem>();
+            var human = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            var tool = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+
+            try
+            {
+                var part = GetFirstPart(entMan, human);
+                shrapnel.AddShrapnel(part, 5, 25f);
+
+                entMan.EnsureComponent<CMUShrapnelExtractorComponent>(tool);
+                var ev = new CMUShrapnelExtractDoAfterEvent();
+                ev.DoAfter = new DoAfter(
+                    0,
+                    new DoAfterArgs(entMan, human, TimeSpan.FromSeconds(1), ev, tool, target: human, used: tool),
+                    TimeSpan.Zero);
+
+                entMan.EventBus.RaiseLocalEvent(tool, ev);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(entMan.GetComponent<CMUShrapnelComponent>(part).Fragments, Is.EqualTo(3));
+                    Assert.That(ev.Repeat, Is.True);
+                    Assert.That(ev.PreSelectedPart, Is.Not.Null);
+                });
+
+                entMan.EventBus.RaiseLocalEvent(tool, ev);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(entMan.GetComponent<CMUShrapnelComponent>(part).Fragments, Is.EqualTo(1));
+                    Assert.That(ev.Repeat, Is.True);
+                    Assert.That(ev.PreSelectedPart, Is.Not.Null);
+                });
+
+                entMan.EventBus.RaiseLocalEvent(tool, ev);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(entMan.HasComponent<CMUShrapnelComponent>(part), Is.False);
+                    Assert.That(ev.Repeat, Is.False);
+                    Assert.That(ev.PreSelectedPart, Is.Null);
+                });
+            }
+            finally
+            {
+                entMan.DeleteEntity(human);
+                entMan.DeleteEntity(tool);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ShrapnelExtractionDamageDoesNotFractureOrCauseInternalBleeding()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            server.CfgMan.SetCVar(CMUMedicalCCVars.TraumaPierceBoneChance, 1f);
+            server.CfgMan.SetCVar(CMUMedicalCCVars.TraumaPierceVascularChance, 1f);
+
+            var entMan = server.EntMan;
+            var hitLocation = entMan.System<SharedHitLocationSystem>();
+            var shrapnel = entMan.System<SharedCMUShrapnelSystem>();
+            var human = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            var tool = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+
+            try
+            {
+                var torso = GetBodyPart(entMan, human, BodyPartType.Torso, BodyPartSymmetry.None);
+                shrapnel.AddShrapnel(torso, 1, 12f);
+                AssertNoFracturesOrInternalBleeding(entMan, human);
+
+                hitLocation.SetForcedHit(human, BodyPartType.Torso);
+                var extractor = entMan.EnsureComponent<CMUShrapnelExtractorComponent>(tool);
+                SetField(extractor, nameof(CMUShrapnelExtractorComponent.DamageOnExtract), FixedPoint2.New(100));
+                SetField(extractor, nameof(CMUShrapnelExtractorComponent.PainPenalty), 0f);
+
+                Assert.That(shrapnel.TryExtractShrapnel(human, (tool, extractor), out var removed, human, torso), Is.True);
+                Assert.That(removed, Is.EqualTo(1));
+                AssertNoFracturesOrInternalBleeding(entMan, human);
+            }
+            finally
+            {
+                entMan.DeleteEntity(human);
                 entMan.DeleteEntity(tool);
             }
         });
@@ -619,6 +796,34 @@ public sealed class PainShockReworkTest
         }
 
         return false;
+    }
+
+    private static bool HasActiveShrapnelExtractionDoAfter(DoAfterComponent comp)
+    {
+        foreach (var doAfter in comp.DoAfters.Values)
+        {
+            if (!doAfter.Cancelled &&
+                !doAfter.Completed &&
+                doAfter.Args.Event is CMUShrapnelExtractDoAfterEvent)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void AssertNoFracturesOrInternalBleeding(IEntityManager entMan, EntityUid bodyUid)
+    {
+        var body = entMan.System<SharedBodySystem>();
+        foreach (var (partUid, _) in body.GetBodyChildren(bodyUid))
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.HasComponent<FractureComponent>(partUid), Is.False);
+                Assert.That(entMan.HasComponent<InternalBleedingComponent>(partUid), Is.False);
+            });
+        }
     }
 
     private static T GetField<T>(BodyPartWoundComponent comp, string name)

--- a/Content.IntegrationTests/_RMC14/CMArmorSystemTest.cs
+++ b/Content.IntegrationTests/_RMC14/CMArmorSystemTest.cs
@@ -1,0 +1,55 @@
+using Content.Shared._RMC14.Armor;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests._RMC14;
+
+[TestFixture]
+[TestOf(typeof(CMArmorSystem))]
+public sealed class CMArmorSystemTest
+{
+    private const string TestArmorEntity = "RMCArmorInvalidOriginDamageable";
+
+    [TestPrototypes]
+    private const string Prototypes = $@"
+- type: entity
+  id: {TestArmorEntity}
+  name: {TestArmorEntity}
+  components:
+  - type: Damageable
+    damageContainer: Biological
+  - type: CMArmor
+";
+
+    [Test]
+    public async Task DamageWithInvalidOriginDoesNotResolveOriginTransform()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+        var sysMan = server.ResolveDependency<IEntitySystemManager>();
+
+        DamageSpecifier? result = null;
+
+        await server.WaitPost(() =>
+        {
+            var target = entMan.SpawnEntity(TestArmorEntity, map.MapCoords);
+            var slash = protoMan.Index<DamageTypePrototype>("Slash");
+            var damageable = sysMan.GetEntitySystem<DamageableSystem>();
+
+            result = damageable.TryChangeDamage(target, new DamageSpecifier(slash, 10), origin: EntityUid.Invalid);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(result, Is.Not.Null);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/_RMC14/LarvaQueueDialogTest.cs
+++ b/Content.IntegrationTests/_RMC14/LarvaQueueDialogTest.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Numerics;
 using Content.IntegrationTests.Pair;
+using Content.Server._RMC14.Xenonids.JoinXeno;
 using Content.Server._RMC14.Xenonids.Parasite;
 using Content.Server.GameTicking;
 using Content.Server.Mind;
@@ -227,7 +228,7 @@ public sealed class LarvaQueueJoinXenoUiTest
     }
 
     [Test]
-    public async Task LarvaQueueOffersGhostedLesserDroneWhenNoLarvaAvailable()
+    public async Task LarvaQueueDoesNotOfferGhostedLesserDrone()
     {
         await using var pair = await PoolManager.GetServerClient(new PoolSettings
         {
@@ -247,8 +248,6 @@ public sealed class LarvaQueueJoinXenoUiTest
         EntityUid ghost = default;
         EntityUid hive = default;
         EntityUid lesser = default;
-        NetEntity ghostNet = default;
-        string lesserName = string.Empty;
         await server.WaitAssertion(() =>
         {
             ghost = entMan.SpawnEntity(GameTicker.ObserverPrototypeName, map.GridCoords);
@@ -256,13 +255,11 @@ public sealed class LarvaQueueJoinXenoUiTest
             hive = entMan.SpawnEntity("CMXenoHive", map.GridCoords.Offset(new Vector2(1, 0)));
             lesser = entMan.SpawnEntity("CMXenoLesserDrone", map.GridCoords.Offset(new Vector2(2, 0)));
             hiveSystem.SetHive(lesser, hive);
-            lesserName = entMan.GetComponent<MetaDataComponent>(lesser).EntityName;
 
             var mindId = mind.CreateMind(player.UserId, "Lesser Drone");
             mind.TransferTo(mindId, lesser);
             mind.TransferTo(mindId, ghost);
             mind.SetUserId(mindId, player.UserId);
-            ghostNet = entMan.GetNetEntity(ghost);
 
             entMan.EventBus.RaiseLocalEvent(ghost, new JoinLarvaQueueEvent(entMan.GetNetEntity(hive)));
         });
@@ -272,11 +269,15 @@ public sealed class LarvaQueueJoinXenoUiTest
         await server.WaitAssertion(() =>
         {
             Assert.That(player.AttachedEntity, Is.EqualTo(ghost));
-            AssertConfirmDialog(entMan, ghost, lesserName);
-        });
+            Assert.That(entMan.HasComponent<AbandonedXenoQueueableComponent>(lesser), Is.False);
+            Assert.That(entMan.HasComponent<DialogComponent>(ghost), Is.False);
 
-        await DeclineDialog(pair, ghostNet);
-        await pair.RunTicksSync(5);
+            OpenJoinXenoUi(entMan, ghost);
+            var state = GetJoinXenoState(entMan, ghost);
+            var entry = state.Entries.Single(e => e.Hive == entMan.GetNetEntity(hive));
+            Assert.That(entry.Status, Is.EqualTo(JoinXenoQueueStatus.Queued));
+            Assert.That(entry.Position, Is.EqualTo(1));
+        });
 
         await pair.CleanReturnAsync();
     }

--- a/Content.Server/_CMU14/Blackfoot/BlackfootTowSystem.cs
+++ b/Content.Server/_CMU14/Blackfoot/BlackfootTowSystem.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Shared._CMU14.Blackfoot;
+using Content.Shared.Ghost;
 using Content.Shared.Interaction;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
@@ -30,6 +31,9 @@ public sealed partial class BlackfootTowSystem : EntitySystem
     private void OnActivate(Entity<BlackfootTowComponent> ent, ref ActivateInWorldEvent args)
     {
         if (args.Handled)
+            return;
+
+        if (IsGhost(args.User))
             return;
 
         if (ent.Comp.CanTow)
@@ -67,7 +71,8 @@ public sealed partial class BlackfootTowSystem : EntitySystem
     {
         if (!args.CanInteract ||
             !args.CanAccess ||
-            args.Using != null)
+            args.Using != null ||
+            IsGhost(args.User))
         {
             return;
         }
@@ -111,6 +116,9 @@ public sealed partial class BlackfootTowSystem : EntitySystem
 
     private void ToggleTug(EntityUid tugUid, EntityUid user)
     {
+        if (IsGhost(user))
+            return;
+
         if (!TryComp(tugUid, out BlackfootTowComponent? tugTow))
             return;
 
@@ -319,6 +327,9 @@ public sealed partial class BlackfootTowSystem : EntitySystem
 
     private void Attach(Entity<BlackfootTowComponent> tug, Entity<BlackfootTowComponent> target, EntityUid user)
     {
+        if (IsGhost(user))
+            return;
+
         tug.Comp.TowedEntity = target.Owner;
         target.Comp.TowVehicle = tug.Owner;
         Dirty(tug);
@@ -335,6 +346,9 @@ public sealed partial class BlackfootTowSystem : EntitySystem
 
     private void Detach(Entity<BlackfootTowComponent> tug, EntityUid user)
     {
+        if (IsGhost(user))
+            return;
+
         var target = tug.Comp.TowedEntity;
         tug.Comp.TowedEntity = null;
         Dirty(tug);
@@ -400,5 +414,10 @@ public sealed partial class BlackfootTowSystem : EntitySystem
     private void Popup(EntityUid user, string message, PopupType type = PopupType.Small)
     {
         _popup.PopupCursor(message, user, type);
+    }
+
+    private bool IsGhost(EntityUid user)
+    {
+        return HasComp<GhostComponent>(user);
     }
 }

--- a/Content.Server/_CMU14/Medical/StatusEffects/CMUPainFeedbackSystem.cs
+++ b/Content.Server/_CMU14/Medical/StatusEffects/CMUPainFeedbackSystem.cs
@@ -32,6 +32,7 @@ public sealed partial class CMUPainFeedbackSystem : EntitySystem
     [Dependency] private SharedDrunkSystem _drunk = default!;
 
     private static readonly ProtoId<StatusEffectPrototype> Stutter = "Stutter";
+    private const float SevereBlurMax = 0.49f;
 
     public override void Initialize()
     {
@@ -55,7 +56,7 @@ public sealed partial class CMUPainFeedbackSystem : EntitySystem
             if (mob.CurrentState == MobState.Dead || HasComp<SynthComponent>(uid))
                 continue;
 
-            if (pain.Tier < PainTier.Moderate)
+            if (pain.Tier < PainTier.Severe)
             {
                 feedback.NextEffect = TimeSpan.Zero;
                 continue;
@@ -72,41 +73,41 @@ public sealed partial class CMUPainFeedbackSystem : EntitySystem
     private void ApplyFeedback(EntityUid uid, CMUPainFeedbackComponent feedback, PainShockComponent pain)
     {
         var tier = pain.Tier;
-        var shock = tier == PainTier.Shock;
+        if (tier < PainTier.Severe)
+            return;
 
         ApplyTemporaryBlur(
             uid,
             GetBlurDuration(feedback, tier),
             GetBlurAmount(feedback, pain));
 
-        if (tier < PainTier.Severe)
+        if (tier < PainTier.Shock)
             return;
 
         ApplyTimedStatus<StutteringAccentComponent>(
             uid,
             Stutter,
-            shock ? feedback.ShockStutterDuration : feedback.SevereStutterDuration);
+            feedback.ShockStutterDuration);
 
         ApplyDrunkenness(
             uid,
-            shock ? feedback.ShockDrunkPower : feedback.SevereDrunkPower,
-            shock);
+            feedback.ShockDrunkPower,
+            slur: true);
 
         ApplyAsphyxiation(
             uid,
-            shock ? feedback.ShockAsphyxiation : feedback.SevereAsphyxiation);
+            feedback.ShockAsphyxiation);
 
         TryPainEmote(
             uid,
-            shock ? feedback.ShockEmoteChance : feedback.SevereEmoteChance,
-            shock ? feedback.ShockEmotes : feedback.SevereEmotes);
+            feedback.ShockEmoteChance,
+            feedback.ShockEmotes);
     }
 
     private TimeSpan GetBlurDuration(CMUPainFeedbackComponent feedback, PainTier tier)
     {
         return tier switch
         {
-            PainTier.Moderate => feedback.SevereBlurDuration,
             PainTier.Severe => feedback.SevereBlurDuration,
             PainTier.Shock => feedback.ShockBlurDuration,
             _ => TimeSpan.Zero,
@@ -116,18 +117,17 @@ public sealed partial class CMUPainFeedbackSystem : EntitySystem
     private float GetBlurAmount(CMUPainFeedbackComponent feedback, PainShockComponent pain)
     {
         var value = pain.Pain.Float();
-        var moderate = PainTierThresholds.UpwardThresholds[(int) PainTier.Moderate - 1].Float();
         var severe = PainTierThresholds.UpwardThresholds[(int) PainTier.Severe - 1].Float();
         var shock = _pain.ShockThreshold.Float();
 
-        if (value < moderate)
+        if (value < severe)
             return 0f;
 
-        if (value < severe)
-            return Lerp(0.02f, feedback.SevereBlurStartAmount, InverseLerp(moderate, severe, value));
-
         if (value < shock)
-            return Lerp(feedback.SevereBlurStartAmount, feedback.ShockBlurStartAmount, InverseLerp(severe, shock, value));
+        {
+            var severeAmount = Math.Min(feedback.SevereBlurAmount, SevereBlurMax);
+            return Lerp(feedback.SevereBlurStartAmount, severeAmount, InverseLerp(severe, shock, value));
+        }
 
         var shockEnd = Math.Max(feedback.ShockBlurFullPain, shock);
         return Lerp(feedback.ShockBlurStartAmount, feedback.ShockBlurAmount, InverseLerp(shock, shockEnd, value));

--- a/Content.Server/_RMC14/Xenonids/JoinXeno/LarvaQueueSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/JoinXeno/LarvaQueueSystem.cs
@@ -1,7 +1,6 @@
 using Content.Server.GameTicking;
 using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Components;
-using Content.Server._RMC14.Xenonids.Construction;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Dialog;
 using Content.Shared._RMC14.Dropship;
@@ -381,8 +380,7 @@ public sealed partial class LarvaQueueSystem : EntitySystem
             return false;
         }
 
-        return xeno.Role != LesserDroneRole ||
-               HasComp<XenoHiveCoreRoleComponent>(uid);
+        return xeno.Role != LesserDroneRole;
     }
 
     private bool TryOfferEntityClaim(EntityUid uid, Entity<HiveComponent> hive, LarvaQueueState queue)

--- a/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
@@ -35,6 +35,8 @@ public sealed partial class XenoRoleSystem : EntitySystem
     [Dependency] private RoleSystem _role = default!;
     [Dependency] private IGameTiming _timing = default!;
 
+    private static readonly ProtoId<JobPrototype> LesserDroneRole = "CMXenoLesserDrone";
+
     private TimeSpan _disconnectedXenoGhostRoleTime;
 
     private TimeSpan _rankTwoTime;
@@ -247,6 +249,12 @@ public sealed partial class XenoRoleSystem : EntitySystem
 
     private void MarkAbandonedForQueue(EntityUid uid)
     {
+        if (TryComp(uid, out XenoComponent? xeno) &&
+            xeno.Role == LesserDroneRole)
+        {
+            return;
+        }
+
         EnsureComp<AbandonedXenoQueueableComponent>(uid);
     }
 }

--- a/Content.Shared/_CMU14/Medical/Examine/CMUMedicalExamineSystem.cs
+++ b/Content.Shared/_CMU14/Medical/Examine/CMUMedicalExamineSystem.cs
@@ -97,7 +97,7 @@ public sealed partial class CMUMedicalExamineSystem : EntitySystem
 
             if (includeFractures
                 && TryComp<FractureComponent>(partUid, out var fracture)
-                && fracture.Severity is FractureSeverity.Compound or FractureSeverity.Comminuted)
+                && fracture.Severity.IsAtLeast(FractureSeverity.Simple))
             {
                 var stabilized = HasComp<CMUSplintedComponent>(partUid) || HasComp<CMUCastComponent>(partUid);
                 sections.Add($"[color={FractureColor}]{DescribeVisibleFracture(fracture.Severity, stabilized)}[/color]");
@@ -440,6 +440,7 @@ public sealed partial class CMUMedicalExamineSystem : EntitySystem
         var prefix = stabilized ? "stabilized " : string.Empty;
         return severity switch
         {
+            FractureSeverity.Simple => $"a {prefix}simple fracture",
             FractureSeverity.Compound => $"a {prefix}compound fracture",
             FractureSeverity.Comminuted => $"a {prefix}shattered bone",
             _ => "a broken bone",

--- a/Content.Shared/_CMU14/Medical/Shrapnel/SharedCMUShrapnelSystem.cs
+++ b/Content.Shared/_CMU14/Medical/Shrapnel/SharedCMUShrapnelSystem.cs
@@ -7,12 +7,14 @@ using Content.Shared._CMU14.Medical.Wounds.Events;
 using Content.Shared.Body.Part;
 using Content.Shared.Body.Systems;
 using Content.Shared.Damage;
+using Content.Shared.Damage.Components;
 using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Popups;
 using Content.Shared.Explosion;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
@@ -62,6 +64,8 @@ public sealed partial class SharedCMUShrapnelSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<CMUHumanMedicalComponent, GetVerbsEvent<InteractionVerb>>(OnGetShrapnelVerbs);
+        SubscribeLocalEvent<DamageableComponent, GetVerbsEvent<AlternativeVerb>>(OnGetShrapnelAltVerbs);
+        SubscribeLocalEvent<CMUShrapnelExtractorComponent, UseInHandEvent>(OnExtractorUseInHand);
         SubscribeLocalEvent<CMUShrapnelExtractorComponent, CMUShrapnelExtractDoAfterEvent>(OnExtractorDoAfter);
         SubscribeLocalEvent<CMUHumanMedicalComponent, MoveEvent>(OnHumanMove);
         SubscribeLocalEvent<CMUHumanMedicalComponent, ComponentRemove>(OnHumanRemove);
@@ -180,7 +184,13 @@ public sealed partial class SharedCMUShrapnelSystem : EntitySystem
         {
             var damage = new DamageSpecifier();
             damage.DamageDict[tool.Comp.DamageType] = tool.Comp.DamageOnExtract;
-            _damageable.TryChangeDamage(body, damage, origin: tool.Owner);
+            _damageable.TryChangeDamage(
+                body,
+                damage,
+                interruptsDoAfters: false,
+                origin: tool.Owner,
+                tool: tool.Owner,
+                impact: DamageImpact.SnaggingContact);
         }
 
         if (tool.Comp.PainPenalty > 0f)
@@ -261,6 +271,42 @@ public sealed partial class SharedCMUShrapnelSystem : EntitySystem
         });
     }
 
+    private void OnGetShrapnelAltVerbs(Entity<DamageableComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!IsLayerEnabled() || !args.CanAccess || !args.CanInteract)
+            return;
+        if (!HasComp<CMUHumanMedicalComponent>(ent.Owner))
+            return;
+        if (args.Using is not { } tool || !TryComp<CMUShrapnelExtractorComponent>(tool, out var extractor))
+            return;
+
+        if (!TryFindExtractionPart(ent.Owner, out var part, args.User))
+            return;
+
+        var user = args.User;
+        var target = ent.Owner;
+        args.Verbs.Add(new AlternativeVerb
+        {
+            Act = () => StartExtraction(user, target, tool, part),
+            Text = Loc.GetString("cmu-medical-shrapnel-extract-verb"),
+            Icon = extractor.VerbIcon,
+            Priority = 10,
+        });
+    }
+
+    private void OnExtractorUseInHand(Entity<CMUShrapnelExtractorComponent> ent, ref UseInHandEvent args)
+    {
+        if (args.Handled || !IsLayerEnabled())
+            return;
+        if (!HasComp<CMUHumanMedicalComponent>(args.User))
+            return;
+        if (!TryFindExtractionPart(args.User, out var part, args.User))
+            return;
+
+        args.Handled = true;
+        StartExtraction(args.User, args.User, ent.Owner, part);
+    }
+
     private void StartExtraction(EntityUid user, EntityUid target, EntityUid tool, EntityUid selectedPart)
     {
         if (!IsLayerEnabled() || !HasComp<CMUHumanMedicalComponent>(target))
@@ -290,13 +336,17 @@ public sealed partial class SharedCMUShrapnelSystem : EntitySystem
 
     private void OnExtractorDoAfter(Entity<CMUShrapnelExtractorComponent> ent, ref CMUShrapnelExtractDoAfterEvent args)
     {
+        var preSelectedPart = args.PreSelectedPart;
+        args.Repeat = false;
+        args.PreSelectedPart = null;
+
         if (args.Cancelled || args.Target is not { } target)
             return;
         if (!HasComp<CMUHumanMedicalComponent>(target))
             return;
 
         EntityUid? preferred = null;
-        if (args.PreSelectedPart is { } netPart && TryGetEntity(netPart, out var part))
+        if (preSelectedPart is { } netPart && TryGetEntity(netPart, out var part))
             preferred = part.Value;
 
         if (TryExtractShrapnel(target, ent, out var removed, args.User, preferred))
@@ -306,6 +356,12 @@ public sealed partial class SharedCMUShrapnelSystem : EntitySystem
                 target,
                 args.User);
             _audio.PlayPredicted(ent.Comp.ExtractSound, target, args.User);
+
+            if (TryFindExtractionPart(target, out var nextPart, args.User))
+            {
+                args.PreSelectedPart = GetNetEntity(nextPart);
+                args.Repeat = true;
+            }
         }
     }
 

--- a/Content.Shared/_CMU14/Medical/StatusEffects/CMUPainFeedbackComponent.cs
+++ b/Content.Shared/_CMU14/Medical/StatusEffects/CMUPainFeedbackComponent.cs
@@ -25,6 +25,9 @@ public sealed partial class CMUPainFeedbackComponent : Component
     public float SevereBlurStartAmount = 0.1f;
 
     [DataField]
+    public float SevereBlurAmount = 0.45f;
+
+    [DataField]
     public float ShockBlurStartAmount = 2.25f;
 
     [DataField]

--- a/Content.Shared/_CMU14/Medical/Trauma/CMUTraumaContact.cs
+++ b/Content.Shared/_CMU14/Medical/Trauma/CMUTraumaContact.cs
@@ -195,6 +195,9 @@ public static class CMUTraumaContactModel
         FixedPoint2 bruteDamage,
         CMUTraumaContactSettings settings)
     {
+        if (impact.IsSpecified && impact.Contact is DamageImpactContact.Burn or DamageImpactContact.Snag)
+            return false;
+
         if (impact is { Delivery: DamageImpactDelivery.Explosion } ||
             impact is { Energy: DamageImpactEnergy.Severe })
         {

--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -357,7 +357,7 @@ public sealed partial class CMArmorSystem : EntitySystem
             }
         }
 
-        if (args.Origin is { } origin)
+        if (args.Origin is { } origin && Exists(origin))
         {
             var originCoords = _transform.GetMapCoordinates(origin);
             var armorCoords = _transform.GetMapCoordinates(ent);

--- a/Content.Tests/Client/Eye/Blinding/BlurryVisionOverlayTest.cs
+++ b/Content.Tests/Client/Eye/Blinding/BlurryVisionOverlayTest.cs
@@ -1,0 +1,64 @@
+using System.Reflection;
+using Content.Client.Eye.Blinding;
+using Content.Client.Viewport;
+using NUnit.Framework;
+using GraphicsEye = Robust.Shared.Graphics.Eye;
+
+namespace Content.Tests.Client.EyeBlinding;
+
+[TestFixture]
+public sealed class BlurryVisionOverlayTest
+{
+    [Test]
+    public void PlayerEyeDrawsPlayerBlur()
+    {
+        var playerEye = new GraphicsEye();
+
+        Assert.That(ShouldDrawForViewportEye(playerEye, playerEye), Is.True);
+    }
+
+    [Test]
+    public void UnrelatedEyeDoesNotDrawPlayerBlur()
+    {
+        var playerEye = new GraphicsEye();
+        var otherEye = new GraphicsEye();
+
+        Assert.That(ShouldDrawForViewportEye(otherEye, playerEye), Is.False);
+    }
+
+    [Test]
+    public void CurrentZLevelEyeDrawsPlayerBlur()
+    {
+        var playerEye = new GraphicsEye();
+        var zEye = new ScalingViewport.ZEye
+        {
+            Depth = 0,
+            BlurCurrentLevel = true,
+        };
+
+        Assert.That(ShouldDrawForViewportEye(zEye, playerEye), Is.True);
+    }
+
+    [Test]
+    public void LookedUpZLevelEyeDoesNotDrawPlayerBlurAgain()
+    {
+        var playerEye = new GraphicsEye();
+        var zEye = new ScalingViewport.ZEye
+        {
+            Depth = 1,
+            BlurCurrentLevel = false,
+        };
+
+        Assert.That(ShouldDrawForViewportEye(zEye, playerEye), Is.False);
+    }
+
+    private static bool ShouldDrawForViewportEye(object viewportEye, GraphicsEye playerEye)
+    {
+        var method = typeof(BlurryVisionOverlay).GetMethod(
+            "ShouldDrawForViewportEye",
+            BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.That(method, Is.Not.Null);
+
+        return (bool) method!.Invoke(null, new object[] { viewportEye, playerEye })!;
+    }
+}

--- a/Resources/Prototypes/_CMU14/Vehicles/Blackfoot/support.yml
+++ b/Resources/Prototypes/_CMU14/Vehicles/Blackfoot/support.yml
@@ -37,6 +37,9 @@
   components:
   - type: Transform
     anchored: false
+  - type: Physics
+    bodyType: Static
+    canCollide: false
   - type: Sprite
     sprite: _CMU14/Structures/Vehicles/Blackfoot/blackfoot_structures.rsi
     state: fuel-pump


### PR DESCRIPTION
:cl:
add: Simple fractures show on examine.
fix: Hairline fractures stay hidden on examine.
fix: Ghosted Lesser Drones are not added to larva queue.
fix: Ghosted Lesser Drones are not offered by larva queue.
tweak: Pain shock blur starts minimally at severe pain.
tweak: Pain shock blur is stronger at shock.
fix: Looking up no longer stops pain shock visuals.
add: Z starts shrapnel removal when you have shrapnel.
add: Alt-click with knife starts shrapnel removal.
tweak: Shrapnel removal continues until all shrapnel is gone.
fix: Shrapnel removal damage cannot break bones or cause internal bleeding.