### PR TITLE
Minor Bug fixes

### DIFF
--- a/Content.Shared/_RMC14/Medical/CPR/CPRDummyComponent.cs
+++ b/Content.Shared/_RMC14/Medical/CPR/CPRDummyComponent.cs
@@ -19,6 +19,8 @@ public sealed partial class CPRDummyComponent : Component
     {
         "CMSeniorEnlistedAdvisor",
         "CMCMO",
+        "AU14JobadvisorBase",
+        // TODO: AU14 CMO
     };
 }
 

--- a/Content.Shared/_RMC14/Medical/CPR/CPRSystem.cs
+++ b/Content.Shared/_RMC14/Medical/CPR/CPRSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.Mind;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
+using Content.Shared.Roles;
 using Content.Shared.Roles.Jobs;
 using Content.Shared.Verbs;
 using Robust.Shared.Network;
@@ -376,17 +377,25 @@ public sealed partial class CPRSystem : EntitySystem
 
     private void TryResetDummyCounter(Entity<CPRDummyComponent> ent, EntityUid user)
     {
+        bool hasAccess = false;
         _mind.TryGetMind(user, out var mindId, out _);
-        if (!_job.MindTryGetJobId(mindId, out var jobId) || !ent.Comp.ResetCPRCounterJobs.Contains(jobId!.Value))
+        if (_job.MindTryGetJobId(mindId, out var jobId))
         {
-            if (_net.IsClient)
-                return;
+            hasAccess = ent.Comp.ResetCPRCounterJobs.Contains(jobId!.Value);
+            if (!hasAccess
+                && _prototypes.TryIndex(jobId.Value, out JobPrototype? jobProto)
+                && jobProto != null)
+            {
+                var firstParent = jobProto.Parents?.FirstOrDefault();
+                if (firstParent != null)
+                    hasAccess = ent.Comp.ResetCPRCounterJobs.Contains(firstParent);
+            }
+        }
 
-            var jobNames = ent.Comp.ResetCPRCounterJobs
-                .Select(job => _prototypes.Index(job).LocalizedName)
-                .ToList();
-            var jobsString = string.Join("; ", jobNames);
-            _popups.PopupEntity(Loc.GetString("rmc-cpr-dummy-reset-denied", ("jobs", jobsString)), ent, user, PopupType.MediumCaution);
+        if (!hasAccess)
+        {
+            if (!_net.IsClient)
+                ShowResetDeniedPopup(ent, user);
             return;
         }
 
@@ -394,9 +403,14 @@ public sealed partial class CPRSystem : EntitySystem
         ent.Comp.CPRFailed = 0;
         Dirty(ent);
 
-        if (_net.IsClient)
-            return;
+        if (!_net.IsClient)
+            _popups.PopupEntity(Loc.GetString("rmc-cpr-dummy-reset-success"), ent, user, PopupType.Medium);
+    }
 
-        _popups.PopupEntity(Loc.GetString("rmc-cpr-dummy-reset-success"), ent, user, PopupType.Medium);
+    private void ShowResetDeniedPopup(Entity<CPRDummyComponent> ent, EntityUid user)
+    {
+        var jobNames = ent.Comp.ResetCPRCounterJobs.Select(job => _prototypes.Index(job).LocalizedName).ToList();
+        var jobsString = string.Join("; ", jobNames);
+        _popups.PopupEntity(Loc.GetString("rmc-cpr-dummy-reset-denied", ("jobs", jobsString)), ent, user, PopupType.MediumCaution);
     }
 }

