### PR TITLE
Adds ChemicalIrritant system for human gas chemicals

### DIFF
--- a/Content.Server/_CMU14/Weapons/ChemicalIrritantSystem.cs
+++ b/Content.Server/_CMU14/Weapons/ChemicalIrritantSystem.cs
@@ -1,0 +1,16 @@
+using Content.Shared._CMU14.ChemicalIrritants;
+
+namespace Content.Server._CMU14.Weapons;
+
+/// <summary>
+/// Server-side system for chemical irritants (tear gas, pepper spray, etc.)
+/// This registers and runs the shared system on the server.
+/// </summary>
+public sealed class ChemicalIrritantSystem : SharedChemicalIrritantSystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        // Any server-specific logic can go here
+    }
+}

--- a/Content.Shared/_CMU14/Weapons/ChemicalIrritants/ChemicalIrritantComponent.cs
+++ b/Content.Shared/_CMU14/Weapons/ChemicalIrritants/ChemicalIrritantComponent.cs
@@ -1,0 +1,39 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CMU14.ChemicalIrritants;
+
+/// <summary>
+/// Tracks chemical irritant effects currently affecting a victim.
+/// Effect parameters are stored in CheemicalIrritantProfil and copied
+/// from the injector on first contact.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ChemicalIrritantComponent : Component
+{
+
+    [DataField, AutoNetworkedField]
+    public float IrritantAmount = 0f;
+
+    [DataField, AutoNetworkedField]
+    public float DepletionPerTick = 2f;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan UpdateEvery = TimeSpan.FromSeconds(1);
+
+    public TimeSpan NextIrritantEffectAt;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan TimeBetweenMessages = TimeSpan.FromSeconds(3);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastMessage;
+    
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastTripTime;
+
+    /// <summary>
+    /// Effect parameters copied from the injector on first contact.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public ChemicalIrritantProfile Profile = new();
+}

--- a/Content.Shared/_CMU14/Weapons/ChemicalIrritants/ChemicalIrritantInjectorComponent.cs
+++ b/Content.Shared/_CMU14/Weapons/ChemicalIrritants/ChemicalIrritantInjectorComponent.cs
@@ -1,0 +1,52 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CMU14.ChemicalIrritants;
+
+/// <summary>
+/// Component for clouds and dispensers that apply chemical irritants.
+/// Effect parameters are defined once in ChemicalIrritantProfile and
+/// copied onto the victim's ChemicalirritantComponent on contact.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedChemicalIrritantSystem))]
+public sealed partial class ChemicalIrritantInjectorComponent : Component
+{
+    [ViewVariables]
+    public HashSet<EntityUid> ContactedEntities = new();
+
+    [DataField(required: true), AutoNetworkedField]
+    public float IrritantPerSecond = 10f;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan TimeBetweenGasInjects = TimeSpan.FromSeconds(1);
+
+    [DataField, AutoNetworkedField]
+    public bool AffectsDead = false;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan NextGasInjectionAt;
+
+    /// <summary>
+    /// When >= 0, the injector has a finite supply. Set to -1 for infinite.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float IrritantCapacity = -1f;
+
+    [DataField, AutoNetworkedField]
+    public float IrritantUsed = 0f;
+
+    [DataField, AutoNetworkedField]
+    public float FilterDamage = 5f;
+
+    [DataField, AutoNetworkedField]
+    public bool NeurotoxinFilterDamage = false;
+
+    /// <summary>
+    /// All effect parameters for this irritant. Copied to the victim on contact.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public ChemicalIrritantProfile Profile = new();
+
+    [DataField, AutoNetworkedField]
+    public float DepletionPerTick = 2f;
+}

