### PR TITLE
APC Vanish Bugfix

### DIFF
--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -324,10 +324,11 @@ namespace Content.Client.Construction
                         state.StateId.Name is null)
                         continue;
 
-                    _sprite.AddBlankLayer((ghost.Value, sprite), i);
-                    _sprite.LayerSetSprite((ghost.Value, sprite), i, new SpriteSpecifier.Rsi(rsi.Path, state.StateId.Name));
-                    sprite.LayerSetShader(i, "unshaded");
-                    _sprite.LayerSetVisible((ghost.Value, sprite), i, true);
+                    var ghostLayerIndex = sprite.AllLayers.Count();
+                    _sprite.AddBlankLayer((ghost.Value, sprite));
+                    _sprite.LayerSetSprite((ghost.Value, sprite), ghostLayerIndex, new SpriteSpecifier.Rsi(rsi.Path, state.StateId.Name));
+                    sprite.LayerSetShader(ghostLayerIndex, "unshaded");
+                    _sprite.LayerSetVisible((ghost.Value, sprite), ghostLayerIndex, true);
                 }
 
                 Del(dummy);

--- a/Content.IntegrationTests/_RMC14/WallApcConstructionTest.cs
+++ b/Content.IntegrationTests/_RMC14/WallApcConstructionTest.cs
@@ -1,0 +1,66 @@
+using Content.Server.Construction;
+using Content.Server.Construction.Components;
+using Content.Shared._RMC14.Power;
+using NUnit.Framework;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests._RMC14;
+
+[TestFixture]
+public sealed class WallApcConstructionTest
+{
+    [Test]
+    public async Task ConstructedWallApcKeepsConstructionGraphState()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        var changed = false;
+
+        await server.WaitPost(() =>
+        {
+            var entMan = server.EntMan;
+            var frame = entMan.SpawnEntity("CMApcFrame", map.GridCoords);
+            var frameConstruction = entMan.GetComponent<ConstructionComponent>(frame);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(frameConstruction.Graph, Is.EqualTo("CMApc"));
+                Assert.That(frameConstruction.Node, Is.EqualTo("apcFrame"));
+            });
+
+            changed = entMan.System<ConstructionSystem>().ChangeNode(frame, null, "apc");
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var constructedCount = 0;
+            var query = entMan.EntityQueryEnumerator<RMCApcComponent, MetaDataComponent, ConstructionComponent>();
+
+            while (query.MoveNext(out var uid, out _, out var meta, out var construction))
+            {
+                if (meta.EntityPrototype?.ID != "CMApcConstructed")
+                    continue;
+
+                constructedCount++;
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(entMan.Deleted(uid), Is.False);
+                    Assert.That(construction.Graph, Is.EqualTo("CMApc"));
+                    Assert.That(construction.Node, Is.EqualTo("apc"));
+                });
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(changed, Is.True);
+                Assert.That(constructedCount, Is.EqualTo(1));
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Power/apc.yml
@@ -174,6 +174,10 @@
 - type: entity
   parent: CMApcBase
   id: CMApcConstructed
+  components:
+  - type: Construction
+    graph: CMApc
+    node: apc
 
 - type: entity
   parent: CMApcBase


### PR DESCRIPTION
## About the PR
Fixes wall APC construction.

Constructed RMC wall APCs now retain their construction graph state when the frame is completed, preventing the finished APC from disappearing. This also fixes a client crash when placing the APC from the construction menu caused by construction ghost previews copying sparse sprite layer indexes.

## Technical details
- Added `Construction` graph/node state to `CMApcConstructed`.
- Updated client construction ghost generation to append visible sprite layers sequentially instead of inserting them at their original target sprite indexes.
- Added an integration regression test that changes a `CMApcFrame` to the completed `apc` node and verifies a valid `CMApcConstructed` remains.

Tested:
- `dotnet build Content.Client/Content.Client.csproj`
- `dotnet build Content.IntegrationTests/Content.IntegrationTests.csproj`
- `WallApcConstructionTest`
- Construction integration suite, 31/31 passed
- `git diff --check`

## Media
https://github.com/user-attachments/assets/8c260cce-fdb6-4fbd-8d04-8222a34eba7c



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed constructed wall APCs disappearing when construction is completed.
- fix: Fixed a client crash when placing wall APCs from the construction menu.