### PR TITLE
removes corporate spy from colony antags

### DIFF
--- a/Content.Server/AU14/Round/ColonyAntagsRuleSystem.cs
+++ b/Content.Server/AU14/Round/ColonyAntagsRuleSystem.cs
@@ -18,7 +18,6 @@ public sealed partial class ColonyAntagsRuleSystem : GameRuleSystem<ColonyAntags
         { "RunawaySynth", 0.5f },
         { "Fugitive", 0.5f },
         { "DrugDealer", 0.5f },
-        { "CorporateSpy", 0.35f },
         { "CLFVeteran", 0.5f },
         { "StrikeOrganizer", 0.5f },
         { "Cannibal", 0.25f },


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR removes corporate spy from the colony antag chances.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Corporate spy is often involved in a lot of We-Yu's bigger problems, recently. As a role, it's job is to grief weyland, which means stealing stuff and tattling to relevant figures. However..

This role is very underbaked. They get an ID card to get into the facility, as well as.. a short description that tells them nothing, and an objective to steal research. Notice how 'tattling to relevant figures' is not listed anywhere? In fact, most of the time, giving up secrets would go AGAINST their objective.
<img width="1241" height="78" alt="image" src="https://github.com/user-attachments/assets/0e0eb7b5-c99d-4070-91c6-b2daf5aa954b" />


This role causes a lot of unneeded headache and shitflinging for weyland. A shitter corporate spy, the usual kind, will take the bioweapons laptops and immediately go over to GOVFOR, which causes GOVFOR to raid weyland, often times disrupting the research inside and potentially even leading to biological hazard breaches such as xenos escaping or abominations infecting a lot of govfor personnel. This is INCREDIBLY UNFUN and UNINTERACTIVE for We-Yu, as they often do not know how GOVFOR came up with the idea to raid the facility. If a Liaison wants to prevent this, they must borderline metagame and assume that the bioweapons laptops are not allowed to exist in the facility and must be immediately gathered up and hidden, which again, feels like metagaming.

If a spy plays PROPERLY however.. it's.. often silently detrimental and still unfun. They steal research items, and if done silently without reporting to govfor, stuff just goes missing with no-one knowing where it goes, which leads to scientists blaming one another and arguing. This isn't engaging.

We-Yu security is not trained to be on the lookout for corporate spies, and especially is unable to detect them when _they are scientists or the FUCKING **LIAISON THEMSELVES**_. 

And on top of all of this, sometimes the spies will just.. RELEASE 'BIOWEAPONS' (like xenos) intentionally! for no reason! and especially when the spy is rolling for a WE-YU role, it's hard to tell what's intentional spy behavior or just shittery. 

TL;DR: Spies are often going above and beyond what their role description provides to ruin rounds, all because they assume the role is just 'screw over weyland.'. This role encourages metagaming.

## Technical details
<!-- Summary of code changes for easier review. -->
One-Liner.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Removed the corporate spy antagonist role from the colony antagonist gamerule.