--- a/Content.Shared/_RMC14/RMCCalendar/RMCCalendarSystem.cs
+++ b/Content.Shared/_RMC14/RMCCalendar/RMCCalendarSystem.cs
@@ -21,7 +21,7 @@ public sealed partial class RMCCalendarSystem : EntitySystem
     private void OnExamined(Entity<RMCCalendarComponent> ent, ref ExaminedEvent args)
     {
         var owner = ent.Owner;
-        var worldDate = EntityQuery<GlobalTimeManagerComponent>().FirstOrDefault()?.DateOffset ?? DateTime.Today.AddYears(160);
+        var worldDate = EntityQuery<GlobalTimeManagerComponent>().FirstOrDefault()?.DateOffset ?? DateTime.Today.AddYears(215);
         var time = worldDate.ToString("dd MMMM, yyyy");
 
         var todayHolidays = _customHolidaySystem.GetCustomHolidays()

--- a/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
+++ b/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
@@ -587,29 +587,27 @@ public abstract partial class SharedCMAutomatedVendorSystem : EntitySystem
             {
                 // Get every AU14VendorJO
                 var joVendors = EntityQueryEnumerator<AU14VendorJOComponent>();
-                var allVendorsTotal = 0;
+                var totalSectionVends = 0;
 
                 // Goes through each AU14VendorJO and gets the value for this kit type.
-                while (joVendors.MoveNext(out _, out var joVendorComponent))
+                while (joVendors.MoveNext(out _, out var joVendor))
                 {
-                    foreach (var linkedEntry in args.LinkedEntries)
+                    for (int i = 0; i < section.Entries.Count; i++)
                     {
-                        joVendorComponent.GlobalSharedVends.TryGetValue(linkedEntry, out var linkedCount);
-                        allVendorsTotal += linkedCount;
+                        if (joVendor.GlobalSharedVends.TryGetValue(i, out var count))
+                            totalSectionVends += count;
                     }
-                    if (joVendorComponent.GlobalSharedVends.TryGetValue(args.Entry, out var vendCount))
-                        allVendorsTotal += vendCount;
                 }
 
-                if (allVendorsTotal >= joLimit)
+                if (totalSectionVends >= joLimit)
                 {
                     ResetChoices();
                     _popup.PopupEntity(Loc.GetString("au14-vending-machine-jo-max"), vendor.Owner, actor);
                     return;
                 }
 
-                var old = thisJOVendor.GlobalSharedVends.GetValueOrDefault(args.Entry, 0);
-                thisJOVendor.GlobalSharedVends[args.Entry] = old + 1;
+                var current = thisJOVendor.GlobalSharedVends.GetValueOrDefault(args.Entry);
+                thisJOVendor.GlobalSharedVends[args.Entry] = current + 1;
                 Dirty(vendor, thisJOVendor);
             }
         }

--- a/Resources/Prototypes/_AU14/Entities/IDCards/GOVFOR.yml
+++ b/Resources/Prototypes/_AU14/Entities/IDCards/GOVFOR.yml
@@ -125,22 +125,22 @@
 
 - type: entity
   parent: CMIDCardBase
-  id: AU14IDCardGOVFORAuxSupportSynth
-  name: support synthetic ID card
+  id: AU14JobIDCardGOVFORAuxTech
+  name: auxiliary technician ID card
   components:
   - type: PresetIdCard
-    job: AU14JobGOVFORAuxSupportSynth
+    job: AU14JobGOVFORAuxTech
   - type: ItemIFF
     factions:
     - GOVFOR
 
 - type: entity
   parent: CMIDCardBase
-  id: AU14JobIDCardGOVFORAuxTech
-  name: auxiliary technician ID card
+  id: AU14IDCardGOVFORAuxSupportSynth
+  name: support synthetic ID card
   components:
   - type: PresetIdCard
-    job: AU14JobGOVFORAuxTech
+    job: AU14JobGOVFORAuxSupportSynth
   - type: ItemIFF
     factions:
     - GOVFOR

--- a/Resources/Prototypes/_AU14/Entities/Vendors/cmbciuvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/cmbciuvendors.yml
@@ -52,13 +52,8 @@
         amount: 25
       - id: AU14HeadCommandoBeanie
         amount: 10
-    - name: Headsets
-      entries:
       - id: RMCM5CameraGear
         amount: 30
-      - id: AU14HeadsetGovforMarine
-        name: empty headset
-        amount: 20
     - name: Heads Up Display
       entries:
       - id: RMCVisorSquad
