### PR TITLE
Ranger ID IFF fix, removed Sheperds' from DS rotation

### DIFF
--- a/Resources/Prototypes/_AU14/Entities/IDCards/Colony.yml
+++ b/Resources/Prototypes/_AU14/Entities/IDCards/Colony.yml
@@ -514,6 +514,10 @@
   components:
   - type: PresetIdCard
     job: AU14JobCivilianCWPSRanger
+  - type: ItemIFF
+    factions:
+    - FactionSurvivor
+    - FactionCMB
 
 - type: entity
   parent: AU14IDCardBaseCivilianNoIFF

--- a/Resources/Prototypes/_AU14/gamemode/gamemodes.yml
+++ b/Resources/Prototypes/_AU14/gamemode/gamemodes.yml
@@ -59,7 +59,7 @@
   requiresGovforVote: true
   supportedPlanets:
 #  - AUPlanetLV747
-  - AUPlanetShepherdsPride
+#  - AUPlanetShepherdsPride
   - AUPlanetSorokyne
   - AUPlanetCorsatStation
   - AUPlanetTrijent


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ranger ID IFF fix, removed Sheperds' from DS rotation

## Why / Balance
Allows ranger to add cmb radio to comm tower. Sheperds' needs a bit more work for Distress Signal specifically xenos.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: CWPS Ranger ID IFF (comm towers)
- remove: Sheperds' from Distress Signal rotation