### PR TITLE
Spec Fixes + Tweaks

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
@@ -245,20 +245,11 @@
     sprite: _RMC14/Objects/Clothing/Back/Backpacks/Marines/scout_cloak.rsi
   - type: Storage
     grid:
-    - 0,0,14,1 # 15 slots
-  - type: ClothingRequireEquipped
-    autoUnequip: true
-    whitelist:
-      tags:
-      - RMCScoutArmor
-    denyReason: rmc-wear-scout-armor-required
+    - 0,0,10,1
   - type: ThermalCloak
-    opacity: 0.03 # Put to 0.03 for testing
+    opacity: 0.035 # Put to 0.03 for testing
     restrictWeapons: true
     cloakedHideLayers:
-    - Hair
-    - HeadTop
-    - HeadSide
     - Tail
     - Snout # I don't know if this is hugely problematic but better safe than sorry
     whitelist:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
@@ -757,7 +757,7 @@
     - id: RMCVultureStock
     - id: RMCMagazineSniperM707Vulture
       amount: 12
-    - id: CMGlassesM42ScoutSight
+    - id: RMCVisorNightVision
     - id: CMBackpackSniper
     - id: RMCScoutShoes
     - id: RMCPamphletVulture
@@ -783,7 +783,7 @@
     - id: CMScrewdriver
     - id: RMCScoutShoes
     - id: CMBackpackSniper
-    - id: CMGlassesM42ScoutSight
+    - id: RMCVisorNightVision
     - id: RMCPamphletVulture
   - type: Tag
     tags:
@@ -803,7 +803,7 @@
     - id: RMCLaserDesignatorSpotter
     - id: RMCScoutShoes
     - id: CMBackpackSniper
-    - id: CMGlassesM42ScoutSight
+    - id: RMCVisorNightVision
   - type: Tag
     tags:
     - AU14KitSpotter

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/royal_kits.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/royal_kits.yml
@@ -29,7 +29,7 @@
     - 0,0,17,1
   - type: StorageFill
     contents:
-    - id: CMGlassesM42ScoutSight
+    - id: RMCVisorNightVision
     - id: CMMagazineSniperM96S
       amount: 6
     - id: RMCM96SBSniperRifle
@@ -73,7 +73,7 @@
       - RMCL112SniperRifle
   - type: StorageFill
     contents:
-    - id: CMGlassesM42ScoutSight
+    - id: RMCVisorNightVision
     - id: RMCL112SniperRifleSuppressedSH
     - id: RMCMagazineSniperL112SH
       amount: 10

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
@@ -10,7 +10,7 @@
     - 0,0,21,3
   - type: StorageFill
     contents:
-    - id: CMGlassesM42ScoutSight
+    - id: RMCVisorNightVision
     - id: CMMagazineSniperM96S
       amount: 10
     - id: CMMagazineSniperM96SIncendiary
@@ -44,7 +44,7 @@
     - id: RMCXM43E1AntiMaterielRifle
     - id: RMCMagazineSniperXM43E1AntiMateriel
       amount: 10
-    - id: CMGlassesM42ScoutSight
+    - id: RMCVisorNightVision
     - id: RMCScoutShoes
     - id: CMBackpackSniper
     - id: AU14KitSpotter
@@ -378,7 +378,7 @@
     contents:
     - id: CMArmorM45
     - id: CMArmorHelmetM45
-    - id: CMGlassesM42ScoutSight
+    - id: RMCVisorNightVision
     - id: CMBackpackSniper
     - id: RMCLaserDesignatorSpotter
     - id: CMPamphletSpotter

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/vulture_sniper.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/vulture_sniper.yml
@@ -31,7 +31,7 @@
   - type: RMCSelectiveFire
     recoilWielded: 2
     scatterWielded: 1
-    baseFireRate: 0.5
+    baseFireRate: 0.25
   - type: RMCWeaponAccuracy
     accuracyMultiplier: 1.35
   - type: WieldDelay
@@ -234,7 +234,8 @@
     deleteOnCollide: false
     damage:
       types:
-        Piercing: 400
+        Piercing: 1000
+        Blunt: 50
         Structural: 1800
     soundHit:
       path: /Audio/_RMC14/Bullets/bullet_vulture_impact.ogg
@@ -244,7 +245,7 @@
       falloff: 9999
       ignoreModifiers: true
   - type: CMArmorPiercing
-    amount: 50
+    amount: 70
   - type: RMCPenetratingProjectile
     range: 40
     rangeLossPerHit: 3
@@ -253,8 +254,8 @@
   - type: RMCStunOnHit
     stuns:
     - maxRange: 32
-      knockBackPowerMin: 3
-      knockBackPowerMax: 3
+      knockBackPowerMin: 6
+      knockBackPowerMax: 6
       knockBackSpeed: 8
       stunTime: 0
       superSlowTime: 0


### PR DESCRIPTION
- Scout sights in special weapon kits have been replaced with NVG visors to be more balanced during HvH.
- The M707 Vulture has been buffed and is now worth taking. The amount of setup required to use the weapon effectively should reap benefit. The weapon will now sever limbs pretty much every shot while its fully deployed and does a huge heap of damage to armored targets. The weapon's bullets will fling targets a further distance on impact and its fire rate has been halved.
- The scout cloak now no longer requires scout armor to be used.

**Changelog**
:cl:
- tweak: Scout sights in special weapon kits have been replaced with NVG visors to be more balanced during HvH.
- tweak: The M707 Vulture has been buffed and is now worth taking. The amount of setup required to use the weapon effectively should reap benefit. The weapon will now sever limbs pretty much every shot while its fully deployed and does a huge heap of damage to armored targets. The weapon's bullets will fling targets a further distance on impact and its fire rate has been halved.
- fix: The scout cloak now no longer requires scout armor to be used but is also SLIGHTLY (0.5) more visible.