### PR TITLE
Fix for the Relogin test

### DIFF
--- a/Content.Server/AU14/Airlock/AURandomAirlockBreakSystem.cs
+++ b/Content.Server/AU14/Airlock/AURandomAirlockBreakSystem.cs
@@ -1,4 +1,6 @@
+using Content.Server.GameTicking;
 using Content.Server.Wires;
+using Content.Shared._RMC14.Rules;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -8,6 +10,7 @@ public sealed partial class AURandomAirlockBreakSystem : EntitySystem
 {
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private GameTicker _gameTicker = default!;
 
     public override void Initialize()
     {
@@ -24,6 +27,9 @@ public sealed partial class AURandomAirlockBreakSystem : EntitySystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
+
+        if (_gameTicker.IsGameRuleActive<CMDistressSignalRuleComponent>())
+            return;
 
         var now = _timing.CurTime;
         var query = EntityQueryEnumerator<AURandomAirlockBreakComponent, WiresComponent>();

--- a/Content.Server/AU14/Light/AURandomLightBreakSystem.cs
+++ b/Content.Server/AU14/Light/AURandomLightBreakSystem.cs
@@ -1,4 +1,6 @@
+using Content.Server.GameTicking;
 using Content.Server.Light.EntitySystems;
+using Content.Shared._RMC14.Rules;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -9,6 +11,7 @@ public sealed partial class AURandomLightBreakSystem : EntitySystem
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private PoweredLightSystem _poweredLight = default!;
+    [Dependency] private GameTicker _gameTicker = default!;
 
     public override void Initialize()
     {
@@ -25,6 +28,9 @@ public sealed partial class AURandomLightBreakSystem : EntitySystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
+
+        if (_gameTicker.IsGameRuleActive<CMDistressSignalRuleComponent>())
+            return;
 
         var now = _timing.CurTime;
         var query = EntityQueryEnumerator<AURandomLightBreakComponent>();

--- a/Content.Server/_CMU14/ZLevels/Core/CMUZLevelsSystem.View.cs
+++ b/Content.Server/_CMU14/ZLevels/Core/CMUZLevelsSystem.View.cs
@@ -767,7 +767,10 @@ public sealed partial class CMUZLevelsSystem
                     }
 
                     var target = _transform.GetMapCoordinates(highGroundUid);
-                    var range = highGround.PreviewRange + 0.05f;
+                    var range = Math.Min(highGround.PreviewRange + 0.05f, ExamineSystemShared.MaxRaycastRange);
+                    if (highGround.PreviewRange + 0.05f > ExamineSystemShared.MaxRaycastRange)
+                        Logger.GetSawmill("content").Warning($"CanPreviewUpperZFromStairCore: range ({highGround.PreviewRange + 0.05f}) exceeds max raycast range ({ExamineSystemShared.MaxRaycastRange})!");
+
                     if (Vector2.DistanceSquared(origin.Position, target.Position) > range * range)
                         continue;
 
@@ -777,7 +780,7 @@ public sealed partial class CMUZLevelsSystem
                         _profilePvsStairLosChecks++;
                     }
 
-                    if (_examine.InRangeUnOccluded(origin, target, highGround.PreviewRange, ent => ent == viewer.Owner || ent == highGroundUid))
+                    if (_examine.InRangeUnOccluded(origin, target, range, ent => ent == viewer.Owner || ent == highGroundUid))
                     {
                         AddStairPreviewPosition(previewPositions, target.Position);
                         if (previewPositions.Count >= CMUZLevelViewerComponent.MaxStairPreviewPositions)

--- a/Resources/Prototypes/_AU14/Entities/Medical/medical.yml
+++ b/Resources/Prototypes/_AU14/Entities/Medical/medical.yml
@@ -978,6 +978,9 @@
   - type: Sprite
     sprite: _AU14/Items/quickclot.rsi
     state: qc_ripped
+  - type: Tag
+    tags:
+    - Trash
   - type: Item
     sprite: _AU14/Items/quickclot.rsi
     inhandVisuals:

--- a/Resources/Prototypes/_AU14/Entities/Mobs/K9.yml
+++ b/Resources/Prototypes/_AU14/Entities/Mobs/K9.yml
@@ -166,6 +166,7 @@
       - Dropper
       - GlassBeaker
       - Bottle
+      - PillPacket
       - PillCanister
       - Syringe
       - CMSurgicalLine
@@ -186,22 +187,17 @@
       - CigPack
       - RMCPenlight
       - Flare
-      - CMBoneSaw
-      - CMSurgicalDrill
-      - CMCautery
-      - RMCScalpel
-      - CMBoneSetter
-      - CMRetractor
+      - CMUBoneGraft
       - CMUCastItem
       - CMUOrganClamp
-      - CMHemostat
       - CMUSplintItem
-      - CMUBoneGraft
-      - CMBoneGel
       components:
+      - CMSurgeryTool
       - Hypospray
       - Defibrillator
       - Pill
+      - RMCHandLabeler
+      - RMCStethoscope
       - RMCLighter
   - type: FixedItemSizeStorage
   - type: IgnoreContentsSize

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -412,19 +412,20 @@
       - Flare
       - RMCMiniTank
       # New Med
-      - CMBoneSaw
-      - CMSurgicalDrill
-      - CMCautery
-      - RMCScalpel
-      - CMBoneSetter
-      - CMRetractor
+      # - CMRetractor
+      # - CMHemostat
+      # - CMBoneSaw
+      # - CMCautery
+      # - CMSurgicalDrill
+      # - RMCScalpel
+      # - CMBoneSetter
+      # - CMBoneGel
+      - CMUBoneGraft
       - CMUCastItem
       - CMUOrganClamp
-      - CMHemostat
       - CMUSplintItem
-      - CMUBoneGraft
-      - CMBoneGel
       components:
+      - CMSurgeryTool # catch-all for above commented out NewMed tags
       - Hypospray
       - Defibrillator
       - Pill

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/lifesaver_bag.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/lifesaver_bag.yml
@@ -40,19 +40,20 @@
       - RMCPenlight
       - Flare
       # New Med
-      - CMBoneSaw
-      - CMSurgicalDrill
-      - CMCautery
-      - RMCScalpel
-      - CMBoneSetter
-      - CMRetractor
+      # - CMRetractor
+      # - CMHemostat
+      # - CMBoneSaw
+      # - CMCautery
+      # - CMSurgicalDrill
+      # - RMCScalpel
+      # - CMBoneSetter
+      # - CMBoneGel
+      - CMUBoneGraft
       - CMUCastItem
       - CMUOrganClamp
-      - CMHemostat
       - CMUSplintItem
-      - CMUBoneGraft
-      - CMBoneGel
       components:
+      - CMSurgeryTool # catch-all for above commented out NewMed tags
       - Hypospray
       - Defibrillator
       - Pill

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/surgery.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/surgery.yml
@@ -113,6 +113,9 @@
     soundHit:
       path: /Audio/Effects/lightburn.ogg
   - type: CMCautery
+  - type: Tag
+    tags:
+    - CMCautery
   - type: PhysicalComposition
     materialComposition:
       CMSteel: 5000
@@ -250,6 +253,7 @@
   - type: Tag
     tags:
     - CMCautery
+    - RMCScalpel
   - type: UseDelay
   - type: ItemToggleMeleeWeapon
     activatedDamage:


### PR DESCRIPTION
- **🩹 CMSurgeryTool component whitelist for medical belt/bag**
- **🩹 clamp highGround.PreviewRange to satisfy Relogin test case (InRangeUnOccluded check performed over extreme range)**

## About the PR
- Relogin test keeps coming back with this InRangeUnOccluded failure, hopefully clamping it here should halt it from going to extreme range

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Medical belt/bags are able to hold surgery tools (like the cautery)
- tweak: Used Hemo Gauze is tagged as Trash
- fix: Lights/airlocks no longer randomly break (part of colony engineering loop) on Distress Signal