### PR TITLE
Spec Fixes

### DIFF
--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/weaponsspecialistBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/weaponsspecialistBase.yml
@@ -11,7 +11,6 @@
   playTimeTracker: AU14JobGOVFORWeaponsSpecialist
   accessGroups:
   - AU14GovforWeaponsSpecialist
-  hasIcon: false
 
 - type: job
   abstract: true

--- a/Resources/Prototypes/_AU14/access/groups/govfor_access_groups.yml
+++ b/Resources/Prototypes/_AU14/access/groups/govfor_access_groups.yml
@@ -33,6 +33,7 @@
   tags:
   - AU14AccessGovforSquadWeaponsSpecialist
   - AU14AccessGovforSquad
+  - AU14AccessGovfor
 
 - type: accessGroup
   id: AU14GovforFTL


### PR DESCRIPTION
Weapon Specialists now have icons.
Weapon Specialists now have access to govfor doors.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Weapon Specialists icon now shows.
- fix: Weapon Specialists now have access to govfor doors.