### PR TITLE
Remove Badbloods from rotation.

### DIFF
--- a/Resources/Prototypes/_AU14/Maps/planets.yml
+++ b/Resources/Prototypes/_AU14/Maps/planets.yml
@@ -33,7 +33,7 @@
     - XenoThreatCF
     - wendigoThreat
     - abominationsThreatDistress
-    - badBloodClanThreat
+#    - badBloodClanThreat
     thirdparties:
     - WEYUSurvLarge
     - WEYUSurvMedium
@@ -460,7 +460,7 @@
     - XenoThreatCF
     - wendigoThreat
     - abominationsThreatDistress
-    - badBloodClanThreat
+#    - badBloodClanThreat
 
     thirdparties:
     - WEYUSurvLarge
@@ -525,7 +525,7 @@
     - cultistThreat
     - XenoThreat
     - XenoThreatCF
-    - badBloodClanThreat
+#    - badBloodClanThreat
 
     thirdparties:
     - WEYUSurvLarge
@@ -604,7 +604,7 @@
     - wendigoThreat
     - abominationsThreat
     - abominationsThreatDistress
-    - badBloodClanThreat
+#    - badBloodClanThreat
 
     joboverrides:
       AU14JobLEOBase: AU14JobCivilianCMBDeputy
@@ -667,7 +667,7 @@
     - wendigoThreat
  #   - TribalsThreat
     - abominationsThreatDistress
-    - badBloodClanThreat
+#    - badBloodClanThreat
 
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
@@ -728,7 +728,7 @@
     threats:
     - XenoThreat
     #- TribalsThreat
-    - badBloodClanThreat
+#    - badBloodClanThreat
 
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
@@ -786,7 +786,7 @@
     threats:
     - XenoThreat
  #   - TribalsThreat
-    - badBloodClanThreat
+#    - badBloodClanThreat
 
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
@@ -843,8 +843,8 @@
     - abominationThirdParty
     threats:
     - XenoThreat
-    - TribalsThreat
-    - badBloodClanThreat
+#    - TribalsThreat
+#    - badBloodClanThreat
 
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
@@ -902,7 +902,8 @@
     - abominationThirdParty
     threats:
     - abominationsThreatDistress
-    -  badBloodClanThreat
+    - XenoThreat
+ #   -  badBloodClanThreat
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
 
@@ -957,7 +958,8 @@
     - abominationThirdParty
     threats:
     - abominationsThreatDistress
-    - badBloodClanThreat
+    - XenoThreat
+#    - badBloodClanThreat
 
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale


### PR DESCRIPTION
Removes badbloods and tribals from rotation until they can be built out more. General feedback has been extremely negative.
Adds xenos as a threat for some maps that did not have them.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Xenos added as a threat option on all maps.
- remove: Removed badblood and tribals threat from rotation until they can be built out more.