### PR TITLE
✨ disable cultists from moving non-xeno/non-cultist dead bodies

### DIFF
--- a/Content.Client/AU14/Cultist/CultistDragSystem.cs
+++ b/Content.Client/AU14/Cultist/CultistDragSystem.cs
@@ -1,0 +1,27 @@
+using Content.Shared.AU14;
+using Content.Shared._RMC14.Xenonids;
+using Content.Shared.DragDrop;
+using Content.Shared.Mobs.Systems;
+
+namespace Content.Client.AU14.Cultist;
+
+public sealed partial class CultistDragSystem : EntitySystem
+{
+    [Dependency] private MobStateSystem _mobState = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<CultistComponent, CanStartDragEvent>(OnCultistCanStartDrag);
+    }
+
+    private void OnCultistCanStartDrag(Entity<CultistComponent> cultist, ref CanStartDragEvent args)
+    {
+        var target = args.Target;
+        if (HasComp<CultistComponent>(target) || HasComp<XenoComponent>(target))
+            return;
+
+        if (_mobState.IsDead(target))
+            args.Cancelled = true;
+    }
+}

--- a/Content.Client/Interaction/DragDropSystem.cs
+++ b/Content.Client/Interaction/DragDropSystem.cs
@@ -203,10 +203,13 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
         }
 
         var ev = new CanDragEvent();
-
         RaiseLocalEvent(entity, ref ev);
-
         if (ev.Handled != true)
+            return false;
+
+        var startEv = new CanStartDragEvent(dragger, entity);
+        RaiseLocalEvent(dragger, ref startEv);
+        if (startEv.Cancelled)
             return false;
 
         _draggedEntity = entity;

--- a/Content.Shared/DragDrop/DraggableEvents.cs
+++ b/Content.Shared/DragDrop/DraggableEvents.cs
@@ -65,3 +65,9 @@ public record struct DragDropTargetEvent(EntityUid User, EntityUid Dragged)
     public readonly EntityUid Dragged = Dragged;
     public bool Handled = false;
 }
+
+/// <summary>
+/// Raised on the entity attempting to start a drag.
+/// </summary>
+[ByRefEvent]
+public record struct CanStartDragEvent(EntityUid User, EntityUid Target, bool Cancelled = false);


### PR DESCRIPTION
## About the PR
- Cultists were hiding bodies & killing to capture is low-effort
- Requested by Queorz

- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Cultists can no longer move dead mobs unless they are either cultist or xeno
