### PR TITLE
VAI IFF/Faction to Third Party & Ambassador

### DIFF
--- a/Content.Shared/_RMC14/Scoping/SharedScopeSystem.cs
+++ b/Content.Shared/_RMC14/Scoping/SharedScopeSystem.cs
@@ -330,7 +330,7 @@ public abstract partial class SharedScopeSystem : EntitySystem
 
     public virtual bool Unscope(Entity<ScopeComponent> scope)
     {
-        if (_net.IsClient)
+        if (_net.IsClient && scope.Comp.Attachment)
             return false;
 
         if (scope.Comp.User is not { } user)

--- a/Resources/Prototypes/_AU14/Entities/Clothing/Headset/colonyheadsets.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Headset/colonyheadsets.yml
@@ -157,7 +157,7 @@
   - type: RMCHeadset
     channels:
     - UASOF
-    - VAI
+    - radioVAI
 
 - type: entity
   parent: AU14ColonyAdminHeadset

--- a/Resources/Prototypes/_AU14/Entities/Clothing/Headset/thirdpartyheadsets.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Headset/thirdpartyheadsets.yml
@@ -62,7 +62,7 @@
       - CMEncryptionKeyColony
   - type: RMCHeadset
     channels:
-    - VAI
+    - radioVAI
   - type: GrantSquadLeaderTracker
     defaultMode: SquadLeader
     trackerModes:
@@ -79,7 +79,7 @@
   components:
   - type: RMCHeadset
     channels:
-    - VAI
+    - radioVAI
 
 - type: entity
   parent: AU14ColonyAdminHeadset
@@ -90,7 +90,7 @@
   components:
   - type: RMCHeadset
     channels:
-    - VAI
+    - radioVAI
 
 - type: entity
   parent: AU14HeadsetGovforMarine

--- a/Resources/Prototypes/_AU14/Entities/IDCards/Colony.yml
+++ b/Resources/Prototypes/_AU14/Entities/IDCards/Colony.yml
@@ -30,34 +30,6 @@
   - type: Corrodible
     isCorrodible: false
 
-# ├──[ COMMS TOWER FREQS ]───────────────────────────────────────────┤
-- type: entity
-  id: FactionCLF
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: IFFFaction
-  - type: FactionFrequencies
-    channels:
-    - radioCLF
-
-- type: entity
-  id: FactionCMB
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: IFFFaction
-  - type: FactionFrequencies
-    channels:
-    - radioCMB
-
-- type: entity
-  id: FactionWeYa
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: IFFFaction
-  - type: FactionFrequencies
-    channels:
-    - radioWEYU
-
 # ├──[ CLF & MOB ]───────────────────────────────────────────────────┤
 - type: entity
   parent: CMIDCardBase
@@ -181,7 +153,7 @@
     job: AU14JobCivilianScientist
   - type: ItemIFF
     factions:
-    - FactionWeYa
+    - FactionWEYU
 
 # ├──[ SYNTHS ]──────────────────────────────────────────────────────┤
 - type: entity
@@ -195,7 +167,7 @@
     factions:
     - FactionSurvivor
     - FactionCMB
-    - FactionWeYa
+    - FactionWEYU
 
 - type: entity
   parent: AU14IDCardBaseCivilianNoIFF
@@ -255,7 +227,7 @@
     job: AU14JobCivilianCorporateLiaison
   - type: ItemIFF
     factions:
-    - FactionWeYa
+    - FactionWEYU
 
 - type: entity
   parent: AU14IDCardBaseCivilianNoIFF

--- a/Resources/Prototypes/_AU14/Entities/IDCards/ThirdParties/Ambassadors.yml
+++ b/Resources/Prototypes/_AU14/Entities/IDCards/ThirdParties/Ambassadors.yml
@@ -1,0 +1,11 @@
+# ├──[ THIRD PARTY AMBASSADORS ]─────────────────────────────────────┤
+- type: entity
+  parent: CMIDCardBase
+  id: AU14IDCardVAIAmbassador
+  name: VAI ambassador ID card
+  components:
+  - type: PresetIdCard
+    job: AU14JobCivilianAmbassadorUA
+  - type: ItemIFF
+    factions:
+    - FactionVAI

--- a/Resources/Prototypes/_AU14/Entities/IDCards/ThirdParties/VAI.yml
+++ b/Resources/Prototypes/_AU14/Entities/IDCards/ThirdParties/VAI.yml
@@ -6,3 +6,6 @@
   components:
   - type: PresetIdCard
     job: AU14VAIMercenary
+  - type: ItemIFF
+    factions:
+    - FactionVAI

--- a/Resources/Prototypes/_AU14/Entities/IDCards/factionIFF.yml
+++ b/Resources/Prototypes/_AU14/Entities/IDCards/factionIFF.yml
@@ -1,0 +1,39 @@
+# ├──[ COLONY ]──────────────────────────────────────────────────────┤
+- type: entity
+  id: FactionCLF
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: IFFFaction
+  - type: FactionFrequencies
+    channels:
+    - radioCLF
+
+- type: entity
+  id: FactionCMB
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: IFFFaction
+  - type: FactionFrequencies
+    channels:
+    - radioCMB
+
+- type: entity
+  id: FactionWEYU
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: IFFFaction
+  - type: FactionFrequencies
+    channels:
+    - radioWEYU
+
+# ├──[ THIRD PARTIES ]───────────────────────────────────────────────┤
+- type: entity
+  id: FactionVAI
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: IFFFaction
+  - type: FactionFrequencies
+    channels:
+    - radioVAI
+
+# TODO: ICSCSOF, UASOF, TWESOF, UPPSOF, radioVAI, PART, Ambassadors/ThirdParty-callins

--- a/Resources/Prototypes/_AU14/Entities/Structures/Towers/comms_tower.yml
+++ b/Resources/Prototypes/_AU14/Entities/Structures/Towers/comms_tower.yml
@@ -58,15 +58,15 @@
     - radioOpforIntel
     - radioOpforJTAC
     - radioOpforMILP
+    - CMUYautja
+    - CMUYautjaOverseer
+    - CMUYautjaBadBlood
+    - radioVAI
     - ICSCSOF
     - UASOF
     - TWESOF
     - UPPSOF
-    - VAI
     - PART
-    - CMUYautja
-    - CMUYautjaOverseer
-    - CMUYautjaBadBlood
 
 # ├──[ GOVFOR COMMS ]────────────────────────────────────────────────┤
 - type: entity
@@ -111,11 +111,11 @@
   - type: CommunicationsTower
     state: Off
     channels:
+    - radioVAI
     - ICSCSOF
     - UASOF
     - TWESOF
     - UPPSOF
-    - VAI
     - PART
     - CMUYautja
     - CMUYautjaOverseer

--- a/Resources/Prototypes/_AU14/Factions/au_factions.yml
+++ b/Resources/Prototypes/_AU14/Factions/au_factions.yml
@@ -1,4 +1,4 @@
-﻿- type: npcFaction
+- type: npcFaction
   id: GOVFOR
   name: Government Forces
   hostile:
@@ -28,6 +28,7 @@
   - AUGoo
   - CMUAPE
   - Abomination
+
 - type: npcFaction
   id: CMUVAI
   name: Vanguard's Arrow Incorporated

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/uaambassador.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/uaambassador.yml
@@ -44,8 +44,10 @@
     - type: NpcFactionMember
       factions:
       - GOVFOR
+      - OPFOR
+      - CMUVAI
     - type: Marine
-      Faction: govfor
+    # Faction: ""
   hidden: false
 
 - type: startingGear
@@ -53,7 +55,7 @@
   equipment:
     jumpsuit: CMJumpsuitLiaisonBlack
     shoes: RMCShoesLaceupBrown
-    id: AU14IDCardColonyCorporateLiaison
+    id: AU14IDCardVAIAmbassador
     outerClothing: RMCFancySuitJacketBrown
     ears: AU14AmbassadorUAHeadset
     pocket1: AU14StampUAA

--- a/Resources/Prototypes/_AU14/Roles/squads.yml
+++ b/Resources/Prototypes/_AU14/Roles/squads.yml
@@ -223,7 +223,7 @@
     - Goggles
     - Armor
     - Gloves
-    radio: VAI
+    radio: radioVAI
     minimapBackground:
       sprite: /Textures/_RMC14/Interface/map_blips.rsi
       state: background_forecon
@@ -245,7 +245,7 @@
     - Goggles
     - Armor
     - Gloves
-    radio: VAI
+    radio: radioVAI
     minimapBackground:
       sprite: /Textures/_RMC14/Interface/map_blips.rsi
       state: background_forecon
@@ -267,7 +267,7 @@
     - Goggles
     - Armor
     - Gloves
-    radio: VAI
+    radio: radioVAI
     minimapBackground:
       sprite: /Textures/_RMC14/Interface/map_blips.rsi
       state: background_forecon

--- a/Resources/Prototypes/_AU14/radio_channels.yml
+++ b/Resources/Prototypes/_AU14/radio_channels.yml
@@ -203,6 +203,15 @@
   color: "#d39d22"
   longRange: true
 
+# ├──[ MISCELLANEOUS ]───────────────────────────────────────────────┤
+- type: radioChannel
+  id: ColonyHandheld
+  name: chat-radio-colony-softwave
+  keycode: 'ñ' # unused - handhelds broadcast without key
+  frequency: 1461
+  color: "#a6cf40"
+  longRange: true
+
 # ├──[ THIRD PARTY ]─────────────────────────────────────────────────┤
 - type: radioChannel
   id: Hivemind

--- a/Resources/Prototypes/_AU14/radio_channels.yml
+++ b/Resources/Prototypes/_AU14/radio_channels.yml
@@ -258,7 +258,7 @@
   tower: true
 
 - type: radioChannel
-  id: VAI
+  id: radioVAI
   name: chat-radio-vai
   keycode: "z"
   frequency: 1559

--- a/Resources/Prototypes/_AU14/thirdParties/VAI/BaseVAI.yml
+++ b/Resources/Prototypes/_AU14/thirdParties/VAI/BaseVAI.yml
@@ -4,6 +4,9 @@
   abstract: true
   suffix: AU14, UA, VAI
   components:
+  - type: NpcFactionMember
+    factions:
+    - CMUVAI
   - type: GhostTakeoverAvailable
   - type: RandomHumanoidAppearance
   - type: RandomHumanoidAppearanceWhitelisted

--- a/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_id_other.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_id_other.yml
@@ -85,7 +85,7 @@
     state: corporate_liaison
   - type: ItemIFF
     factions:
-    - FactionWeYa
+    - FactionWEYU
     - FactionMarine
   - type: PresetIdCard
     job: CMLiaison
@@ -101,7 +101,7 @@
     state: pmc
   - type: ItemIFF
     factions:
-    - FactionWeYa
+    - FactionWEYU
 
 - type: entity
   parent: CMIDCardPMC
@@ -123,7 +123,7 @@
     state: pmc
   - type: ItemIFF
     factions:
-    - FactionWeYa
+    - FactionWEYU
   - type: PresetIdCard
     job: CMLiaison
 
@@ -134,7 +134,7 @@
   components:
   - type: ItemIFF
     factions:
-    - FactionWeYa
+    - FactionWEYU
     - FactionSurvivor
   - type: PresetIdCard
     job: CMSurvivorCorporate
@@ -227,7 +227,7 @@
   components:
   - type: ItemIFF
     factions:
-    - FactionWeYa
+    - FactionWEYU
   - type: Access
     groups:
     - Colony

--- a/Resources/Prototypes/_RMC14/radio_channels.yml
+++ b/Resources/Prototypes/_RMC14/radio_channels.yml
@@ -2,7 +2,7 @@
 - type: radioChannel #UNMC High Command, for events and such, basically CentComm channel
   id: MarineHighCommand
   name: chat-radio-marine-highcommand
-  keycode: "8" #z in cm13
+  keycode: "Ĥ" #z in cm13
   frequency: 1471
   color: "#318779"
   longRange: true
@@ -113,7 +113,7 @@
 - type: radioChannel
   id: MarineDelta
   name: chat-radio-marine-delta
-  keycode: "9" #d in cm13
+  keycode: "Ɖ" #d in cm13
   frequency: 1494
   color: "#038ae1"
   longRange: true
@@ -138,14 +138,6 @@
   tower: true
 
 # Non Marine
-- type: radioChannel
-  id: ColonyHandheld
-  name: chat-radio-colony-softwave
-  keycode: 'ñ'
-  frequency: 1461
-  color: "#a6cf40" #todo rmc14
-  longRange: true
-
 - type: radioChannel
   id: Provost
   name: chat-radio-provost


### PR DESCRIPTION
- **📋 freed up the 8 & 9 radio keycodes**
- **✨ VAI IFF & Faction - able to tune comms tower**
- **🪲 fixes binocular delay for clients on unscope**

## About the PR
- Looking at it IFF/Factions need some serious work in order to make the Alliances work properly

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added faction and IFF to VAI: comms tower can be tuned - VAI ambassador also govfor+opfor factions
