### PR TITLE
Temporarily remove Fiorina from DS map pool

### DIFF
--- a/Resources/Prototypes/_AU14/gamemode/gamemodes.yml
+++ b/Resources/Prototypes/_AU14/gamemode/gamemodes.yml
@@ -62,7 +62,7 @@
   - AUPlanetSorokyne
   - AUPlanetCorsatStation
   - AUPlanetTrijent
-  - AuPlanetFiorina
+#  - AuPlanetFiorina
   - AuPlanetKutjevo
   - AuPlanetShivasSnowball
   - AUPlanetLV327


### PR DESCRIPTION
Broken and hasn't been fixed, it also spawns the Almayer alongside it for some reason. 
This is temporary and will be re-added whenever someone gets around to fixing it.