### PR TITLE
Revert "Move air deployable sentry from fabricator to ASRS ($600)"

### DIFF
--- a/Resources/Prototypes/_AU14/Catalog/Cargo/cmbciu_requisitions_catalog.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Cargo/cmbciu_requisitions_catalog.yml
@@ -252,5 +252,3 @@
         crate: RMCDropshipAttachmentAmmoGAUAP
       - cost: 4500
         crate: RMCDropshipAttachmentAmmoLaserCannon
-      - cost: 600
-        crate: RMCDropshipAttachmentAmmoLaunchableSentry

--- a/Resources/Prototypes/_AU14/Catalog/Cargo/hazops_requisitions_catalog.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Cargo/hazops_requisitions_catalog.yml
@@ -252,5 +252,3 @@
         crate: RMCDropshipAttachmentAmmoGAUAP
       - cost: 4500
         crate: RMCDropshipAttachmentAmmoLaserCannon
-      - cost: 600
-        crate: RMCDropshipAttachmentAmmoLaunchableSentry

--- a/Resources/Prototypes/_AU14/Catalog/Cargo/lacn_requisitions_catalog.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Cargo/lacn_requisitions_catalog.yml
@@ -258,5 +258,3 @@
         crate: RMCDropshipAttachmentAmmoGAUAP
       - cost: 4500
         crate: RMCDropshipAttachmentAmmoLaserCannon
-      - cost: 600
-        crate: RMCDropshipAttachmentAmmoLaunchableSentry

--- a/Resources/Prototypes/_AU14/Catalog/Cargo/prodigy_requisitions_catalog.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Cargo/prodigy_requisitions_catalog.yml
@@ -248,5 +248,3 @@
         crate: RMCDropshipAttachmentAmmoGAUAP
       - cost: 2500
         crate: RMCDropshipAttachmentAmmoLaserCannon
-      - cost: 600
-        crate: RMCDropshipAttachmentAmmoLaunchableSentry

--- a/Resources/Prototypes/_AU14/Catalog/Cargo/rmc_requisitions_catalog.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Cargo/rmc_requisitions_catalog.yml
@@ -264,5 +264,3 @@
         crate: RMCDropshipAttachmentAmmoGAUAP
       - cost: 2500
         crate: RMCDropshipAttachmentAmmoLaserCannon
-      - cost: 600
-        crate: RMCDropshipAttachmentAmmoLaunchableSentry

--- a/Resources/Prototypes/_AU14/Catalog/Cargo/upp_requisitions_catalog.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Cargo/upp_requisitions_catalog.yml
@@ -258,5 +258,3 @@
         crate: RMCDropshipAttachmentAmmoGAUAP
       - cost: 2500
         crate: RMCDropshipAttachmentAmmoLaserCannon
-      - cost: 600
-        crate: RMCDropshipAttachmentAmmoLaunchableSentry

--- a/Resources/Prototypes/_AU14/Catalog/Cargo/uscm_requisitions_catalog.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Cargo/uscm_requisitions_catalog.yml
@@ -264,5 +264,3 @@
         crate: RMCDropshipAttachmentAmmoGAUAP
       - cost: 4500
         crate: RMCDropshipAttachmentAmmoLaserCannon
-      - cost: 600
-        crate: RMCDropshipAttachmentAmmoLaunchableSentry

--- a/Resources/Prototypes/_AU14/Catalog/Cargo/vaipo_requisitions_catalog.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Cargo/vaipo_requisitions_catalog.yml
@@ -254,5 +254,3 @@
         crate: RMCDropshipAttachmentAmmoGAUAP
       - cost: 4500
         crate: RMCDropshipAttachmentAmmoLaserCannon
-      - cost: 600
-        crate: RMCDropshipAttachmentAmmoLaunchableSentry

--- a/Resources/Prototypes/_AU14/Catalog/Cargo/weyu_requisitions_catalog.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Cargo/weyu_requisitions_catalog.yml
@@ -252,5 +252,3 @@
         crate: RMCDropshipAttachmentAmmoGAUAP
       - cost: 4500
         crate: RMCDropshipAttachmentAmmoLaserCannon
-      - cost: 600
-        crate: RMCDropshipAttachmentAmmoLaunchableSentry

--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
@@ -321,6 +321,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/dropship_ammo.rsi
     state: launchable_sentry
+  - type: DropshipFabricatorPrintable
+    cost: 200
   - type: PowerLoaderAttachable
     attachableTypes:
     - RMCDropshipUtilityPoint


### PR DESCRIPTION
Reverts AU-14/ColonialMarinesUniverse#1260

Why are we nerfing things that are already unused because of how bad they are. Please show me ONE CLIP of these turreys actually doing something meaingful and not just sitting there rotting because they werent setup. On HvX which is the MAIN PLACE these are used xenos can just, walk around it, or send a DRONE YES A DRONE to destroy it.

Changelog

🆑

tweak: Dropship sentries are NO LONGER in the govfor ASRS for $600 and have been returned to the dropship fabricator.