### PR TITLE
Revert "Removes ! and ? chatsans"

### DIFF
--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -35,7 +35,7 @@ public sealed partial class ChatSanitizationManager : IChatSanitizationManager
         { ":D", "chatsan-smiles-widely" },
         { "D:", "chatsan-frowns-deeply" },
         { ":O", "chatsan-surprised" },
-//        { "!", "chatsan-surprised" }, // RMC14 //CMU14 commented out
+        { "!", "chatsan-surprised" }, // RMC14
         { ":3", "chatsan-smiles" },
         { ":S", "chatsan-uncertain" },
         { ":>", "chatsan-grins" },
@@ -81,7 +81,7 @@ public sealed partial class ChatSanitizationManager : IChatSanitizationManager
         { "o.o", "chatsan-wide-eyed" },
         { "._.", "chatsan-surprised" },
         { ".-.", "chatsan-confused" },
- //       { "?", "chatsan-confused" }, // RMC14 //CMU14 commented out
+        { "?", "chatsan-confused" }, // RMC14
         { "-_-", "chatsan-unimpressed" },
         { "smh", "chatsan-unimpressed" },
         { "o/", "chatsan-waves" },


### PR DESCRIPTION
Reverts AU-14/ColonialMarinesUniverse#1291

alot of people from what i know used to type the exclamation mark and question mark to get in return "looks surprised" or "looks confused". the reason why this was removed was because quote "For non english speakers who are used to putting a space between the last word of a sentence and ? or ! it often makes messages in game a lot more confusing than anything. A notable example being the sentence "Who ? What ?" turning into "Who What" followed by "looks confused".".

Now, instead of having this entirely removed, why not just fix it so an isolated exclamation mark or a question mark DOESN'T do that? Either that, or try putting those emotes on the emote wheel...

:cl:
- add: ? and !  emote into "looks surprised" or "looks confused" again