### PR TITLE
✨ use fluent localization for xeno despoiler

### DIFF
--- a/Resources/Locale/en-US/_RMC14/xeno/despoiler.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/despoiler.ftl
@@ -3,17 +3,17 @@ rmc-xeno-despoiler-description = A massive, hunched xenomorph with hyper-pressur
 
 rmc-job-name-xeno-despoiler = Despoiler
 
-rmc-action-despoiler-acid-barrage-name = Acid Barrage
-rmc-action-despoiler-acid-barrage-desc = Activate to arm — the icon lights up green. Hold LMB to charge the volley: the longer you hold, the more projectiles. Release LMB to fire at the cursor.
+ent-RMCActionXenoDespoilerAcidBarrage = Acid Barrage
+    .desc = Activate to arm — the icon lights up green. Hold LMB to charge the volley: the longer you hold, the more projectiles. Release LMB to fire at the cursor.
 
-rmc-action-despoiler-caustic-embrace-name = Caustic Embrace
-rmc-action-despoiler-caustic-embrace-desc = Leap toward the click with an acid splash. Empowered lets you strike a chosen target up to 5 tiles away and applies an acid DoT.
+ent-RMCActionXenoDespoilerCausticEmbrace = Caustic Embrace
+    .desc = Leap toward the click with an acid splash. Empowered lets you strike a chosen target up to 5 tiles away and applies an acid DoT.
 
-rmc-action-despoiler-oozing-wounds-name = Oozing Wounds
-rmc-action-despoiler-oozing-wounds-desc = Creates a ring of acid spray around you. The radius grows as your HP drops. The empowered version stuns and applies acid.
+ent-RMCActionXenoDespoilerOozingWounds = Oozing Wounds
+    .desc = Creates a ring of acid spray around you. The radius grows as your HP drops. The empowered version stuns and applies acid.
 
-rmc-action-despoiler-catalyze-name = Catalyze
-rmc-action-despoiler-catalyze-desc = Spends 1 Hypertension stack and empowers your next active ability.
+ent-RMCActionXenoDespoilerCatalyze = Catalyze
+    .desc = Spends 1 Hypertension stack and empowers your next active ability.
 
 rmc-despoiler-no-hypertension = Not enough Hypertension stacks.
 rmc-despoiler-catalyze-active = The next ability is empowered!

--- a/Resources/Locale/ru-RU/_RMC14/xeno/despoiler.ftl
+++ b/Resources/Locale/ru-RU/_RMC14/xeno/despoiler.ftl
@@ -3,17 +3,17 @@ rmc-xeno-despoiler-description = Огромный, сгорбленный ксе
 
 rmc-job-name-xeno-despoiler = Дисбойлер
 
-rmc-action-despoiler-acid-barrage-name = Кислотный шквал
-rmc-action-despoiler-acid-barrage-desc = Активируй способность — она подсветится. Зажми ЛКМ для зарядки залпа: чем дольше держишь, тем больше снарядов. Отпусти ЛКМ — залп уйдёт в направлении курсора.
+ent-RMCActionXenoDespoilerAcidBarrage = Кислотный шквал
+    .desc = Активируй способность — она подсветится. Зажми ЛКМ для зарядки залпа: чем дольше держишь, тем больше снарядов. Отпусти ЛКМ — залп уйдёт в направлении курсора.
 
-rmc-action-despoiler-caustic-embrace-name = Едкое объятие
-rmc-action-despoiler-caustic-embrace-desc = Прыжок в направлении клика с кислотным выплеском. Эмпауэр позволяет атаковать выбранную цель на дистанции до 5 клеток и накладывает кислотный DoT.
+ent-RMCActionXenoDespoilerCausticEmbrace = Едкое объятие
+    .desc = Прыжок в направлении клика с кислотным выплеском. Эмпауэр позволяет атаковать выбранную цель на дистанции до 5 клеток и накладывает кислотный DoT.
 
-rmc-action-despoiler-oozing-wounds-name = Сочащиеся раны
-rmc-action-despoiler-oozing-wounds-desc = Создаёт кольцо кислотного спрея вокруг себя. Радиус растёт по мере падения собственного HP. Усиленный вариант оглушает и накладывает кислоту.
+ent-RMCActionXenoDespoilerOozingWounds = Сочащиеся раны
+    .desc = Создаёт кольцо кислотного спрея вокруг себя. Радиус растёт по мере падения собственного HP. Усиленный вариант оглушает и накладывает кислоту.
 
-rmc-action-despoiler-catalyze-name = Катализ
-rmc-action-despoiler-catalyze-desc = Расходует 1 стэк Гипертензии и усиливает следующую активную способность.
+ent-RMCActionXenoDespoilerCatalyze = Катализ
+    .desc = Расходует 1 стэк Гипертензии и усиливает следующую активную способность.
 
 rmc-despoiler-no-hypertension = Недостаточно стэков Гипертензии.
 rmc-despoiler-catalyze-active = Следующая способность усилена!

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/despoiler_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/despoiler_actions.yml
@@ -1,8 +1,6 @@
 - type: entity
   parent: ActionXenoBase
   id: RMCActionXenoDespoilerAcidBarrage
-  name: rmc-action-despoiler-acid-barrage-name
-  description: rmc-action-despoiler-acid-barrage-desc
   components:
   - type: Action
     itemIconStyle: NoItem
@@ -37,8 +35,6 @@
 - type: entity
   parent: ActionXenoBase
   id: RMCActionXenoDespoilerCausticEmbrace
-  name: rmc-action-despoiler-caustic-embrace-name
-  description: rmc-action-despoiler-caustic-embrace-desc
   components:
   - type: Action
     itemIconStyle: NoItem
@@ -73,8 +69,6 @@
 - type: entity
   parent: ActionXenoBase
   id: RMCActionXenoDespoilerOozingWounds
-  name: rmc-action-despoiler-oozing-wounds-name
-  description: rmc-action-despoiler-oozing-wounds-desc
   components:
   - type: Action
     itemIconStyle: NoItem
@@ -103,8 +97,6 @@
 - type: entity
   parent: ActionXenoBase
   id: RMCActionXenoDespoilerCatalyze
-  name: rmc-action-despoiler-catalyze-name
-  description: rmc-action-despoiler-catalyze-desc
   components:
   - type: Action
     itemIconStyle: NoItem


### PR DESCRIPTION
## About the PR
- Fixes the localization for TestNoManualEntityLocStrings
- The Russian locale folder shows how to use Fluent for better/easier translations

## Technical details
- Read more here on how it's done:
- https://docs.spacestation14.com/en/ss14-by-example/fluent-and-localization.html#localizing-prototypes

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
**Changelog**
:cl:
- code: Fluent localization example for Xeno Despoiler (use ent- and .desc)
