### PR TITLE
Remove role time requirements from military joes

### DIFF
--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonworkingjoe.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonworkingjoe.yml
@@ -17,12 +17,6 @@
   parent: AU14JobGOVFORWorkingJoeBase
   id: AU14JobGOVFORWorkingJoe
   requirements:
-  - !type:RoleTimeRequirement
-    role: AU14JobGOVFORSquadCombatTech
-    time: 3600 # 1 hour
-  - !type:RoleTimeRequirement
-    role: AU14JobCivilianWasteManagementSpecialist
-    time: 3600 # 1 hour
   - !type:TraitsRequirement
     inverted: true
     traits:


### PR DESCRIPTION
## About the PR
made at the request of multiple community members (https://discord.com/channels/1412210184121614447/1514081124719136818)
(https://discord.com/channels/1412210184121614447/1513745100402856066)
note: opfor joes have unchanged role requirements
:cl:

- remove: GOVFOR Working Joes no longer have CT and janitor playtime requirements.