### PR TITLE
rollback colony WJ playtime req

### DIFF
--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyworkingjoe.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyworkingjoe.yml
@@ -1,6 +1,7 @@
 - type: job
   parent: AU14JobWorkingJoeBase
   id: AU14JobColonyWorkingJoe
+  requirements:
   - !type:TraitsRequirement
     inverted: true
     traits:

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyworkingjoe.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyworkingjoe.yml
@@ -1,13 +1,6 @@
 - type: job
   parent: AU14JobWorkingJoeBase
   id: AU14JobColonyWorkingJoe
-  requirements:
-  - !type:RoleTimeRequirement
-    role: AU14JobCivilianEngineer
-    time: 3600 # 1 hour
-  - !type:RoleTimeRequirement
-    role: AU14JobCivilianWasteManagementSpecialist
-    time: 3600 # 1 hour
   - !type:TraitsRequirement
     inverted: true
     traits:


### PR DESCRIPTION
## About the PR
made at the request of multiple community members (https://discord.com/channels/1412210184121614447/1514081124719136818)
(https://discord.com/channels/1412210184121614447/1513745100402856066)
:cl:
- remove: Colony Working Joes no longer require engineer or janitor playtime.