### PR TITLE
+1 hivebreaker to w-y egg crate

### DIFF
--- a/Resources/Prototypes/_AU14/Catalog/Fills/Crates/weyu_experiments.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Fills/Crates/weyu_experiments.yml
@@ -11,6 +11,7 @@
         amount: 2
       - id: RMCTentUNMCStandardMedicalFolded
       - id: AU14TentBigFoldedSurgical
+      - id: CMUYautjaHivebreaker
 
 - type: entity
   id: AU14CrateSecureWeYuMindBreaker
@@ -53,6 +54,7 @@
         amount: 1
       - id: RMCTentUNMCStandardMedicalFolded
       - id: AU14TentBigFoldedSurgical
+      
 
 # Dedicated clotted-syringe crate — six pre-filled syringes for a WYHT
 # squad to use on captured colonists. Folded medical tents come along

--- a/Resources/Prototypes/_AU14/Catalog/Fills/Crates/weyu_experiments.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Fills/Crates/weyu_experiments.yml
@@ -54,7 +54,6 @@
         amount: 1
       - id: RMCTentUNMCStandardMedicalFolded
       - id: AU14TentBigFoldedSurgical
-      
 
 # Dedicated clotted-syringe crate — six pre-filled syringes for a WYHT
 # squad to use on captured colonists. Folded medical tents come along

--- a/Resources/Prototypes/_AU14/Catalog/Fills/Crates/weyu_experiments.yml
+++ b/Resources/Prototypes/_AU14/Catalog/Fills/Crates/weyu_experiments.yml
@@ -12,6 +12,7 @@
       - id: RMCTentUNMCStandardMedicalFolded
       - id: AU14TentBigFoldedSurgical
       - id: CMUYautjaHivebreaker
+        prob: 0.1
 
 - type: entity
   id: AU14CrateSecureWeYuMindBreaker


### PR DESCRIPTION
Let's hope for less breakouts..

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added one single hivebreaker to the eggs experiment crate.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Originally, the hivebreaker/egg interaction for weyu scientists required two crates. You had to get lucky to get eggs and hivebreaker at the same time. This was a decent idea at the time but recently it's faults have begun showing. Notably; eggs being.. somewhat useless if you don't get the mindbreaker crate chance, as the facilities on most maps are relatively underequipped for long-term containment (partially thanks to bald-ish WYsec.)

This PR aims to alleviate some of the woes of eggs by giving scientists a guaranteed shot at hivebreaking if they get lucky with eggs. At least they will have _a chance_ at creating fun RP instead of just causing mini colony fall, or wasting away the crate out of fear of said mini colony fall. 

## Technical details
<!-- Summary of code changes for easier review. -->
one line change
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: WY Xeno Egg experiment crates have a 10% chance to come with a single Hivebreaker remote. Use wisely.