@@ -592,12 +587,6 @@
         amount: 5
       - id: RMCArmorM4RMarshallMedium
         amount: 5
-    - name: Headsets
-      entries:
-      - id: AU14HeadsetGovforCommand
-        amount: 2
-      - id: AU14HeadsetGovforAuxiliary
-        amount: 2
     - name: Backpack
       entries:
       - id: RMCBackpackRTO

--- a/Resources/Prototypes/_AU14/Entities/Vendors/generalvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/generalvendors.yml
@@ -265,7 +265,7 @@
         isAppendSquadRoleName: false
     - name: Specialized Officers
       choices: { CMUJOLoadoutVendorKit: 1 }
-      sharedJOLimit: 1
+      sharedJOLimit: 2
       entries:
       - id: AU14KitJOIntelligenceOfficer
         giveSquadRoleName: au14-job-name-juniorofficer-io

--- a/Resources/Prototypes/_AU14/Entities/Vendors/hazopsvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/hazopsvendors.yml
@@ -58,13 +58,8 @@
         amount: 25
       - id: AU14HeadCommandoBeanie
         amount: 10
-    - name: Headsets
-      entries:
       - id: RMCM5CameraGear
         amount: 30
-      - id: AU14HeadsetGovforMarine
-        name: empty headset
-        amount: 20
     - name: Heads Up Display
       entries:
       - id: RMCVisorSquad
@@ -363,12 +358,6 @@
       - id: AU14HAZOPShecuBeret
         amount: 4
       - id: AU14JunglePatrolCap
-        amount: 2
-    - name: Headsets
-      entries:
-      - id: AU14HeadsetGovforCommand
-        amount: 2
-      - id: AU14HeadsetGovforAuxiliary
         amount: 2
     - name: Backpack
       entries:

--- a/Resources/Prototypes/_AU14/Entities/Vendors/lacnvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/lacnvendors.yml
@@ -52,13 +52,8 @@
         amount: 20
       - id: AU14LACNCommandoBeanie
         amount: 10
-    - name: Headsets
-      entries:
       - id: RMCM5CameraGear
         amount: 30
-      - id: AU14HeadsetGovforMarine
-        name: empty headset
-        amount: 20
     - name: Heads Up Display
       entries:
       - id: RMCVisorSquad
@@ -638,12 +633,6 @@
         name: Black Beret
       - id: AU14LACNNavyCap
         amount: 5
-    - name: Headsets
-      entries:
-      - id: AU14HeadsetGovforCommand
-        amount: 2
-      - id: AU14HeadsetGovforAuxiliary
-        amount: 2
     - name: Backpack
       entries:
       - id: RMCBackpackRTO

--- a/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
@@ -79,13 +79,8 @@
         amount: 15
       - id: AU14HeadCommandoBeanie
         amount: 10
-    - name: Headsets
-      entries:
       - id: RMCM5CameraGear
         amount: 30
-      - id: AU14HeadsetGovforMarine
-        name: empty headset
-        amount: 20
     - name: Heads Up Display
       entries:
       - id: RMCVisorSquad
@@ -633,12 +628,6 @@
         amount: 5
       - id: AU14DesertPatrolCap
         amount: 5
-    - name: Headsets
-      entries:
-      - id: AU14HeadsetGovforCommand
-        amount: 2
-      - id: AU14HeadsetGovforAuxiliary
-        amount: 2
     - name: Backpack
       entries:
       - id: RMCBackpackRTO

--- a/Resources/Prototypes/_AU14/Entities/Vendors/prodigyvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/prodigyvendors.yml
@@ -50,13 +50,8 @@
         amount: 20
       - id: AU14HeadCommandoBeanie
         amount: 10
-    - name: Headsets
-      entries:
       - id: RMCM5CameraGear
         amount: 30
-      - id: AU14HeadsetGovforMarine
-        name: empty headset
-        amount: 20
     - name: Heads Up Display
       entries:
       - id: RMCVisorSquad
