### PR TITLE
CLF spawn blacklist

### DIFF
--- a/Resources/Prototypes/_AU14/thirdParties/CLF/Survs/CLFSurvThirdParty.yml
+++ b/Resources/Prototypes/_AU14/thirdParties/CLF/Survs/CLFSurvThirdParty.yml
@@ -10,6 +10,10 @@
 - type: auThirdParty
   id: CLFSurvsBig
   partyspawn: CLFSurvsSpawnBig
+  blacklistedgamemodes:
+    - insurgency
+    - forceonforce
+    - colonyfall
   entrymethod: ground
   weight: 25
   minplayers: 101
@@ -29,6 +33,10 @@
 - type: auThirdParty
   id: CLFSurvsMedium
   partyspawn: CLFSurvsSpawnBig
+  blacklistedgamemodes:
+    - insurgency
+    - forceonforce
+    - colonyfall
   entrymethod: ground
   weight: 25
   minplayers: 51
@@ -48,6 +56,10 @@
 - type: auThirdParty
   id: CLFSurvsSmall
   partyspawn: CLFSurvsSpawnBig
+  blacklistedgamemodes:
+    - insurgency
+    - forceonforce
+    - colonyfall
   entrymethod: ground
   weight: 25
   minplayers: 20


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
CLF spawn blacklist was forgotten by me
they can now only spawn on distress

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: CLF Survs can now actually only spawn on distress signal
