### PR TITLE
📋 straightjackets should help subdue a handful of violent prisoners

### DIFF
--- a/Resources/Prototypes/_AU14/Entities/Clothing/Universal/jumpsuits.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Universal/jumpsuits.yml
@@ -6,3 +6,16 @@
   components:
   - type: Sprite
     sprite: _AU14/Clothing/blackfatigues.rsi
+
+- type: entity
+  parent: ClothingOuterStraightjacket
+  id: AU14ClothingOuterStraitjacket
+  name: straitjacket
+  suffix: AU14
+  components:
+  - type: Handcuff
+    cuffedRSI: Clothing/OuterClothing/Misc/straight_jacket.rsi
+    breakoutTime: 100
+    cuffTime: 7
+    uncuffTime: 7
+    stunBonus: 3

--- a/Resources/Prototypes/_AU14/Entities/Vendors/generalvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/generalvendors.yml
@@ -322,6 +322,10 @@
       - id: AU14PouchIFAKFill
       - id: RMCPouchMagazinePistol
       - id: RMCPouchPistol
+    - name: Inmate Restraining Gear
+      entries:
+      - id: AU14ClothingOuterStraitjacket
+        amount: 5 # TODO: bandaid - remove after mappers have placed this
 
 - type: entity
   parent: ColMarTechBase


### PR DESCRIPTION
## About the PR
- Instead of executing/DNR, put a straitjacket on them and bring some calm back to the Brigs.
- Mappers should place these sparingly along with the jumpsuits/shoes, so they can be removed from the vendor.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Five straitjackets are temporarily available to MPs from their vendor
