### PR TITLE
Clf mistake

### DIFF
--- a/Resources/Prototypes/_AU14/thirdParties/CLF/Survs/CLFSurvFighter.yml
+++ b/Resources/Prototypes/_AU14/thirdParties/CLF/Survs/CLFSurvFighter.yml
@@ -65,10 +65,10 @@
     - [ CMJumpsuitColonistCLFArmband ] 
     randomWeapon: # Weapon with ammo pouches and stuff
     - [ AU14WeaponRifleM16A1, AU14PouchMagazineLargeFilledM16, AU14PouchIFAKFill ]
-    - [ AU14WeaponRifleAR10, AU14PouchMagazineLargeFilledAR10, AU14PouchIFAKFill ]
+    - [ AU14WeaponRifleAR10, AU14PouchMagazineLargeFilledM16, AU14PouchIFAKFill ]
     - [ RMCWeaponBoltActionRifle, AU14PouchMagazineLargeFilledHuntingRifle, AU14PouchIFAKFill ]
     - [ AU14WeaponRifleM16A1, AU14PouchMagazineLargeFilledM16, AU14PouchIFAKFill ]
-    - [ AU14WeaponRifleAR10, AU14PouchMagazineLargeFilledAR10, AU14PouchIFAKFill ]
+    - [ AU14WeaponRifleAR10, AU14PouchMagazineLargeFilledM16, AU14PouchIFAKFill ]
     - [ RMCWeaponBoltActionRifle, AU14PouchMagazineLargeFilledHuntingRifle, AU14PouchIFAKFill ]
     - [ WeaponRifleMAR40, AU14PouchMagazineLargeFilledMAR40normal, AU14PouchIFAKFill ]
     - [ RMCWeaponShotgunHG3712, AU14PouchShotgunLargeBuckshot, AU14PouchIFAKFill ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Accidentally used RMC AR-10 mag for CLF survs, AU14 AR-10 uses M-16 mags instead
Fixed

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
fix: CLF surv AR-10 spawn doesnt have wrong ammo anymore