@@ -608,12 +603,6 @@
       entries:
       - id: AU14ProdigyBeret
         amount: 5
-    - name: Headsets
-      entries:
-      - id: AU14HeadsetGovforCommand
-        amount: 2
-      - id: AU14HeadsetGovforAuxiliary
-        amount: 2
     - name: Backpack
       entries:
       - id: RMCBackpackRTO

--- a/Resources/Prototypes/_AU14/Entities/Vendors/rmcvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/rmcvendors.yml
@@ -71,13 +71,8 @@
         amount: 15
       - id: AU14DesertFlapCap
         amount: 15
-    - name: Headsets
-      entries:
       - id: RMCM5CameraGear
         amount: 30
-      - id: AU14HeadsetGovforMarine
-        name: empty headset
-        amount: 20
     - name: Heads Up Display
       entries:
       - id: AU14VisorSquadRMC
@@ -752,12 +747,6 @@
         amount: 5
       - id: AU14DesertPatrolCap
         amount: 5
-    - name: Headsets
-      entries:
-      - id: AU14HeadsetGovforCommand
-        amount: 2
-      - id: AU14HeadsetGovforAuxiliary
-        amount: 2
     - name: Backpack
       entries:
       - id: RMCBackpackRTO

--- a/Resources/Prototypes/_AU14/Entities/Vendors/uppvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/uppvendors.yml
@@ -58,13 +58,8 @@
         amount: 15
       - id: AU14UPPUshanka
         amount: 40
-    - name: Headsets
-      entries:
       - id: RMCM5CameraGear
         amount: 30
-      - id: AU14HeadsetGovforMarine
-        name: empty headset
-        amount: 20
     - name: Heads Up Display
       entries:
       - id: RMCVisorSquad
@@ -708,12 +703,6 @@
         amount: 5
       - id: CMHeadCapSPPUshankaCivilian
         amount: 10
-    - name: Headsets
-      entries:
-      - id: AU14HeadsetGovforCommand
-        amount: 2
-      - id: AU14HeadsetGovforAuxiliary
-        amount: 2
     - name: Backpack
       entries:
       - id: RMCBackpackRTOSPP

--- a/Resources/Prototypes/_AU14/Entities/Vendors/vaipovendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/vaipovendors.yml
@@ -82,13 +82,8 @@
         amount: 20
       - id: AU14HeadCommandoBeanie
         amount: 10
-    - name: Headsets
-      entries:
       - id: RMCM5CameraGear
         amount: 30
-      - id: AU14HeadsetGovforMarine
-        name: empty headset
-        amount: 20
     - name: Heads Up Display
       entries:
       - id: RMCVisorSquad
@@ -659,12 +654,6 @@
     sprite: _AU14/Structures/Vendors/uscmcommandclothes.rsi
   - type: CMAutomatedVendor
     sections:
-    - name: Headsets
-      entries:
-      - id: AU14HeadsetGovforCommand
-        amount: 2
-      - id: AU14HeadsetGovforAuxiliary
-        amount: 2
     - name: Backpack
       entries:
       - id: RMCBackpackRTO

--- a/Resources/Prototypes/_AU14/Entities/Vendors/wypmcvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/wypmcvendors.yml
@@ -54,13 +54,8 @@
         amount: 20
       - id: AU14HeadCommandoBeanie
         amount: 10
-    - name: Headsets
-      entries:
       - id: RMCM5CameraGear
         amount: 30
-      - id: AU14HeadsetGovforMarine
-        name: empty headset
-        amount: 20
     - name: Heads Up Display
       entries:
       - id: RMCVisorSquad
@@ -627,12 +622,6 @@
       entries:
       - id: CMArmorM4PMCLeader
         amount: 5
-    - name: Headsets
-      entries:
-      - id: AU14HeadsetGovforCommand
-        amount: 2
-      - id: AU14HeadsetGovforAuxiliary
-        amount: 2
     - name: Backpack
       entries:
       - id: RMCBackpackRTOPMC

