### PR TITLE
🩹 remove the map ID from fighter grid to stop ServerReloginTest from failing

### DIFF
--- a/Resources/Maps/_AU14/ShuttlesDropships/f84owl.yml
+++ b/Resources/Maps/_AU14/ShuttlesDropships/f84owl.yml
@@ -6,8 +6,6 @@ meta:
   forkVersion: ""
   time: 07/30/2025 02:23:01
   entityCount: 31
-maps:
-- 1
 grids:
 - 1
 orphans:


### PR DESCRIPTION
## About the PR
- Building ontop of this PR, the file was marked as a grid but had a map in it.
- Causes the Relogin test to fail - crashing the deserializer
- https://github.com/AU-14/ColonialMarinesUniverse/pull/1255

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