--- a/Content.Shared/_CMU14/Weapons/ChemicalIrritants/ChemicalIrritantProfile.cs
+++ b/Content.Shared/_CMU14/Weapons/ChemicalIrritants/ChemicalIrritantProfile.cs
@@ -1,0 +1,84 @@
+using Content.Shared.Damage;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._CMU14.ChemicalIrritants;
+
+/// <summary>
+/// Shared effect parameters for chemical irritants.
+/// Held by both the injector (source) and the victim component,
+/// so settings only need to be defined once per injector and are
+/// copied to the victim on first contact.
+/// </summary>
+[DataDefinition, Serializable, NetSerializable]
+public sealed partial class ChemicalIrritantProfile
+{
+    [DataField]
+    public string IrritantType = "tear_gas";
+
+    [DataField]
+    public float EffectThreshold = 5f;
+
+    [DataField]
+    public float BlindThreshold = 20f;
+
+    [DataField]
+    public float SevereThreshold = 30f;
+
+    [DataField]
+    public TimeSpan BlurTime = TimeSpan.FromSeconds(3);
+
+    [DataField]
+    public TimeSpan BlindTime = TimeSpan.FromSeconds(1);
+
+    [DataField]
+    public float JitterChance = 0.30f;
+
+    [DataField]
+    public TimeSpan JitterTime = TimeSpan.FromSeconds(1);
+
+    [DataField]
+    public float DazeChance = 0.15f;
+
+    [DataField]
+    public TimeSpan DazeTime = TimeSpan.FromSeconds(1);
+
+    [DataField]
+    public TimeSpan StutterTime = TimeSpan.FromSeconds(2);
+
+    [DataField]
+    public float SlowChance = 0.10f;
+
+    [DataField]
+    public TimeSpan SlowTime = TimeSpan.FromSeconds(2);
+
+    [DataField]
+    public float SevereSlowChance = 0.25f;
+
+    [DataField]
+    public TimeSpan SevereSlowTime = TimeSpan.FromSeconds(4);
+
+    [DataField]
+    public DamageSpecifier IrritantDamage = new();
+    
+    [DataField]
+    public float TripThreshold = 25f;
+
+    [DataField]
+    public float TripChance = 0.15f;
+
+    [DataField]
+    public TimeSpan TripStunTime = TimeSpan.FromSeconds(2);
+
+    [DataField]
+    public TimeSpan MinimumDelayBetweenTrips = TimeSpan.FromSeconds(5);
+    
+    [DataField]
+    public List<string> ExposureMessages = new()
+    {
+        "Your eyes sting!",
+        "Your lungs burn!",
+        "You cough uncontrollably!",
+        "Your skin burns!",
+        "You gasp for air!"
+    };
+}

