### PR TITLE
Head Physician Loadout

### DIFF
--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyheadphysician.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyheadphysician.yml
@@ -57,12 +57,10 @@
 
 - type: startingGear
   id: AU14GearCivilianHeadPhysician
-  equipment:
-    id: AU14IDCardColonyHeadPhysician
-    jumpsuit: RMCScrubsLightBlue
-    shoes: RMCShoesBlack
-    outerClothing: RMCLabcoatOpened
-    pocket1: AU14StampHPHY
+  equipment: {}
+  storage:
+    back:
+    - AU14StampHPHY
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_AU14/Roles/Loadouts/Items/RoleSpecific/phycisian.yml
+++ b/Resources/Prototypes/_AU14/Roles/Loadouts/Items/RoleSpecific/phycisian.yml
@@ -18,6 +18,11 @@
   equipment:
     id: AU14IDCardColonyGeneralPractitioner
 
+- type: loadout
+  id: CivilianHeadPhysicianSpecializationDefaultAU14
+  equipment:
+    id: AU14IDCardColonyHeadPhysician
+
 # CLF
 
 - type: loadout

--- a/Resources/Prototypes/_AU14/Roles/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_AU14/Roles/Loadouts/loadout_groups.yml
@@ -274,6 +274,14 @@
   - CivilianPhysicianSpecializationGeneralPractitionerAU14
 
 - type: loadoutGroup
+  id: CivilianHeadPhysicianSpecializationAU14
+  name: au14-loadout-group-role-specific-ID
+  minLimit: 1
+  maxLimit: 1
+  loadouts:
+  - CivilianHeadPhysicianSpecializationDefaultAU14
+
+- type: loadoutGroup
   id: MedJumpsuitAU14
   name: au14-loadout-group-civilian-jumpsuit
   minLimit: 1

--- a/Resources/Prototypes/_AU14/Roles/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_AU14/Roles/Loadouts/role_loadouts.yml
@@ -193,6 +193,27 @@
   - SmokablesRMC
 
 - type: roleLoadout
+  id: JobAU14JobCivilianHeadPhysician
+  points: 7
+  groups:
+  - CivilianHeadPhysicianSpecializationAU14
+  - MedBackpackAU14
+  - MedJumpsuitAU14
+  - MedHatsAU14
+  - MedJacketAU14
+  - MedGlovesAU14
+  - CivFootwearAU14
+  - MedMaskAU14
+  - MedBeltAU14
+  - MedPouchAU14
+  - MedPouchRightAU14
+  - ForceMedEssentialAU14
+  - PaperworkRMC
+  - RecreationalRMC
+  - CannedDrinksAU14
+  - SmokablesRMC
+
+- type: roleLoadout
   id: JobAU14JobCivilianEmergencyResponseOfficer
   points: 7
   groups:


### PR DESCRIPTION
## About the PR
Adds a missing role loadout for the Head Physician colonist role.

## Why / Balance
Head Physician already had starting gear, but did not have a selectable role loadout like other colony medical roles.

## Technical details
- Added `JobAU14JobCivilianHeadPhysician` role loadout.
- Added `CivilianHeadPhysicianSpecializationAU14` loadout group.
- Added `CivilianHeadPhysicianSpecializationDefaultAU14`, which equips `AU14IDCardColonyHeadPhysician`.
- Reused the existing AU14 medical loadout groups.

## Media
<img width="1526" height="725" alt="Screenshot 2026-06-14 020705" src="https://github.com/user-attachments/assets/9bad3e46-ae0d-47a5-b438-5fb912c625a1" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Added the missing Head Physician colonist role loadout.