--- a/Resources/Prototypes/_AU14/Maps/planets.yml
+++ b/Resources/Prototypes/_AU14/Maps/planets.yml
@@ -952,7 +952,6 @@
   id: AU14PrimerPlanetChances
   planetText: "Date 2181 -  Chances Claim - Weyland Administrated Frontier Colony entangled with organized crime"
 
-
 - type: lorePrimer
   id: AU14PrimerPlanetLV747
   planetText: "Date 2181 - Solaris Gulch, UA controlled."

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/auxiliarysupportsynthBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/auxiliarysupportsynthBase.yml
@@ -93,7 +93,6 @@
 - type: startingGear
   id: AU14GearGOVFORAuxSupportSynth
   equipment:
-    id: AU14IDCardGOVFORAuxSupportSynth
     ears: AU14HeadsetGovforCommand
     ears2: RMCM5CameraGear
 

--- a/Resources/Prototypes/_AU14/Roles/SkillPresets/platoon.yml
+++ b/Resources/Prototypes/_AU14/Roles/SkillPresets/platoon.yml
@@ -21,14 +21,15 @@
   components:
   - type: SkillPreset
     skills:
-      RMCSkillConstruction: 1
+      RMCSkillLeadership: 1
+      RMCSkillJtac: 4
+      RMCSkillFirearms: 1
       RMCSkillCqc: 1
       RMCSkillEndurance: 1
+      RMCSkillConstruction: 2
       RMCSkillEngineer: 1
-      RMCSkillFirearms: 1
       RMCSkillFireman: 2
       RMCSkillVehicles: 1
-      RMCSkillJtac: 4
 
 - type: entity
   id: AU14SkillPresetPlatoonAutomaticRifleman

--- a/Resources/Prototypes/_AU14/Threats/abominationsThreat/abominationBase.yml
+++ b/Resources/Prototypes/_AU14/Threats/abominationsThreat/abominationBase.yml
@@ -90,6 +90,7 @@
     proto: alien
   - type: MobCollision
   - type: RMCMobCollision
+  - type: MotionDetectorTracked
   - type: StatusEffects
     allowed:
     - Stun

--- a/Resources/Prototypes/_CMU14/Recipes/Reactions/other.yml
+++ b/Resources/Prototypes/_CMU14/Recipes/Reactions/other.yml
@@ -12,3 +12,19 @@
       amount: 16
   products:
     CMUBlackSludge: 64
+
+- type: reaction
+  id: AU14SpaceCleaner
+  requiredMixerCategories:
+  - Stir
+  reactants:
+    Water:
+      amount: 2
+    Vodka:
+      amount: 1
+    LemonLime:
+      amount: 1
+    TableSalt:
+      amount: 1
+  products:
+    SpaceCleaner: 4


### PR DESCRIPTION
- **📋 headsets removed from mil-vendors (opfor received govfor headsets)**
- **🪲 mil-synth spawn with 2 IDs fix**
- **📋 +1 leadership & +1 construction for RTO/FTL**
- **🩹 move the clock forward to the year 2181**
- **✨ DIY space-cleaner - 2 water - 1 vodka - 1 lemonline - 1tsp salt - stir**
- **🪲 CPR dummy can be reset by SEA (uses 1-time inheritance for all SEA variants)**
- **🪲 motion detector tracking for abominations**
- **🔧 JO limit per section - fixes clientside link bug**
- **✨ fixes chevrons - jobIcons are now hidden without it - surprise for IO mains**
- **🪲 fixes loadout inheritance**

## About the PR

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

:cl:
- add: job icons require chevron to be worn, without chevron, no icon and a surprise for IO mains
- fix: loadouts for military jobs have been fixed - now able to look up one immediate parent
- fix: JO vendors sharing limits between sections & bumped IO+EO to 2 per round (e.g. 2 IOs, 0 EO)
- fix: aboms were not detected by the motion tracker
- add: DIY spacecleaner: 2 parts water, 1 part vodka, lemon-lime and a tsp. of salt, then stir it
- remove: govfor headsets removed from govfor/opfor vendors