--- a/Content.Shared/_CMU14/Weapons/ChemicalIrritants/SharedChemicalIrritantSystem.cs
+++ b/Content.Shared/_CMU14/Weapons/ChemicalIrritants/SharedChemicalIrritantSystem.cs
@@ -1,0 +1,346 @@
+using Content.Shared._CMU14.GasMask;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Damage;
+using Content.Shared.Jittering;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Popups;
+using Content.Shared.Rejuvenate;
+using Content.Shared.StatusEffect;
+using Content.Shared.Storage;
+using Content.Shared._RMC14.BlurredVision;
+using Content.Shared._RMC14.Stun;
+using Content.Shared._RMC14.Slow;
+using Content.Shared._RMC14.Synth;
+using Content.Shared._RMC14.Xenonids;
+using Content.Shared._AU14.Abominations; 
+using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.Stunnable;
+using Content.Shared.Speech.EntitySystems;
+using Robust.Shared.Containers;
+using Robust.Shared.Network;
+using Robust.Shared.Physics.Events;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._CMU14.ChemicalIrritants;
+
+public abstract partial class SharedChemicalIrritantSystem : EntitySystem
+{
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private INetManager _net = default!;
+    [Dependency] private SharedStunSystem _stun = default!;
+    [Dependency] private MobStateSystem _mobState = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private SharedStutteringSystem _stutter = default!;
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private SharedJitteringSystem _jitter = default!;
+    [Dependency] private DamageableSystem _damage = default!;
+    [Dependency] private SharedContainerSystem _con = default!;
+    [Dependency] private ItemSlotsSystem _itemSlot = default!;
+    [Dependency] private SharedGasMaskSystem _mask = default!;
+    [Dependency] private StatusEffectQuerySystem _statusEffects = default!;
+    [Dependency] private RMCDazedSystem _daze = default!;
+    [Dependency] private RMCSlowSystem _slow = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ChemicalIrritantComponent, RejuvenateEvent>(OnRejuvenate);
+        SubscribeLocalEvent<ChemicalIrritantInjectorComponent, StartCollideEvent>(OnStartCollide);
+        SubscribeLocalEvent<ChemicalIrritantInjectorComponent, EndCollideEvent>(OnEndCollide);
+    }
+
+    private void OnRejuvenate(Entity<ChemicalIrritantComponent> ent, ref RejuvenateEvent args)
+    {
+        RemCompDeferred<ChemicalIrritantComponent>(ent);
+    }
+
+    private void OnStartCollide(Entity<ChemicalIrritantInjectorComponent> ent, ref StartCollideEvent args)
+    {
+        if (!HasComp<MobStateComponent>(args.OtherEntity))
+            return;
+
+        if (IsImmuneToIrritants(args.OtherEntity))
+            return;
+
+        // Server-only tracking set; no Dirty() needed.
+        ent.Comp.ContactedEntities.Add(args.OtherEntity);
+    }
+
+    private void OnEndCollide(Entity<ChemicalIrritantInjectorComponent> ent, ref EndCollideEvent args)
+    {
+        // Server-only tracking set; no Dirty() needed.
+        ent.Comp.ContactedEntities.Remove(args.OtherEntity);
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (_net.IsClient)
+            return;
+
+        var time = _timing.CurTime;
+
+        // Update injectors
+        var injectorQuery = EntityQueryEnumerator<ChemicalIrritantInjectorComponent>();
+
+        while (injectorQuery.MoveNext(out var uid, out var injector))
+        {
+            if (time < injector.NextGasInjectionAt)
+                continue;
+
+            injector.NextGasInjectionAt = time + injector.TimeBetweenGasInjects;
+
+            // Enforce finite capacity if set
+            if (injector.IrritantCapacity >= 0 && injector.IrritantUsed >= injector.IrritantCapacity)
+                continue;
+
+            foreach (var victim in injector.ContactedEntities)
+            {
+                if (!injector.AffectsDead && _mobState.IsDead(victim))
+                    continue;
+
+                ApplyIrritant(victim, injector);
+            }
+        }
+
+        // Update victims
+        var victimQuery = EntityQueryEnumerator<ChemicalIrritantComponent>();
+
+        while (victimQuery.MoveNext(out var uid, out var chem))
+        {
+            if (time < chem.NextIrritantEffectAt)
+                continue;
+
+            chem.NextIrritantEffectAt = time + chem.UpdateEvery;
+            UpdateIrritantExposure(uid, chem);
+        }
+    }
+
+    private void ApplyIrritant(EntityUid victim, ChemicalIrritantInjectorComponent injector)
+    {
+        if (IsImmuneToIrritants(victim))
+        return;
+
+        if (TryGetFilterFromMask(victim, out var filterId, out var filter))
+        {
+            var filterDamage = new GasMaskFilterDamageComponent
+            {
+                Damage = injector.FilterDamage,
+                Neurotoxin = injector.NeurotoxinFilterDamage
+            };
+
+            _mask.DamageFilter(filterId, filter, filterDamage);
+            return;
+        }
+
+        var time = _timing.CurTime;
+        var alreadyExposed = EnsureComp<ChemicalIrritantComponent>(victim, out var chem);
+
+        if (!alreadyExposed)
+        {
+            chem.LastMessage = time;
+            chem.NextIrritantEffectAt = time;
+            chem.Profile = injector.Profile;
+            chem.DepletionPerTick = injector.DepletionPerTick;
+        }
+
+        chem.IrritantAmount += injector.IrritantPerSecond;
+
+        if (injector.IrritantCapacity >= 0)
+            injector.IrritantUsed += injector.IrritantPerSecond;
+
+        Dirty(victim, chem);
+    }
+
+    private void UpdateIrritantExposure(EntityUid victim, ChemicalIrritantComponent chem)
+    {
+        var time = _timing.CurTime;
+        var profile = chem.Profile;
+
+        chem.IrritantAmount -= chem.DepletionPerTick;
+
+        if (chem.IrritantAmount <= 0)
+        {
+            RemCompDeferred<ChemicalIrritantComponent>(victim);
+            return;
+        }
+
+        Dirty(victim, chem);
+
+        if (chem.IrritantAmount < profile.EffectThreshold)
+            return;
+
+        // Eye irritation / screen darkening
+        _statusEffects.TryAddStatusEffect<RMCBlindedComponent>(
+            victim,
+            "Blinded",
+            profile.BlurTime,
+            true);
+
+        // Random pain jitter
+        if (_random.Prob(profile.JitterChance))
+            _jitter.DoJitter(victim, profile.JitterTime, true);
+
+        // Mild daze and coughing
+        if (_random.Prob(profile.DazeChance))
+        {
+            _daze.TryDaze(victim, profile.DazeTime, true, stutter: false);
+            _stutter.DoStutter(victim, profile.StutterTime, true);
+        }
+
+        // Breathing difficulty
+        if (_random.Prob(profile.SlowChance))
+            _slow.TrySlowdown(victim, profile.SlowTime);
+
+        // Damage (only if damage dict is non-empty)
+        if (profile.IrritantDamage.DamageDict.Count > 0)
+            _damage.TryChangeDamage(victim, profile.IrritantDamage);
+
+        // Heavy exposure: actual blindness
+        if (chem.IrritantAmount >= profile.BlindThreshold)
+        {
+            _statusEffects.TryAddStatusEffect<TemporaryBlindnessComponent>(
+                victim,
+                "TemporaryBlindness",
+                profile.BlindTime,
+                true);
+        }
+
+        // Severe exposure
+        if (chem.IrritantAmount >= profile.SevereThreshold)
+        {
+            _daze.TryDaze(victim, profile.DazeTime, true, stutter: false);
+            _stutter.DoStutter(victim, profile.StutterTime, true);
+
+            if (_random.Prob(profile.SevereSlowChance))
+                _slow.TrySlowdown(victim, profile.SevereSlowTime);
+        }
+        // High-dose trip/fall
+        if (chem.IrritantAmount >= profile.TripThreshold &&
+            _random.Prob(profile.TripChance) &&
+            time - chem.LastTripTime >= profile.MinimumDelayBetweenTrips)
+        {
+            chem.LastTripTime = time;
+            _stun.TryParalyze(victim, profile.TripStunTime, true);
+
+            _popup.PopupEntity(Loc.GetString("You stumble and trip."), victim, victim, PopupType.MediumCaution);
+        }   
+
+        // Exposure message (rate-limited)
+        if (time >= chem.LastMessage + chem.TimeBetweenMessages)
+        {
+            chem.LastMessage = time;
+
+            var message = _random.Pick(profile.ExposureMessages);
+
+            _popup.PopupEntity(
+                message,
+                victim,
+                victim,
+                PopupType.SmallCaution);
+        }
+    }
+
+    private bool IsImmuneToIrritants(EntityUid victim)
+    {
+        return HasComp<SynthComponent>(victim)
+            || HasComp<XenoComponent>(victim)
+            || HasComp<AbominationComponent>(victim);
+    }
+    private bool TryGetFilterFromMask(EntityUid victim, out EntityUid filterId, out GasMaskFilterComponent filter)
+    {
+        filterId = EntityUid.Invalid;
+        filter = null!;
+
+        if (!TryComp<ContainerManagerComponent>(victim, out var manager))
+            return false;
+
+        // Check direct mask slot
+        if (_con.TryGetContainer(victim, "mask", out var maskContainer, manager))
+        {
+            foreach (var maskItem in maskContainer.ContainedEntities)
+            {
+                if (TryGetFilterFromItem(maskItem, out filterId, out filter))
+                    return true;
+            }
+        }
+
+        // Check gas mask stored inside helmet accessory (head slot -> storage -> item with filter)
+        if (_con.TryGetContainer(victim, "head", out var headContainer, manager))
+        {
+            foreach (var headItem in headContainer.ContainedEntities)
+            {
+                if (!TryComp<StorageComponent>(headItem, out var storage) || storage.Container is null)
+                    continue;
+
+                foreach (var accessory in storage.Container.ContainedEntities)
+                {
+                    if (TryGetFilterFromItem(accessory, out filterId, out filter))
+                        return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private bool TryGetFilterFromItem(EntityUid item, out EntityUid filterId, out GasMaskFilterComponent filter)
+    {
+        filterId = EntityUid.Invalid;
+        filter = null!;
+
+        if (!TryComp<ItemSlotsComponent>(item, out var slots))
+            return false;
+
+        if (!_itemSlot.TryGetSlot(item, "filter", out var slot, slots))
+            return false;
+
+        if (slot.ContainerSlot?.ContainedEntity is not EntityUid filterUid)
+            return false;
+
+        if (!TryComp<GasMaskFilterComponent>(filterUid, out var filterComp))
+            return false;
+
+        if (filterComp.Integrity <= 0)
+            return false;
+
+        filterId = filterUid;
+        filter = filterComp;
+        return true;
+    }
+
+    /// <summary>
+    /// Applies irritant directly to a victim without going through an injector entity.
+    /// Uses the victim's existing profile if already exposed, or default values otherwise.
+    /// </summary>
+    public void ApplyIrritantDirect(
+        EntityUid victim,
+        float amount,
+        ChemicalIrritantProfile profile,
+        float? depletionPerTick = null)
+    {
+        if (IsImmuneToIrritants(victim))
+            return;
+        
+        if (TryGetFilterFromMask(victim, out _, out _))
+            return;
+
+        var alreadyExposed = EnsureComp<ChemicalIrritantComponent>(victim, out var chem);
+
+        if (!alreadyExposed)
+        {
+            var time = _timing.CurTime;
+            chem.LastMessage = time;
+            chem.NextIrritantEffectAt = time;
+            chem.Profile = profile;
+
+            if (depletionPerTick != null)
+                chem.DepletionPerTick = depletionPerTick.Value;
+        }
+
+        chem.IrritantAmount += amount;
+        Dirty(victim, chem);
+    }
+}

--- a/Resources/Prototypes/_CMU14/Entities/Objects/Misc/teargassmoke.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/Misc/teargassmoke.yml
@@ -1,7 +1,6 @@
 - type: entity
   id: CMU14TearGas
   name: Tear Gas
-  #categories: [ HideSpawnMenu ]
   components:
   - type: Transform
     anchored: true
@@ -36,37 +35,23 @@
   - type: EvenSmoke
     spawn: CMU14TearGas
     range: 2
-
-    #values tweaked to remove damage and prioritize incapacitating without any ouchies since it's meant to be a crowd control nade
-  - type: NeurotoxinInjector
-    neuroPerSecond: 2.3
-    #current neuro allows for someone who stands in the gas for the entire duration to get knocked out but without the hallucinations of CAS/mortar
+  - type: ChemicalIrritantInjector
+    irritantPerSecond: 7
     affectsDead: false
-    affectsInfectedNested: false
-    toxinDamage:
-        groups:
-          Toxin: 0
-    oxygenDamage:
-        types:
-          Asphyxiation: 0
-    coughDamage:
-        groups:
-          Brute: 0
-
-    #just makes it so that you have audible feedback upon inhaling smoke
-  - type: DamageOverTime
-    affectsDead: false
-    affectsInfectedNested: false
-    emotes:
-    - Cough
-    - Gasp
-  
+    filterDamage: 2
+    depletionPerTick: 1
+    profile:
+      irritantType: tear_gas
+      effectThreshold: 1
+      blindThreshold: 15
+      severeThreshold: 18
+      tripThreshold: 15
+      tripChance: 0.12
+      tripStunTime: 1.5
+      blurTime: 5
+      blindTime: 1
+      minimumDelayBetweenTrips: 6
   - type: DeleteOnExplosion
-
-  #current values allow for a unit with a HAZOPS gas mask filter to stand within the duration of 4 and a half tear gas nades 
-  - type: GasMaskFilterDamage
-    damage: 0.5
-    neurotoxin: true
 
 
 - type: entity
@@ -76,6 +61,8 @@
   components:
   - type: TimedDespawn
     lifetime: 6
+  - type: EdgeSpreader
+    id: CMU14InstantTearGas
 
 
 - type: edgeSpreader


### PR DESCRIPTION
## About the PR
Allo, i've always wanted to use tear gas without being affected while wearing gas masks (i think it'd be so cool to throw gas at rioters and then emerge past it without care). With that in mind, I spent like a week or so studying and trying to create a system for it (also lowkey praying it actually works outside of a localhost dev env...)

## Why / Balance
Right now, tear gas and CN20 can be used to force crowds to disperse but is a double-edged blade because gas masks don't do anything. With this, it'll allow individuals with gas masks AND filters to just walk through the gas without being debuffed (albeit filter takes damage) so GOVFOR can march past tear gas to arrest anyone OR CLF can toss CN20 and use it as hit-and-run cover while wearing gas masks against unprepared GOVFOR

## Technical details
added 4 files to Content.Shared\_CMU14\Weapons\ChemicalIrritants\

-ChemicalIrritantProfile.cs which is a list of settings that describe how an gas behaves

-ChemicalIrritantInjectorComponent.cs which is attached to the gas cloud, tracks who it's touching and how much gas it has left (planning to use this for pepper spray or smthn)

-ChemicalIrritantComponent.cs attached to the victim, tracks how much gas they've absorbed.

-SharedChemicalIrritantSystem.cs which is a fork(?) of the neurotoxin system used by boiler's neuro gas but with different effects and modularity

Added 1 file to Content.Server\_CMU14\Weapons

-ChemicalIrritantSystem.cs needed to actually run the chemicalirritant system

Tweaked 1 file
teargassmoke.yml to work with new system instead of the xeno neurotoxin

Additionally, the system is modular so you can now make new gases with varying intensity of effects through YAML only 

## Media
https://youtu.be/m2NbZMKTWM0

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Tear gas now respects gas masks with filters. Wearing a gas mask with a filter lets you walk through chemical gas unaffected, though the filter takes damage.
- tweak: Tear gas smoke now uses the new ChemicalIrritant system instead of the xeno neurotoxin system.