### PR TITLE
Third Party Fix

### DIFF
--- a/.github/map_checker/matchers.yml
+++ b/.github/map_checker/matchers.yml
@@ -26,6 +26,7 @@
   entityMatchers:
   - ".*"
 
+# ├──[ Prototypes marked with suffix "Don't Map" ]───────────────────┤
 - id: "DoNotMapSpecifiers"
   type: "Blacklist"
   entityMatchers:
@@ -35,23 +36,37 @@
   - "RMCBottleAntiZed"
   - "RMCBlackGooGlass.*"
 
-- id: "AllowApprovedDeniedStamps"
-  type: "Whitelist"
-  entityMatchers:
-  - "CMStamp(Approved|Denied)"
-
+# ├──[ Legacy Map Stamps support - should remove them instead ]──────┤
 - id: "AllowFactionStamps"
   type: "Whitelist"
   entityMatchers:
   - "CMStamp(Liaison|CO|QM)"
   - "RMCStamp(FreePress|TSE|SPP|CLF)"
 
+# ├──[ Legacy Approved/Denied Stamps - remove them for AU14Stamp ]───┤
+- id: "AllowApprovedDeniedStamps"
+  type: "Whitelist"
+  entityMatchers:
+  - "CMStamp(Approved|Denied)"
+
+# ├──[ Warships ]────────────────────────────────────────────────────┤
 - id: "USSBushWarship"
   type: "Whitelist"
   on_paths:
   - "USSBush_above.yml"
   - "USSBush.yml"
   - "USSBush_below.yml"
+  entityMatchers:
+  - "CMStamp.*"
+
+- id: "USSBushWarshipRedux"
+  type: "Whitelist"
+  on_paths:
+  - "USSBushReworkFinalize0"
+  - "USSBushReworkFinalize-1"
+  - "USSBushReworkFinalize1"
+  - "USSBushReworkFinalize2"
+  - "USSBushReworkFinalize3"
   entityMatchers:
   - "CMStamp.*"
 
@@ -64,6 +79,7 @@
   entityMatchers:
   - "CMStamp.*"
 
+# ├──[ Plushies ]────────────────────────────────────────────────────┤
 - id: "AllowedPlushies"
   type: "Whitelist"
   entityMatchers:
@@ -71,11 +87,13 @@
   - "RMCPlushieSharkBlue"
   - "RMCPlushieGnarpGnarp"
 
+# ├──[ Figurines ]───────────────────────────────────────────────────┤
 - id: "RemoveFigurines"
   type: "Blacklist"
   entityMatchers:
   - "RMCFigurine.*"
 
+# ├──[ Comms / Sensor Towers ]───────────────────────────────────────┤
 - id: "SensorCommsTowers"
   type: "Blacklist"
   entityMatchers:
@@ -86,3 +104,17 @@
   type: "Whitelist"
   entityMatchers:
   - "RMCCommunicationsTowerProp.*"
+
+# ├──[ Unused Vending Machines (base ss14) ]─────────────────────────┤
+- id: "BaseGameVendingMachines"
+  type: "Blacklist"
+  entityMatchers:
+    - "VendingMachine(Engi|Booze|Cart|Chef|Dinner|Med|Nutri|Sec|Robotics|Salvage|WallMed|HappyHonk|Chemicals|Chapel).*"
+    - "VendingMachineSeeds"     # there's also SeedsUnlocked
+    - "VendingMachine.*robe.*"  # secdrobe, lawdrobe, hydrobe, etc.
+
+# ├──[ ColMarTech Vendors ]──────────────────────────────────────────┤
+# - id: "ColMarTechVendors"
+#   type: "Blacklist"
+#   entityMatchers:
+#   - "ColMarTech.*"

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapControl.xaml.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapControl.xaml.cs
@@ -530,13 +530,15 @@ public sealed partial class TacticalMapControl : TextureRect
             // Attempt to get the background frame. If this fails (RSI missing/corrupt), skip blip drawing.
             background = system.Frame0(backgroundRsi);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             // Don't let a resource failure crash the entire UI. Skip drawing blips.
             DrawModeBorder(handle, Vector2.Zero, Vector2.Zero, 1f); // still draw border if appropriate
             DrawLines(handle, 1f, Vector2.Zero);
             DrawPreviewLine(handle, 1f, Vector2.Zero);
             DrawLabels(handle, 1f, Vector2.Zero);
+
+            Logger.GetSawmill("tacmap").Error($"[DrawBackgrounds] Failed to render backgrounds (missing/corrupt RSI): {ex}");
             return;
         }
 
@@ -546,15 +548,14 @@ public sealed partial class TacticalMapControl : TextureRect
         handle.DrawTextureRect(Texture, textureRect);
 
         DrawModeBorder(handle, actualTopLeft, actualSize, overlayScale);
-        // Wrap DrawBlips in a try/catch as an extra safety net for any runtime resource issues.
         try
         {
+            // Wrap DrawBlips in a try/catch as an extra safety net for any runtime resource issues.
             DrawBlips(handle, system, background, defibbableRsi, defibbableRsi2, defibbableRsi3, defibbableRsi4, undefibbableRsi, hiveLeaderRsi, actualTopLeft, overlayScale, curTime);
         }
-        catch (Exception)
-        {
-            // swallow—blips are non-critical; the rest of the UI should render.
-        }
+        // swallow—blips are non-critical; the rest of the UI should render.
+        catch (Exception ex) { Logger.GetSawmill("tacmap").Error($"[DrawBlips] Failed to run: {ex}"); }
+
         DrawLines(handle, overlayScale, actualTopLeft);
         DrawPreviewLine(handle, overlayScale, actualTopLeft);
         DrawLabels(handle, overlayScale, actualTopLeft);
@@ -600,30 +601,26 @@ public sealed partial class TacticalMapControl : TextureRect
             float scaledBlipSize = GetScaledBlipSize(overlayScale);
             UIBox2 rect = UIBox2.FromDimensions(position, new Vector2(scaledBlipSize, scaledBlipSize));
 
-            // Draw background / base frame but protect against resource failures per-frame
             try
             {
+                // Draw background / base frame but protect against resource failures per-frame
                 Texture bgTex = blip.Background != null ? system.GetFrame(blip.Background, curTime) : background;
                 handle.DrawTextureRect(bgTex, rect, blip.Color);
             }
-            catch (Exception)
-            {
-                // ignore and continue—don't crash the UI for missing background frames
-            }
+            // ignore and continue—don't crash the UI for missing background frames
+            catch (Exception ex) { Logger.GetSawmill("tacmap").Error($"[DrawBackground] Failed to render (missing background frames): {ex}"); }
 
-            // Draw main blip image safely
             try
             {
+                // Draw main blip image safely
                 if (blip.Image != null)
                 {
                     var frame = system.GetFrame(blip.Image, curTime);
                     handle.DrawTextureRect(frame, rect);
                 }
             }
-            catch (Exception)
-            {
-                // skip drawing this blip image if the frame cannot be loaded
-            }
+            // skip drawing this blip image if the frame cannot be loaded
+            catch (Exception ex) { Logger.GetSawmill("tacmap").Error($"[DrawBlips] Failed to render (missing/corrupt blip image): {ex}"); }
 
             if (_localPlayerEntityId.HasValue && _blipEntityIds != null && i < _blipEntityIds.Length)
             {
@@ -640,10 +637,7 @@ public sealed partial class TacticalMapControl : TextureRect
                     var hiveTex = system.GetFrame(hiveLeaderRsi, curTime);
                     handle.DrawTextureRect(hiveTex, rect);
                 }
-                catch (Exception)
-                {
-                    // ignore
-                }
+                catch (Exception ex) { Logger.GetSawmill("tacmap").Error($"[DrawBlips] Failed to render HiveLeader (missing/corrupt blip): {ex}"); }
             }
 
             var defibTexture = blip.Status switch
@@ -663,10 +657,7 @@ public sealed partial class TacticalMapControl : TextureRect
                     if (dtex != null)
                         handle.DrawTextureRect(dtex, rect);
                 }
-                catch (Exception)
-                {
-                    // ignore
-                }
+                catch (Exception ex) { Logger.GetSawmill("tacmap").Error($"[DrawBlips] Failed to render defibTexture (missing/corrupt blip): {ex}"); }
             }
 
             if (blip.OccupantCount > 0)
@@ -682,9 +673,7 @@ public sealed partial class TacticalMapControl : TextureRect
                     handle.DrawRect(badgeRect, Color.Black.WithAlpha(0.75f));
                     handle.DrawString(countFont, badgeOrigin, countText, Color.White);
                 }
-                catch (Exception)
-                {
-                }
+                catch (Exception ex) { Logger.GetSawmill("tacmap").Error($"[DrawBlips] Failed to render vehicle OccupantCount (missing/corrupt blip/font or count): {ex}"); }
             }
 
             if (blip.FireteamNumber > 0)
@@ -700,9 +689,7 @@ public sealed partial class TacticalMapControl : TextureRect
                     handle.DrawRect(badgeRect, Color.Black.WithAlpha(0.75f));
                     handle.DrawString(ftFont, badgeOrigin, ftText, Color.White);
                 }
-                catch (Exception)
-                {
-                }
+                catch (Exception ex) { Logger.GetSawmill("tacmap").Error($"[DrawBlips] Failed to render Fireteam numbers (missing/corrupt blip/font or fireteam): {ex}"); }
             }
         }
     }

--- a/Content.Server/AU14/ThirdParty/AuThirdPartySystem.cs
+++ b/Content.Server/AU14/ThirdParty/AuThirdPartySystem.cs
@@ -37,7 +37,6 @@ public sealed partial class AuThirdPartySystem : EntitySystem
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IEntityManager _entityManager = default!;
     [Dependency] private MapLoaderSystem _mapLoader = default!;
-    private readonly ISawmill _sawmill = Logger.GetSawmill("thirdparty");
     [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private AuRoundSystem _auRoundSystem = default!;
     [Dependency] private ChatSystem _chat = default!;
@@ -47,6 +46,7 @@ public sealed partial class AuThirdPartySystem : EntitySystem
     [Dependency] private MetaDataSystem _metaData = default!;
     [Dependency] private IdCardSystem _idCard = default!;
     [Dependency] private IdentitySystem _identity = default!;
+    private readonly ISawmill _sawmill = Logger.GetSawmill("thirdparty");
 
     // --- State for round third party spawning ---
     private ThreatPrototype? _currentThreat;
@@ -305,48 +305,48 @@ public sealed partial class AuThirdPartySystem : EntitySystem
         {
             // Only check main-map/groundside markers; dropship spawns handled elsewhere via useDropship
 
-                var markerCoords = _entityManager.GetComponent<TransformComponent>(marker).Coordinates;
-                _sawmill.Debug($"[AuThirdPartySystem] Checking marker {marker} at coords {markerCoords}");
+            var markerCoords = _entityManager.GetComponent<TransformComponent>(marker).Coordinates;
+            _sawmill.Debug($"[AuThirdPartySystem] Checking marker {marker} at coords {markerCoords}");
 
-                foreach (var session in _playerManager.Sessions)
+            foreach (var session in _playerManager.Sessions)
+            {
+                if (!session.AttachedEntity.HasValue)
                 {
-                    if (!session.AttachedEntity.HasValue)
-                    {
-                        _sawmill.Debug($"[AuThirdPartySystem] Session has no attached entity, skipping");
-                        continue;
-                    }
-
-                    var attached = session.AttachedEntity.Value;
-                    _sawmill.Debug($"[AuThirdPartySystem] Found attached entity {attached} for session");
-
-                    // Skip ghosts
-                    if (_entityManager.HasComponent<GhostComponent>(attached))
-                    {
-                        _sawmill.Debug($"[AuThirdPartySystem] Attached entity {attached} is a ghost, skipping");
-                        continue;
-                    }
-
-                    if (!_entityManager.TryGetComponent<TransformComponent>(attached, out var playerXform))
-                    {
-                        _sawmill.Debug($"[AuThirdPartySystem] Could not get TransformComponent for attached entity {attached}, skipping");
-                        continue;
-                    }
-
-                    // Log check steps for debugging
-                    _sawmill.Debug($"[AuThirdPartySystem] Checking player {attached} for proximity to marker {marker} (player coords={playerXform.Coordinates}, marker coords={markerCoords})");
-
-                    if (_transform.InRange(playerXform.Coordinates, markerCoords, PlayerAvoidRadius))
-                    {
-                        _sawmill.Debug($"[AuThirdPartySystem] Marker {marker} is blocked by player {attached} within radius {PlayerAvoidRadius}");
-                        return true;
-                    }
-                    else
-                    {
-                        _sawmill.Debug($"[AuThirdPartySystem] Player {attached} not within avoid radius of marker {marker}");
-                    }
+                    _sawmill.Debug($"[AuThirdPartySystem] Session has no attached entity, skipping");
+                    continue;
                 }
 
-                return false;
+                var attached = session.AttachedEntity.Value;
+                _sawmill.Debug($"[AuThirdPartySystem] Found attached entity {attached} for session");
+
+                // Skip ghosts
+                if (_entityManager.HasComponent<GhostComponent>(attached))
+                {
+                    _sawmill.Debug($"[AuThirdPartySystem] Attached entity {attached} is a ghost, skipping");
+                    continue;
+                }
+
+                if (!_entityManager.TryGetComponent<TransformComponent>(attached, out var playerXform))
+                {
+                    _sawmill.Debug($"[AuThirdPartySystem] Could not get TransformComponent for attached entity {attached}, skipping");
+                    continue;
+                }
+
+                // Log check steps for debugging
+                _sawmill.Debug($"[AuThirdPartySystem] Checking player {attached} for proximity to marker {marker} (player coords={playerXform.Coordinates}, marker coords={markerCoords})");
+
+                if (_transform.InRange(playerXform.Coordinates, markerCoords, PlayerAvoidRadius))
+                {
+                    _sawmill.Debug($"[AuThirdPartySystem] Marker {marker} is blocked by player {attached} within radius {PlayerAvoidRadius}");
+                    return true;
+                }
+                else
+                {
+                    _sawmill.Debug($"[AuThirdPartySystem] Player {attached} not within avoid radius of marker {marker}");
+                }
+            }
+
+            return false;
         }
 
 
@@ -371,8 +371,8 @@ public sealed partial class AuThirdPartySystem : EntitySystem
         var spawnedLeaders = new List<EntityUid>();
         var spawnedGrunts = new List<EntityUid>();
         var SpawnedEnts = new List<EntityUid>();
-         // Track the last marker we used during this spawn operation
-         EntityUid? lastUsedMarker = null;
+        // Track the last marker we used during this spawn operation
+        EntityUid? lastUsedMarker = null;
         // Before spawning, verify we have enough unused markers for each required type. If not, abort the spawn.
         var leaderReq = spawnProto.LeadersToSpawn.Values.Sum();
         var gruntReq = spawnProto.GruntsToSpawn.Values.Sum();
@@ -467,8 +467,8 @@ public sealed partial class AuThirdPartySystem : EntitySystem
                     Dirty(marker, lmComp);
                 }
                 // Parachute markers are intentionally NOT marked as used so they may be reused.
-                 lastUsedMarker = marker;
-                 _sawmill.Debug($"[AuThirdPartySystem] Spawned leader {protoId} at {coords} (entity {ent})");
+                lastUsedMarker = marker;
+                _sawmill.Debug($"[AuThirdPartySystem] Spawned leader {protoId} at {coords} (entity {ent})");
             }
         }
         _sawmill.Debug($"[AuThirdPartySystem] Spawning grunts...");
@@ -505,16 +505,16 @@ public sealed partial class AuThirdPartySystem : EntitySystem
                         RaiseLocalEvent(gridEntity, ref attemptEvent);
                     }
                 }
-                 spawnedGrunts.Add(ent);
-                 // Mark this marker's component as used (do NOT mark neighbors yet)
-                 if (_entityManager.TryGetComponent<ThreatSpawnMarkerComponent>(marker, out var gmComp) && !gmComp.Used)
-                 {
-                     gmComp.Used = true;
-                     Dirty(marker, gmComp);
-                 }
-                 // Parachute markers are intentionally NOT marked as used so they may be reused.
-                  lastUsedMarker = marker;
-                  _sawmill.Debug($"[AuThirdPartySystem] Spawned grunt {protoId} at {coords} (entity {ent})");
+                spawnedGrunts.Add(ent);
+                // Mark this marker's component as used (do NOT mark neighbors yet)
+                if (_entityManager.TryGetComponent<ThreatSpawnMarkerComponent>(marker, out var gmComp) && !gmComp.Used)
+                {
+                    gmComp.Used = true;
+                    Dirty(marker, gmComp);
+                }
+                // Parachute markers are intentionally NOT marked as used so they may be reused.
+                lastUsedMarker = marker;
+                _sawmill.Debug($"[AuThirdPartySystem] Spawned grunt {protoId} at {coords} (entity {ent})");
             }
         }
         _sawmill.Debug($"[AuThirdPartySystem] Spawning ents...");
@@ -551,16 +551,16 @@ public sealed partial class AuThirdPartySystem : EntitySystem
                         RaiseLocalEvent(gridEntity, ref attemptEvent);
                     }
                 }
-                 SpawnedEnts.Add(ent);
-                 // Mark this marker's component as used (do NOT mark neighbors yet)
-                 if (_entityManager.TryGetComponent<ThreatSpawnMarkerComponent>(marker, out var emComp) && !emComp.Used)
-                 {
-                     emComp.Used = true;
-                     Dirty(marker, emComp);
-                 }
-                 // Parachute markers are intentionally NOT marked as used so they may be reused.
-                  lastUsedMarker = marker;
-                  _sawmill.Debug($"[AuThirdPartySystem] Spawned ent {protoId} at {coords} (entity {ent})");
+                SpawnedEnts.Add(ent);
+                // Mark this marker's component as used (do NOT mark neighbors yet)
+                if (_entityManager.TryGetComponent<ThreatSpawnMarkerComponent>(marker, out var emComp) && !emComp.Used)
+                {
+                    emComp.Used = true;
+                    Dirty(marker, emComp);
+                }
+                // Parachute markers are intentionally NOT marked as used so they may be reused.
+                lastUsedMarker = marker;
+                _sawmill.Debug($"[AuThirdPartySystem] Spawned ent {protoId} at {coords} (entity {ent})");
             }
         }
 
@@ -790,7 +790,4 @@ public sealed partial class AuThirdPartySystem : EntitySystem
             }
         }
     }
-
-
 }
-

--- a/Content.Server/AU14/ThirdParty/AuThirdPartySystem.cs
+++ b/Content.Server/AU14/ThirdParty/AuThirdPartySystem.cs
@@ -1,33 +1,30 @@
 using System.Linq;
 using Content.Server.Access.Systems;
+using Content.Server.AU14.Round;
+using Content.Server.AU14.VendorMarker;
+using Content.Server.Chat.Systems;
+using Content.Server.GameTicking;
 using Content.Server.IdentityManagement;
 using Content.Server.Preferences.Managers;
-using Content.Server.AU14.Round;
-using Content.Shared.AU14.Threats;
-using Content.Shared.Access.Systems;
-using Robust.Shared.Map;
-using Content.Shared.Roles;
-using Content.Shared.Mind;
-using Content.Server.GameTicking;
+using Content.Shared._RMC14.CrashLand;
 using Content.Shared._RMC14.Dropship;
+using Content.Shared.AU14.Threats;
 using Content.Shared.AU14.util;
+using Content.Shared.Ghost;
+using Content.Shared.Humanoid;
+using Content.Shared.Mind;
+using Content.Shared.ParaDrop;
 using Content.Shared.Players;
 using Content.Shared.Preferences;
-using Robust.Shared.Random;
+using Content.Shared.Roles;
 using Robust.Server.Player;
+using Robust.Shared.EntitySerialization;
 using Robust.Shared.EntitySerialization.Systems;
+using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
-using Robust.Server.GameObjects;
-using Content.Server.AU14.VendorMarker;
-using Content.Shared.Ghost;
-using Content.Shared.Humanoid;
-using Content.Shared.ParaDrop;
-using Content.Shared._RMC14.CrashLand;
-using Content.Server.Chat.Systems;
-using Robust.Shared.Timing;
-using Robust.Shared.EntitySerialization;
+using Robust.Shared.Random;
 
 namespace Content.Server.AU14.ThirdParty;
 
@@ -435,40 +432,48 @@ public sealed partial class AuThirdPartySystem : EntitySystem
                         marker = PickSafeMarker(leaderMarkers);
                     else
                         marker = safe[_random.Next(safe.Count)];
+
                     leaderMarkers.Remove(marker);
                 }
                 else
-                {
                     marker = useDropship ? leaderMarkers[_random.Next(leaderMarkers.Count)] : PickSafeMarker(leaderMarkers);
-                }
-                var coords = _entityManager.GetComponent<TransformComponent>(marker).Coordinates;
-                var ent = _entityManager.SpawnEntity(protoId, coords);
-                // If parachute mode, hand off to the shared paradrop system so the entity falls from the sky.
-                if (parachuteMode)
-                {
-                    // Ensure the entity is paradroppable; SharedParaDropSystem will fall back to crash-land if missing.
-                    var paraComp = EnsureComp<ParaDroppableComponent>(ent);
-                    Dirty(ent, paraComp);
 
-                    // Raise AttemptCrashLandEvent on the grid entity that the parachute marker resides on so the para-drop handler will run.
-                    var markerXform = _entityManager.GetComponent<TransformComponent>(marker);
-                    if (markerXform.GridUid.HasValue)
-                    {
-                        var gridEntity = markerXform.GridUid.Value;
-                        var attemptEvent = new Content.Shared._RMC14.CrashLand.AttemptCrashLandEvent(ent);
-                        RaiseLocalEvent(gridEntity, ref attemptEvent);
-                    }
-                }
-                spawnedLeaders.Add(ent);
-                // Mark this marker's component as used (do NOT mark neighbors yet)
-                if (_entityManager.TryGetComponent<ThreatSpawnMarkerComponent>(marker, out var lmComp) && !lmComp.Used)
+                var coords = _entityManager.GetComponent<TransformComponent>(marker).Coordinates;
+                try
                 {
-                    lmComp.Used = true;
-                    Dirty(marker, lmComp);
+                    EntityUid ent = _entityManager.SpawnEntity(protoId, coords);
+                    // If parachute mode, hand off to the shared paradrop system so the entity falls from the sky.
+                    if (parachuteMode)
+                    {
+                        // Ensure the entity is paradroppable; SharedParaDropSystem will fall back to crash-land if missing.
+                        var paraComp = EnsureComp<ParaDroppableComponent>(ent);
+                        Dirty(ent, paraComp);
+
+                        // Raise AttemptCrashLandEvent on the grid entity that the parachute marker resides on so the para-drop handler will run.
+                        var markerXform = _entityManager.GetComponent<TransformComponent>(marker);
+                        if (markerXform.GridUid.HasValue)
+                        {
+                            var gridEntity = markerXform.GridUid.Value;
+                            var attemptEvent = new AttemptCrashLandEvent(ent);
+                            RaiseLocalEvent(gridEntity, ref attemptEvent);
+                        }
+                    }
+                    spawnedLeaders.Add(ent);
+                    // Mark this marker's component as used (do NOT mark neighbors yet)
+                    if (_entityManager.TryGetComponent<ThreatSpawnMarkerComponent>(marker, out var lmComp) && !lmComp.Used)
+                    {
+                        lmComp.Used = true;
+                        Dirty(marker, lmComp);
+                    }
+                    // Parachute markers are intentionally NOT marked as used so they may be reused.
+                    lastUsedMarker = marker;
+                    _sawmill.Debug($"[AuThirdPartySystem] Spawned leader {protoId} at {coords} (entity {ent})");
                 }
-                // Parachute markers are intentionally NOT marked as used so they may be reused.
-                lastUsedMarker = marker;
-                _sawmill.Debug($"[AuThirdPartySystem] Spawned leader {protoId} at {coords} (entity {ent})");
+                catch (Exception ex)
+                {
+                    _sawmill.Error($"[AuThirdPartySystem] Failed to spawn leader ({protoId})! {ex.Message}");
+                    continue;
+                }
             }
         }
         _sawmill.Debug($"[AuThirdPartySystem] Spawning grunts...");
@@ -491,30 +496,38 @@ public sealed partial class AuThirdPartySystem : EntitySystem
                     marker = useDropship ? gruntMarkers[_random.Next(gruntMarkers.Count)] : PickSafeMarker(gruntMarkers);
                 }
                 var coords = _entityManager.GetComponent<TransformComponent>(marker).Coordinates;
-                var ent = _entityManager.SpawnEntity(protoId, coords);
-                if (parachuteMode)
+                try
                 {
-                    var paraComp = EnsureComp<ParaDroppableComponent>(ent);
-                    Dirty(ent, paraComp);
-
-                    var markerXform = _entityManager.GetComponent<TransformComponent>(marker);
-                    if (markerXform.GridUid.HasValue)
+                    EntityUid ent = _entityManager.SpawnEntity(protoId, coords);
+                    if (parachuteMode)
                     {
-                        var gridEntity = markerXform.GridUid.Value;
-                        var attemptEvent = new Content.Shared._RMC14.CrashLand.AttemptCrashLandEvent(ent);
-                        RaiseLocalEvent(gridEntity, ref attemptEvent);
+                        var paraComp = EnsureComp<ParaDroppableComponent>(ent);
+                        Dirty(ent, paraComp);
+
+                        var markerXform = _entityManager.GetComponent<TransformComponent>(marker);
+                        if (markerXform.GridUid.HasValue)
+                        {
+                            var gridEntity = markerXform.GridUid.Value;
+                            var attemptEvent = new AttemptCrashLandEvent(ent);
+                            RaiseLocalEvent(gridEntity, ref attemptEvent);
+                        }
                     }
+                    spawnedGrunts.Add(ent);
+                    // Mark this marker's component as used (do NOT mark neighbors yet)
+                    if (_entityManager.TryGetComponent<ThreatSpawnMarkerComponent>(marker, out var gmComp) && !gmComp.Used)
+                    {
+                        gmComp.Used = true;
+                        Dirty(marker, gmComp);
+                    }
+                    // Parachute markers are intentionally NOT marked as used so they may be reused.
+                    lastUsedMarker = marker;
+                    _sawmill.Debug($"[AuThirdPartySystem] Spawned grunt {protoId} at {coords} (entity {ent})");
                 }
-                spawnedGrunts.Add(ent);
-                // Mark this marker's component as used (do NOT mark neighbors yet)
-                if (_entityManager.TryGetComponent<ThreatSpawnMarkerComponent>(marker, out var gmComp) && !gmComp.Used)
+                catch (Exception ex)
                 {
-                    gmComp.Used = true;
-                    Dirty(marker, gmComp);
+                    _sawmill.Error($"[AuThirdPartySystem] Failed to spawn grunt ({protoId})! {ex.Message}");
+                    continue;
                 }
-                // Parachute markers are intentionally NOT marked as used so they may be reused.
-                lastUsedMarker = marker;
-                _sawmill.Debug($"[AuThirdPartySystem] Spawned grunt {protoId} at {coords} (entity {ent})");
             }
         }
         _sawmill.Debug($"[AuThirdPartySystem] Spawning ents...");
@@ -537,30 +550,38 @@ public sealed partial class AuThirdPartySystem : EntitySystem
                     marker = useDropship ? entityMarkers[_random.Next(entityMarkers.Count)] : PickSafeMarker(entityMarkers);
                 }
                 var coords = _entityManager.GetComponent<TransformComponent>(marker).Coordinates;
-                var ent = _entityManager.SpawnEntity(protoId, coords);
-                if (parachuteMode)
+                try
                 {
-                    var paraComp = EnsureComp<ParaDroppableComponent>(ent);
-                    Dirty(ent, paraComp);
-
-                    var markerXform = _entityManager.GetComponent<TransformComponent>(marker);
-                    if (markerXform.GridUid.HasValue)
+                    EntityUid ent = _entityManager.SpawnEntity(protoId, coords);
+                    if (parachuteMode)
                     {
-                        var gridEntity = markerXform.GridUid.Value;
-                        var attemptEvent = new Content.Shared._RMC14.CrashLand.AttemptCrashLandEvent(ent);
-                        RaiseLocalEvent(gridEntity, ref attemptEvent);
+                        var paraComp = EnsureComp<ParaDroppableComponent>(ent);
+                        Dirty(ent, paraComp);
+
+                        var markerXform = _entityManager.GetComponent<TransformComponent>(marker);
+                        if (markerXform.GridUid.HasValue)
+                        {
+                            var gridEntity = markerXform.GridUid.Value;
+                            var attemptEvent = new AttemptCrashLandEvent(ent);
+                            RaiseLocalEvent(gridEntity, ref attemptEvent);
+                        }
                     }
+                    SpawnedEnts.Add(ent);
+                    // Mark this marker's component as used (do NOT mark neighbors yet)
+                    if (_entityManager.TryGetComponent<ThreatSpawnMarkerComponent>(marker, out var emComp) && !emComp.Used)
+                    {
+                        emComp.Used = true;
+                        Dirty(marker, emComp);
+                    }
+                    // Parachute markers are intentionally NOT marked as used so they may be reused.
+                    lastUsedMarker = marker;
+                    _sawmill.Debug($"[AuThirdPartySystem] Spawned ent {protoId} at {coords} (entity {ent})");
                 }
-                SpawnedEnts.Add(ent);
-                // Mark this marker's component as used (do NOT mark neighbors yet)
-                if (_entityManager.TryGetComponent<ThreatSpawnMarkerComponent>(marker, out var emComp) && !emComp.Used)
+                catch (Exception ex)
                 {
-                    emComp.Used = true;
-                    Dirty(marker, emComp);
+                    _sawmill.Error($"[AuThirdPartySystem] Failed to spawn entity ({protoId})! {ex.Message}");
+                    continue;
                 }
-                // Parachute markers are intentionally NOT marked as used so they may be reused.
-                lastUsedMarker = marker;
-                _sawmill.Debug($"[AuThirdPartySystem] Spawned ent {protoId} at {coords} (entity {ent})");
             }
         }
 

--- a/Content.Server/AU14/Threats/AuThreatSystem.cs
+++ b/Content.Server/AU14/Threats/AuThreatSystem.cs
@@ -1,27 +1,24 @@
-using System.Collections.Generic;
 using System.Linq;
+using Content.Server.AU14.Round;
+using Content.Server.GameTicking;
 using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Mind.Commands;
 using Content.Shared.AU14.Threats;
-using Content.Server.AU14.Round;
-using Robust.Shared.Timing;
 using Content.Shared.AU14.util;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Map;
-using Content.Shared.Roles;
+using Content.Shared.Ghost;
 using Content.Shared.Mind;
-using Content.Server.GameTicking;
-using Robust.Shared.Network;
+using Content.Shared.NPC.Components;
 using Content.Shared.NPC.Prototypes;
 using Content.Shared.NPC.Systems;
-using Content.Shared.Ghost;
-using Content.Shared.NPC.Components;
 using Content.Shared.Players;
+using Content.Shared.Roles;
 using Robust.Server.Player;
-using Robust.Shared.Player;
 using Robust.Shared.Enums;
-using Robust.Shared.Log;
+using Robust.Shared.Map;
+using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 using Robust.Shared.Random;
 
 namespace Content.Server.AU14.Threats;
@@ -307,10 +304,13 @@ public sealed partial class AuThreatSystem : EntitySystem
                     var marker = markers.Count > 0 ? markers[i % markers.Count] : EntityUid.Invalid;
                     if (marker != EntityUid.Invalid)
                     {
-                        var ent = _entityManager.SpawnEntity(protoId,
-                            _entityManager.GetComponent<TransformComponent>(marker).Coordinates);
-                        spawnedLeaders.Add(ent);
-                        Logger.GetSawmill("au14.threat").Debug($"[DEBUG] Spawned leader entity {ent} at marker {marker}");
+                        try
+                        {
+                            EntityUid ent = _entityManager.SpawnEntity(protoId, _entityManager.GetComponent<TransformComponent>(marker).Coordinates);
+                            spawnedLeaders.Add(ent);
+                            Logger.GetSawmill("au14.threat").Debug($"[DEBUG] Spawned leader entity {ent} at marker {marker}");
+                        }
+                        catch (Exception ex) { Logger.GetSawmill("au14.threat").Error($"[AuThreatSystem] Failed to spawn leader ({protoId})! {ex.Message}"); }
                     }
                 }
             }
@@ -327,10 +327,13 @@ public sealed partial class AuThreatSystem : EntitySystem
                     var marker = markers.Count > 0 ? markers[i % markers.Count] : EntityUid.Invalid;
                     if (marker != EntityUid.Invalid)
                     {
-                        var ent = _entityManager.SpawnEntity(protoId,
-                            _entityManager.GetComponent<TransformComponent>(marker).Coordinates);
-                        spawnedMembers.Add(ent);
-                        Logger.GetSawmill("au14.threat").Debug($"[DEBUG] Spawned member entity {ent} at marker {marker}");
+                        try
+                        {
+                            EntityUid ent = _entityManager.SpawnEntity(protoId, _entityManager.GetComponent<TransformComponent>(marker).Coordinates);
+                            spawnedMembers.Add(ent);
+                            Logger.GetSawmill("au14.threat").Debug($"[DEBUG] Spawned member entity {ent} at marker {marker}");
+                        }
+                        catch (Exception ex) { Logger.GetSawmill("au14.threat").Error($"[AuThreatSystem] Failed to spawn member ({protoId})! {ex.Message}"); }
                     }
                 }
             }
@@ -349,11 +352,13 @@ public sealed partial class AuThreatSystem : EntitySystem
                     var marker = markers.Count > 0 ? markers[i % markers.Count] : EntityUid.Invalid;
                     if (marker != EntityUid.Invalid)
                     {
-                        _entityManager.SpawnEntity(protoId,
-                            _entityManager.GetComponent<TransformComponent>(marker).Coordinates);
-                        spawnedEntities++;
-                        Logger.GetSawmill("au14.threat").Debug(
-                            $"[DEBUG] Spawned other entity of protoId {protoId} at marker {marker}");
+                        try
+                        {
+                            _entityManager.SpawnEntity(protoId, _entityManager.GetComponent<TransformComponent>(marker).Coordinates);
+                            spawnedEntities++;
+                            Logger.GetSawmill("au14.threat").Debug($"[DEBUG] Spawned other entity of protoId {protoId} at marker {marker}");
+                        }
+                        catch (Exception ex) { Logger.GetSawmill("au14.threat").Error($"[AuThreatSystem] Failed to spawn entity ({protoId})! {ex.Message}"); }
                     }
                 }
             }

--- a/Content.Server/_RMC14/UniversalRecorder/UniversalRecorderSystem.cs
+++ b/Content.Server/_RMC14/UniversalRecorder/UniversalRecorderSystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.Popups;
 using Content.Shared.Tools.Systems;
 using Content.Shared.UserInterface;
 using Content.Shared.Verbs;
+using Content.Shared.Whitelist;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
@@ -56,6 +57,7 @@ public sealed partial class UniversalRecorderSystem : EntitySystem
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private SharedToolSystem _tool = default!;
     [Dependency] private UserInterfaceSystem _ui = default!;
+    [Dependency] private EntityWhitelistSystem _whitelist = default!;
 
     public override void Initialize()
     {
@@ -223,6 +225,14 @@ public sealed partial class UniversalRecorderSystem : EntitySystem
 
         if (TryGetTape(ent, out _))
             return;
+
+        if (ent.Comp.TapeSlot.Whitelist != null
+            && !_whitelist.IsValid(ent.Comp.TapeSlot.Whitelist, args.Used))
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-universal-recorder-popup-insert-fail"), ent.Owner, args.User);
+            args.Handled = true;
+            return;
+        }
 
         if (!_itemSlots.TryInsertFromHand(ent.Owner, ent.Comp.TapeSlot, args.User, excludeUserAudio: true))
             return;

--- a/Content.Shared/CCVar/CCVars.Ic.cs
+++ b/Content.Shared/CCVar/CCVars.Ic.cs
@@ -44,7 +44,7 @@ public sealed partial class CCVars
     ///     Adds a period at the end of a sentence if the sentence ends in a letter.
     /// </summary>
     public static readonly CVarDef<bool> ChatPunctuation =
-        CVarDef.Create("ic.punctuation", true, CVar.SERVER);
+        CVarDef.Create("ic.punctuation", false, CVar.SERVER);
 
     /// <summary>
     ///     Enables automatically forcing IC name rules. Uppercases the first letter of the first and last words of the name

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -18,7 +18,7 @@ public sealed partial class RMCCVars : CVars
         CVarDef.Create("rmc.xeno_speed_multiplier", 1f, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<bool> RMCAutoPunctuate =
-        CVarDef.Create("rmc.auto_punctuate", false, CVar.REPLICATED | CVar.CLIENT | CVar.ARCHIVE);
+        CVarDef.Create("rmc.auto_punctuate", true, CVar.REPLICATED | CVar.CLIENT | CVar.ARCHIVE);
 
     public static readonly CVarDef<bool> RMCAutoEjectMagazines =
         CVarDef.Create("rmc.auto_eject_magazines", true, CVar.REPLICATED | CVar.CLIENT | CVar.ARCHIVE);

--- a/Content.Shared/_RMC14/Marines/Squads/SquadLeaderHeadsetComponent.cs
+++ b/Content.Shared/_RMC14/Marines/Squads/SquadLeaderHeadsetComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Radio;
+using Content.Shared.Radio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
@@ -9,7 +9,7 @@ namespace Content.Shared._RMC14.Marines.Squads;
 public sealed partial class SquadLeaderHeadsetComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public HashSet<ProtoId<RadioChannelPrototype>> Channels = ["MarineJTAC", "MarineCommand"];
+    public HashSet<ProtoId<RadioChannelPrototype>> Channels; // SquadSystem.UpdateSquadLeaderHeadsetChannels handles it
 
     [DataField, AutoNetworkedField]
     public EntityUid Leader;

--- a/Content.Shared/_RMC14/Marines/Squads/SquadSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Squads/SquadSystem.cs
@@ -1,9 +1,7 @@
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Content.Shared._RMC14.Admin;
 using Content.Shared._RMC14.Chat;
-using Content.Shared._RMC14.Commendations;
 using Content.Shared._RMC14.Cryostorage;
 using Content.Shared._RMC14.Inventory;
 using Content.Shared._RMC14.Marines.Announce;
@@ -34,7 +32,6 @@ using Content.Shared.Roles;
 using Content.Shared.Roles.Jobs;
 using Content.Shared.Storage;
 using Content.Shared.Whitelist;
-using Robust.Client.GameObjects;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -779,23 +776,24 @@ public sealed partial class SquadSystem : EntitySystem
 
         _marineOrders.EnsureOrderActions((toPromote.Owner, orders));
 
+        var squad = toPromote.Comp?.Squad;
         var slots = _inventory.GetSlotEnumerator(toPromote.Owner, SlotFlags.EARS);
         while (slots.MoveNext(out var slot))
         {
             if (slot.ContainedEntity is not { } contained)
                 continue;
 
-            if (TryComp(contained, out EncryptionKeyHolderComponent? holder))
+            if (squad != null && TryComp(contained, out EncryptionKeyHolderComponent? holder))
             {
                 newLeader.Headset = contained;
                 Dirty(toPromote, newLeader);
                 EnsureComp<SquadLeaderHeadsetComponent>(contained);
+                UpdateSquadLeaderHeadsetChannels(contained, squad.Value);
                 _encryptionKey.UpdateChannels(contained, holder);
                 break;
             }
         }
 
-        var squad = toPromote.Comp?.Squad;
         if (TryComp(toPromote, out ActorComponent? actor))
         {
             var squadStr = Exists(squad) ? $" for {Name(squad.Value)}" : string.Empty;
@@ -849,6 +847,33 @@ public sealed partial class SquadSystem : EntitySystem
         RemComp<RMCTrackableComponent>(marine);
         RemCompDeferred<RMCPointingComponent>(marine);
         _awardRecommendation.SetCanRecommend(marine, false);
+    }
+
+    private void UpdateSquadLeaderHeadsetChannels(EntityUid headset, EntityUid squad)
+    {
+        if (!TryComp<SquadLeaderHeadsetComponent>(headset, out var headsetComp) ||
+            !TryComp<SquadTeamComponent>(squad, out var squadTeam))
+            return;
+
+        string group = squadTeam.Group?.ToUpperInvariant() ?? "";
+        if (group is "GOVFOR" or "OPFOR")
+        {
+            headsetComp.Channels = new()
+            {
+                new ProtoId<RadioChannelPrototype>($"radio{group}JTAC"),
+                new ProtoId<RadioChannelPrototype>($"radio{group}Command")
+            };
+        }
+        else
+        {
+            headsetComp.Channels = new()
+            {
+                new ProtoId<RadioChannelPrototype>("MarineJTAC"),
+                new ProtoId<RadioChannelPrototype>("MarineCommand")
+            };
+        }
+
+        Dirty(headset, headsetComp);
     }
 
     public bool AreInSameSquad(Entity<SquadMemberComponent?> one, Entity<SquadMemberComponent?> two)

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -51,7 +51,6 @@ preload_grids = false
 [admin]
 see_own_notes = true
 
-
 [ic]
 # random_characters = true
 random_species_weights = ""

--- a/Resources/ConfigPresets/RMC14/normandy.toml
+++ b/Resources/ConfigPresets/RMC14/normandy.toml
@@ -1,4 +1,4 @@
-﻿[adminlogs]
+[adminlogs]
 server_name = "normandy"
 
 [game]
@@ -10,7 +10,3 @@ tags = "lang:en,region:am_n_e,rp:high"
 
 [loki]
 name = "normandy"
-
-[rmc]
-planet_map_vote = false
-lobby_start_paused = true

--- a/Resources/ConfigPresets/RMC14/rmc.toml
+++ b/Resources/ConfigPresets/RMC14/rmc.toml
@@ -1,4 +1,4 @@
-﻿[accessibility]
+[accessibility]
 screen_shake_intensity = 1
 
 [admin]
@@ -94,10 +94,6 @@ max_compressed_size = 4194304
 max_uncompressed_size = 8388608
 auto_record_temp_dir = "recording"
 auto_record_name = "done/{year}_{month}_{day}-{hour}_{minute}-round_{round}.zip"
-
-[rmc]
-discord_account_linking_message_link = "https://discord.com/channels/1168210010233376858/1256765329002991679/1256767294839980132"
-lobby_min_players = 20
 
 [server]
 rules_file = "RMCOverview"

--- a/Resources/Locale/en-US/_RMC14/rmc-universal-recorder.ftl
+++ b/Resources/Locale/en-US/_RMC14/rmc-universal-recorder.ftl
@@ -26,6 +26,7 @@ rmc-universal-recorder-popup-no-data = The tape has no data.
 rmc-universal-recorder-popup-full = Tape full.
 rmc-universal-recorder-popup-broken = The tape is broken.
 rmc-universal-recorder-popup-insert-generic = You insert the tape.
+rmc-universal-recorder-popup-insert-fail = That won't fit!
 rmc-universal-recorder-popup-recording-start = Recording started.
 rmc-universal-recorder-popup-recording-stop = Recording stopped.
 rmc-universal-recorder-popup-playback-start = Playback started.

--- a/Resources/Prototypes/_AU14/Entities/Mobs/WorkingJoe/colony.yml
+++ b/Resources/Prototypes/_AU14/Entities/Mobs/WorkingJoe/colony.yml
@@ -17,3 +17,11 @@
       settings: short
   - type: Loadout
     prototypes: [AU14GearColonyWorkingJoe]
+
+- type: startingGear
+  parent: AU14GearWorkingJoeBase
+  id: AU14GearColonyWorkingJoe
+  equipment:
+    id: AU14IDCardColonyWorkingJoe
+    ears: AU14HeadsetWorkingJoe
+    ears2: RMCM5CameraGear

--- a/Resources/Prototypes/_AU14/Entities/Mobs/WorkingJoe/military.yml
+++ b/Resources/Prototypes/_AU14/Entities/Mobs/WorkingJoe/military.yml
@@ -3,20 +3,28 @@
   id: AU14MobWorkingJoeGOVFOR
   suffix: AU14, GOVFOR
   components:
-  - type: GhostTakeoverAvailable
-  - type: GhostRoleApplySpecial
-  - type: GhostRole
-    makeSentient: true
-    allowSpeech: true
-    allowMovement: true
-    reregister: false
-    name: Working Joe (GOVFOR)
-    description: au14-job-description-workingjoe
-    job: AU14JobGOVFORWorkingJoe
-    raffle:
-      settings: short
+  # - type: GhostTakeoverAvailable
+  # - type: GhostRoleApplySpecial
+  # - type: GhostRole
+  #   makeSentient: true
+  #   allowSpeech: true
+  #   allowMovement: true
+  #   reregister: false
+  #   name: Working Joe (GOVFOR)
+  #   description: au14-job-description-workingjoe
+  #   job: AU14JobGOVFORWorkingJoe
+  #   raffle:
+  #     settings: short
   - type: Loadout
     prototypes: [AU14GearGOVFORWorkingJoe]
+
+- type: startingGear
+  parent: AU14GearWorkingJoeBase
+  id: AU14GearGOVFORWorkingJoe
+  equipment:
+    id: AU14IDCardGOVFORWorkingJoe
+    ears: AU14HeadsetWorkingJoe
+    ears2: RMCM5CameraGear
 
 - type: entity
   parent: AU14MobWorkingJoe
@@ -37,3 +45,11 @@
       settings: short
   - type: Loadout
     prototypes: [AU14GearOPFORWorkingJoe]
+
+- type: startingGear
+  parent: AU14GearWorkingJoeBase
+  id: AU14GearOPFORWorkingJoe
+  equipment:
+    id: AU14IDCardOPFORWorkingJoe
+    ears: AU14HeadsetWorkingJoe
+    ears2: RMCM5CameraGear

--- a/Resources/Prototypes/_AU14/HUD/govfor_job_icons.yml
+++ b/Resources/Prototypes/_AU14/HUD/govfor_job_icons.yml
@@ -42,13 +42,6 @@
 
 - type: jobIcon
   parent: CMJobIconBase
-  id: AU14JobIconPlatoonSarge
-  icon:
-    sprite: _AU14/Interface/au14govforjobicons.rsi
-    state: govfor_ftl
-
-- type: jobIcon
-  parent: CMJobIconBase
   id: AU14JobIconPilotOfficer
   icon:
     sprite: _AU14/Interface/au14govforjobicons.rsi
@@ -59,18 +52,46 @@
   id: AU14JobIconRFN
   icon:
     sprite: _AU14/Interface/au14govforjobicons.rsi
+    state: old_govfor_rfn
+
+- type: jobIcon
+  parent: CMJobIconBase
+  id: AU14JobIconMP
+  icon:
+    sprite: _AU14/Interface/au14govforjobicons.rsi
     state: govfor_mp
 
 - type: jobIcon
   parent: CMJobIconBase
-  id: AU14JobIconSarge
+  id: AU14JobIconFTL
+  icon:
+    sprite: _AU14/Interface/au14govforjobicons.rsi
+    state: govfor_ftl
+
+- type: jobIcon
+  parent: CMJobIconBase
+  id: AU14JobIconSquadSgt
   icon:
     sprite: _AU14/Interface/au14govforjobicons.rsi
     state: govfor_sergeant
 
 - type: jobIcon
   parent: CMJobIconBase
+  id: AU14JobIconPlatoonSgt
+  icon:
+    sprite: _AU14/Interface/au14govforjobicons.rsi
+    state: old_govfor_platoonsergeant
+
+- type: jobIcon
+  parent: CMJobIconBase
   id: AU14JobIconRTO
+  icon:
+    sprite: _AU14/Interface/au14govforjobicons.rsi
+    state: old_govfor_rto
+
+- type: jobIcon
+  parent: CMJobIconBase
+  id: AU14JobIconAuxTech
   icon:
     sprite: _AU14/Interface/au14govforjobicons.rsi
     state: govfor_auxtech

--- a/Resources/Prototypes/_AU14/HUD/opfor_job_icons.yml
+++ b/Resources/Prototypes/_AU14/HUD/opfor_job_icons.yml
@@ -31,7 +31,7 @@
   id: AU14JobIconOPFOROpsOfc
   icon:
     sprite: _AU14/Interface/au14opforjobicons.rsi
-    state: opsofc
+    state: old_platco
 
 - type: jobIcon
   parent: CMJobIconBase
@@ -42,10 +42,10 @@
 
 - type: jobIcon
   parent: CMJobIconBase
-  id: AU14JobIconOPFORPlatoonSarge
+  id: AU14JobIconOPFORFTL
   icon:
     sprite: _AU14/Interface/au14opforjobicons.rsi
-    state: sergeant
+    state: ftl
 
 - type: jobIcon
   parent: CMJobIconBase
@@ -59,18 +59,39 @@
   id: AU14JobIconOPFORRFN
   icon:
     sprite: _AU14/Interface/au14opforjobicons.rsi
+    state: old_rfn
+
+- type: jobIcon
+  parent: CMJobIconBase
+  id: AU14JobIconOPFORMP
+  icon:
+    sprite: _AU14/Interface/au14opforjobicons.rsi
     state: mp
 
 - type: jobIcon
   parent: CMJobIconBase
-  id: AU14JobIconOPFORSarge
+  id: AU14JobIconOPFORSquadSgt
   icon:
     sprite: _AU14/Interface/au14opforjobicons.rsi
-    state: ftl
+    state: sergeant
+
+- type: jobIcon
+  parent: CMJobIconBase
+  id: AU14JobIconOPFORPlatoonSgt
+  icon:
+    sprite: _AU14/Interface/au14opforjobicons.rsi
+    state: old_platoonsergeant
 
 - type: jobIcon
   parent: CMJobIconBase
   id: AU14JobIconOPFORRTO
+  icon:
+    sprite: _AU14/Interface/au14opforjobicons.rsi
+    state: old_rto
+
+- type: jobIcon
+  parent: CMJobIconBase
+  id: AU14JobIconOPFORAuxTech
   icon:
     sprite: _AU14/Interface/au14opforjobicons.rsi
     state: auxtech

--- a/Resources/Prototypes/_AU14/Maps/soro.yml
+++ b/Resources/Prototypes/_AU14/Maps/soro.yml
@@ -38,9 +38,7 @@
 
             # Ambassadors
             AU14JobCivilianAmbassadorICSC: [1, 1]
-            AU14JobCivilianAmbassadorUPP: [1, 1]
 
-            # Corporate
             # todo UPP researcher job overrides
 
             # Security/LEO

--- a/Resources/Prototypes/_AU14/Roles/Jobs/CLF/clfcellleader.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/CLF/clfcellleader.yml
@@ -58,12 +58,11 @@
       mindRole: MindRoleCLFLeader
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: colonist
     - type: ShowMarineIcons
       factions:
       - CLF
-  hidden: false
 
 - type: startingGear
   id: AU14GearCLFCellLeader

--- a/Resources/Prototypes/_AU14/Roles/Jobs/CLF/clfdoctor.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/CLF/clfdoctor.yml
@@ -48,12 +48,11 @@
       mindRole: MindRoleCLFPhysician
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: colonist
     - type: ShowMarineIcons
       factions:
       - CLF
-  hidden: false
 
 - type: startingGear
   id: AU14GearCLFPhysician

--- a/Resources/Prototypes/_AU14/Roles/Jobs/CLF/clfguerilla.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/CLF/clfguerilla.yml
@@ -40,12 +40,11 @@
       mindRole: MindRoleCLFGuerrilla
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: colonist
     - type: ShowMarineIcons
       factions:
       - CLF
-  hidden: false
 
 - type: startingGear
   id: AU14GearCLFGuerilla

--- a/Resources/Prototypes/_AU14/Roles/Jobs/CLF/clfmachinegunner.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/CLF/clfmachinegunner.yml
@@ -43,12 +43,11 @@
       prefix: au14-job-prefix-clfmachinegunner
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: colonist
     - type: ShowMarineIcons
       factions:
       - CLF
-  hidden: false
 
 - type: startingGear
   id: AU14GearCLFMachineGunner

--- a/Resources/Prototypes/_AU14/Roles/Jobs/CLF/clfsurgeon.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/CLF/clfsurgeon.yml
@@ -54,12 +54,11 @@
       mindRole: MindRoleCLFSurgeon
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: colonist
     - type: ShowMarineIcons
       factions:
       - CLF
-  hidden: false
 
 - type: startingGear
   id: AU14GearCLFSurgeon

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyadminassistant.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyadminassistant.yml
@@ -56,9 +56,8 @@
       prefix: au14-job-prefix-colonyadminassistant
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: admin_assistant
 
 - type: startingGear
   id: AU14GearCivilianColonyAdminAssistant

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyadministrator.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyadministrator.yml
@@ -56,9 +56,8 @@
       prefix: au14-job-prefix-colonyadministrator
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: admin
 
 - type: startingGear
   id: AU14GearCivilianColonyAdministrator

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonycivilian.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonycivilian.yml
@@ -30,9 +30,8 @@
       prefix: au14-job-prefix-civiliancolonist
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: colonist
 
 - type: startingGear
   id: AU14GearCivilianColonist

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyemergencyresponseofficer.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyemergencyresponseofficer.yml
@@ -38,9 +38,8 @@
       prefix: au14-job-prefix-emergencyresponseofficer
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: ero
 
 - type: startingGear
   id: AU14GearCivilianEmergencyResponseOfficer

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyengineer.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyengineer.yml
@@ -34,9 +34,8 @@
       prefix: au14-job-prefix-colonyengineer
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: engineer
 
 - type: startingGear
   id: AU14GearCivilianEngineer

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyfoodserviceworker.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyfoodserviceworker.yml
@@ -33,9 +33,8 @@
     - type: AU14FoodServiceWorkerMarker
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: fsw
 
 - type: startingGear
   id: AU14GearCivilianFoodServiceWorker

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyforeman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyforeman.yml
@@ -50,9 +50,8 @@
       prefix: au14-job-prefix-colonyforeman
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: foreman
 
 - type: startingGear
   id: AU14GearCivilianForeman

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyfreightsystemsspecialist.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyfreightsystemsspecialist.yml
@@ -35,9 +35,8 @@
       prefix: au14-job-prefix-freightsystemsspecialist
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: fss
 
 - type: startingGear
   id: AU14GearCivilianFreightSystemsSpecialist

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyheadofengineering.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyheadofengineering.yml
@@ -51,9 +51,8 @@
       prefix: au14-job-prefix-headofengineering
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: head_of_engineering
 
 - type: startingGear
   id: AU14GearCivilianHeadOfEngineering

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyheadofservice.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyheadofservice.yml
@@ -46,9 +46,8 @@
       prefix: au14-job-prefix-headofservice
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: head_of_service
 
 - type: startingGear
   id: AU14GearCivilianHeadOfService

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyheadphysician.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyheadphysician.yml
@@ -51,9 +51,8 @@
       prefix: au14-job-prefix-headphysician
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: head_physician
 
 - type: startingGear
   id: AU14GearCivilianHeadPhysician

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyjournalist.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyjournalist.yml
@@ -31,9 +31,8 @@
       prefix: au14-job-prefix-journalist
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: journalist
 
 - type: startingGear
   id: AU14GearCivilianJournalist

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonynurse.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonynurse.yml
@@ -32,9 +32,8 @@
       prefix: au14-job-prefix-nurse
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: nurse
 
 - type: startingGear
   id: AU14GearCivilianNurse

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyphysician.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyphysician.yml
@@ -38,9 +38,8 @@
       prefix: au14-job-prefix-physician
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: physician
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyshopkeep.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonyshopkeep.yml
@@ -32,9 +32,8 @@
       prefix: au14-job-prefix-civilianshopkeep
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: shopkeep
 
 - type: startingGear
   id: AU14GearCivilianShopkeep

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonysynth.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonysynth.yml
@@ -59,7 +59,7 @@
       prefix: au14-job-prefix-civiliancolonysynthetic
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
         state: synth
     - type: MeleeWeapon
       soundHit:
@@ -75,8 +75,6 @@
           Blunt: 35
     - type: Synth
       generation: "rmc-species-synth-generation-second"
-
-  hidden: false
 
 - type: startingGear
   id: AU14GearCivilianColonySynthetic

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonywatsemanagementspecialist.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/colonywatsemanagementspecialist.yml
@@ -35,9 +35,8 @@
       prefix: au14-job-prefix-civilianwastemanagementspecialist
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: wms
 
 - type: startingGear
   id: AU14GearCivilianWasteManagementSpecialist

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/lawenforcementbase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/lawenforcementbase.yml
@@ -7,8 +7,6 @@
   playTimeTracker: AU14JobCivilianCMBDeputy
   basePlaytimeTracker: true
   icon: "RMCJobIconBureauDeputy"
-  hidden: false
-
 
 - type: playTimeTracker
   id: AU14JobCivilianCMBDeputy

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/lawenforcementleaderbase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/lawenforcementleaderbase.yml
@@ -7,7 +7,6 @@
   playTimeTracker: AU14JobCivilianCMBMarshal
   icon: "RMCJobIconBureauMarshal"
   basePlaytimeTracker: true
-  hidden: false
   access: # accessGroups in use by inheritors
   - AU14AccessColonyMarshall
   - AU14AccessColonyAdministrator

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/workingjoeBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/workingjoeBase.yml
@@ -10,8 +10,6 @@
   canBeAntag: false
   whitelisted: true
   whitelistParent: AU14JobGeneralWhitelist
-  jobEntity: AU14MobWorkingJoe
-  jobPreviewEntity: AU14MobWorkingJoeDummy
 
 - type: playTimeTracker
   id: AU14JobWorkingJoe

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/workingjoeBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/base/workingjoeBase.yml
@@ -27,6 +27,7 @@
   storage:
       belt:
       - AU14MaintenanceJack
+      - RMCSynthResetKeySeegson
       back:
       - AU14SprayCleanerExperimental
       - RMCBucketJanitorial

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyethicsandwellnessadvisor.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyethicsandwellnessadvisor.yml
@@ -8,7 +8,7 @@
   ranks:
     RMCRankCivilian: []
   startingGear: AU14GearCivilianEthicsAndWellnessAdvisor
-  icon: "AU14JobIconColonyAdvisor"
+  icon: "AU14JobIconColonyNurse"
   hasIcon: false
   requireAdminNotify: false
   joinNotifyCrew: false
@@ -31,9 +31,8 @@
       prefix: au14-job-prefix-ethicsandwellnessadvisor
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: nurse
 
 - type: startingGear
   id: AU14GearCivilianEthicsAndWellnessAdvisor

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonykellandwarden.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonykellandwarden.yml
@@ -39,9 +39,8 @@
       prefix: au14-job-prefix-civiliankellandwarden
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: kelland_warden
 
 - type: startingGear
   id: AU14GearCivilianKellandWarden

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyminer.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyminer.yml
@@ -29,9 +29,8 @@
       prefix: au14-job-prefix-civilianminer
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: colonist
 
 - type: startingGear
   id: AU14GearCivilianMiner

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyprisoner.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyprisoner.yml
@@ -28,9 +28,8 @@
       prefix: au14-job-prefix-civilianprisoner
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: prisoner
 
 - type: startingGear
   id: AU14GearCivilianPrisoner

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyusafrecruiter.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyusafrecruiter.yml
@@ -13,7 +13,7 @@
   ranks:
     RMCRankCivilian: []
   startingGear: AU14GearCivilianUSASFRecruiter
-  icon: "AU14JobIconRFN"
+  icon: "AU14JobIconColonyAdvisor"
   requireAdminNotify: false
   joinNotifyCrew: false
   supervisors: au14-job-supervisors-colonycivilian
@@ -36,9 +36,8 @@
       prefix: au14-job-prefix-usasfrecruiter
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: advisor
 
 - type: startingGear
   id: AU14GearCivilianUSASFRecruiter

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyworkingjoe.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyworkingjoe.yml
@@ -12,8 +12,9 @@
   icon: "AU14JobIconColonyWorkingJoe"
   spawnMenuRoleName: Working Joe (Colony)
   supervisors: au14-job-supervisors-workingjoe-colony
-  dummyStartingGear: AU14GearColonyWorkingJoe
   usePlayerProfile: false
+  jobEntity: AU14MobWorkingJoeColony
+  jobPreviewEntity: AU14MobWorkingJoeDummy
   hasIcon: false
   accessGroups:
   - auadmin
@@ -41,15 +42,6 @@
       - Colonist
       - AUPrisonStaff
       - auwy
-
-- type: startingGear
-  parent: AU14GearWorkingJoeBase
-  id: AU14GearColonyWorkingJoe
-  equipment:
-    id: AU14IDCardColonyWorkingJoe
-    ears: AU14HeadsetWorkingJoe
-    back: AU14IMPBackpackMarine
-    pocket1: AU14StampJoe
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyworkingjoe.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/colonyworkingjoe.yml
@@ -42,6 +42,10 @@
       - Colonist
       - AUPrisonStaff
       - auwy
+    - type: TacticalMapIcon
+      icon:
+        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
+        state: working_joe
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/hazmatworkingjoe.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/hazmatworkingjoe.yml
@@ -1,83 +1,31 @@
 - type: job
-  parent: AU14JobWorkingJoeBase
-  id: AU14JobHazmatWorkingJoe
-  whitelisted: true
-  whitelistParent: AU14JobGeneralWhitelist
-  requirements:
-  - !type:TraitsRequirement
-    inverted: true
-    traits:
-    - SocialAnxietyHeavy
-    - FrontalLisp
-    - NonResuscitable
-    - Epilepsy
-  icon: "AU14JobIconColonyWorkingJoe"
+  parent: AU14JobColonyWorkingJoe
+  id: AU14JobColonyWorkingJoeHazmat
   spawnMenuRoleName: Working Joe (Hazmat)
-  supervisors: au14-job-supervisors-workingjoe-colony
-  usePlayerProfile: false
-  hasIcon: false
-  accessGroups:
-  - auadmin
-  - Colonist
-  - AUPrisonStaff
-  - auwy
+  inheritAddComponentSpecials: true
   special:
   - !type:AddComponentSpecial
     components:
-    - type: IntrinsicRadioTransmitter
-      channels:
-      - radioAI
-      - Colony
-      - radioWEYU
-      - radioCMB
-    - type: ActiveRadio
-      channels:
-      - radioAI
-      - Colony
-      - radioWEYU
-      - radioCMB
-    - type: Access
-      groups:
-      - auadmin
-      - Colonist
-      - AUPrisonStaff
-      - auwy
     - type: Loadout
-      prototypes: [ AU14GearHazmatWorkingJoe ]
-  dummyStartingGear: AU14GearHazmatWorkingJoe
-  hidden: false
+      prototypes: [ AU14GearColonyWorkingJoeHazmat ]
+  dummyStartingGear: AU14GearColonyWorkingJoeHazmat
 
 - type: startingGear
-  id: AU14GearHazmatWorkingJoe
+  parent: AU14GearWorkingJoeBase
+  id: AU14GearColonyWorkingJoeHazmat
   equipment:
-    id: AU14IDCardColonyWorkingJoe
-    ears: AU14HeadsetWorkingJoe
     shoes: AU14BootsCBRN
     gloves: RMCHandsVeteranCBRN
     jumpsuit: AU14JoeHazmat
-    belt: CMBeltUtilityFilled
-    back: AU14IMPBackpackMarine
-    pocket2: RMCPouchConstructionFillFull
-  storage:
-      belt:
-      - AU14MaintenanceJack
-      - RMCSynthResetKeySeegson
-      back:
-      - AU14SprayCleanerExperimental
-      - RMCBucketJanitorial
-      - CMMop
-      - CMWetSign
-      - RMCLightReplacer
-      - AU14StampJoe
   inhand:
   - CMFireExtinguisher
 
 - type: entity
   parent: CMSpawnPointJobBase
-  id: AU14SpawnPointHazmatWorkingJoe
+  id: AU14SpawnPointWorkingJoeHazmat
   name: Spawn Point Working Joe (Hazmat)
   components:
   - type: SpawnPoint
-    job_id: AU14JobHazmatWorkingJoe
+    job_id: AU14JobColonyWorkingJoeHazmat
   - type: Sprite
     state: syn_spawn

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/law enforcement/colonycmbdeputy.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/law enforcement/colonycmbdeputy.yml
@@ -60,9 +60,8 @@
       prefix: au14-job-prefix-cmbdeputy
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_RMC14/Interface/cm_job_icons.rsi
+        state: cmb_dep
 
 - type: startingGear
   id: AU14GearCivilianCMBDeputy

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/law enforcement/colonycmbmarshal.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/law enforcement/colonycmbmarshal.yml
@@ -46,9 +46,8 @@
       prefix: au14-job-prefix-cmbmarshal
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_RMC14/Interface/cm_job_icons.rsi
+        state: cmb_mar
 
 - type: startingGear
   id: AU14GearCivilianCMBMarshal

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/law enforcement/colonycwpsranger.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/law enforcement/colonycwpsranger.yml
@@ -60,9 +60,8 @@
       prefix: au14-job-prefix-civiliancwpsranger
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_RMC14/Interface/cm_job_icons.rsi
+        state: cmb_dep
 
 - type: startingGear
   id: AU14GearCivilianCWPSRanger

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/law enforcement/colonynspacontable.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/law enforcement/colonynspacontable.yml
@@ -61,9 +61,8 @@
       prefix: au14-job-prefix-civiliannspaConstable
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_RMC14/Interface/cm_job_icons.rsi
+        state: tse_paconstable
 
 - type: startingGear
   id: AU14GearCiviliannspaConstable

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/law enforcement/colonynspainspector.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/law enforcement/colonynspainspector.yml
@@ -48,9 +48,8 @@
       prefix: au14-job-prefix-civiliannspainspector
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_RMC14/Interface/cm_job_icons.rsi
+        state: tse_painspector
 
 - type: startingGear
   id: AU14GearCivilianNSPAInspector

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/law enforcement/colonypapofficer.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/law enforcement/colonypapofficer.yml
@@ -54,9 +54,8 @@
       prefix: au14-job-prefix-civilianpapofficer
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_RMC14/Interface/cm_job_icons.rsi
+        state: cmb_dep
 
 - type: startingGear
   id: AU14GearCivilianPaPOfficer

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/law enforcement/colonysecurityofficer.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/law enforcement/colonysecurityofficer.yml
@@ -45,9 +45,8 @@
       prefix: au14-job-prefix-colonysecurityofficer
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_RMC14/Interface/cm_job_icons.rsi
+        state: weya_goon_standard
 
 - type: startingGear
   id: AU14GearColonySecurityOfficer
@@ -128,7 +127,6 @@
       icon:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: synth
-  hidden: false
 
 - type: startingGear
   id: AU14GearColonySecurityLeader

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/mobboss.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/mobboss.yml
@@ -29,9 +29,8 @@
       prefix: au14-job-prefix-mobboss
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: colonist
 
 - type: startingGear
   id: AU14GearMobBoss

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/mobgoon.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/mobgoon.yml
@@ -29,9 +29,8 @@
       prefix: au14-job-prefix-mobboss
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: colonist
 
 - type: startingGear
   id: AU14GearMobGoon

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/LaselleLiasion.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/LaselleLiasion.yml
@@ -43,8 +43,8 @@
       prefix: au14-job-prefix-laselleliaison
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: laselle_liaison
 #    - type: AssignSquad
 #      whitelist:
 #        tags:
@@ -54,7 +54,6 @@
       - GOVFOR
     - type: Marine
       Faction: govfor
-  hidden: false
 
 - type: startingGear
   id: AU14GearCivilianLaselleLiaison

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/ccaambassador.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/ccaambassador.yml
@@ -39,14 +39,13 @@
       prefix: au14-job-prefix-civilianambassadorcca
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: cca_ambassador
     - type: NpcFactionMember
       factions:
       - GOVFOR
     - type: Marine
       Faction: govfor
-  hidden: false
 
 - type: startingGear
   id: AU14GearCivilianAmbassadorCCA

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/colonypilot.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/colonypilot.yml
@@ -50,9 +50,8 @@
       prefix: au14-job-prefix-civiliancolonypilot
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: pilot
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: colony_pilot
 
 - type: startingGear
   id: AU14GearCivilianColonyPilot

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/icscambassador.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/icscambassador.yml
@@ -39,14 +39,13 @@
       prefix: au14-job-prefix-civilianambassadoricsc
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: icsc_ambassador
     - type: NpcFactionMember
       factions:
       - GOVFOR
     - type: Marine
       Faction: govfor
-  hidden: false
 
 - type: startingGear
   id: AU14GearCivilianAmbassadorICSC

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/orbitalmanager.yml.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/orbitalmanager.yml.yml
@@ -54,9 +54,8 @@
       prefix: au14-job-prefix-orbitalmanager
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: orbital_manager
 
 - type: startingGear
   id: AU14GearCivilianOrbitalManager

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/orbitalsecurity.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/orbitalsecurity.yml
@@ -41,9 +41,8 @@
       prefix: au14-job-prefix-orbitalsecurity
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
-  hidden: false
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: orbital_security
 
 - type: startingGear
   id: AU14GearCivilianOrbitalSecurity

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/tweambassador.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/tweambassador.yml
@@ -39,14 +39,13 @@
       prefix: au14-job-prefix-civilianambassadortwe
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: twe_ambassador
     - type: NpcFactionMember
       factions:
       - GOVFOR
     - type: Marine
       Faction: govfor
-  hidden: false
 
 - type: startingGear
   id: AU14GearCivilianAmbassadorTWE

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/uaambassador.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/uaambassador.yml
@@ -39,15 +39,14 @@
       prefix: au14-job-prefix-civilianambassadorua
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: ua_ambassador
     - type: NpcFactionMember
       factions:
       - AUUnitedAmericas
     # - CMUVAI
     - type: Marine
     # Faction: ""
-  hidden: false
 
 - type: startingGear
   id: AU14GearCivilianAmbassadorUA

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/uppambassador.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/uppambassador.yml
@@ -39,14 +39,13 @@
       prefix: au14-job-prefix-civilianambassadorupp
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: upp_ambassador
     - type: NpcFactionMember
       factions:
       - GOVFOR
     - type: Marine
       Faction: govfor
-  hidden: false
 
 - type: startingGear
   id: AU14GearCivilianAmbassadorUPP

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/DSPilotBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/DSPilotBase.yml
@@ -69,7 +69,7 @@
       prefix: au14-job-prefix-govfordspilot
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
         state: govfor_po
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/advisorBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/advisorBase.yml
@@ -59,7 +59,7 @@
       prefix: au14-job-prefix-govforadvisor
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
         state: govfor_advisor
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/auxiliarysupportsynthBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/auxiliarysupportsynthBase.yml
@@ -70,8 +70,8 @@
       prefix: au14-job-prefix-govforauxsupportsynth
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
-        state: govfor_syn
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
+        state: govfor_synth
     - type: MeleeWeapon
       soundHit:
         path: /Audio/_RMC14/Weapons/synthpunch1.ogg

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/auxiliarytechnician.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/auxiliarytechnician.yml
@@ -4,7 +4,7 @@
   id: AU14JobAuxTechBaseAbstract
   name: au14-job-name-govforAuxTech
   description: au14-job-description-govforAuxTech
-  icon: "AU14JobIconRTO"
+  icon: "AU14JobIconAuxTech"
   spawnMenuRoleName: Auxiliary Technician (GOVFOR)
   startingGear: AU14GearGOVFORAuxTech
   dummyStartingGear: AU14GearGOVFORAuxTechDummy
@@ -64,7 +64,7 @@
       prefix: au14-job-prefix-govforAuxTech
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
         state: govfor_auxtech
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/commanderBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/commanderBase.yml
@@ -59,7 +59,7 @@
       speechStyleClass: commanderSpeech
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi # au14govforjobicons.rsi
         state: govfor_platco
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/corpsmanBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/corpsmanBase.yml
@@ -46,7 +46,7 @@
       prefix: au14-job-prefix-govforplatooncorpsman
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
         state: govfor_corpsman
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/dropshipcrewchiefBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/dropshipcrewchiefBase.yml
@@ -59,7 +59,7 @@
       prefix: au14-job-prefix-govfordcc
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
         state: govfor_dcc
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/militarydoctorbase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/militarydoctorbase.yml
@@ -53,7 +53,7 @@
       prefix: au14-job-prefix-govforMilitaryDoctor
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
         state: govfor_doctor
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/militarypolicebase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/militarypolicebase.yml
@@ -4,7 +4,7 @@
   id: AU14JobMilitaryPoliceBaseAbstract
   name: au14-job-name-govformilitarypoliceman
   description: au14-job-description-govformilitarypoliceman
-  icon: "AU14JobIconRFN"
+  icon: "AU14JobIconMP"
   spawnMenuRoleName: Military Policeman (GOVFOR)
   supervisors: au14-job-supervisors-govforplatco
   startingGear: AU14GearGOVFORMilitaryPoliceMan
@@ -61,7 +61,7 @@
       prefix: au14-job-prefix-govformilitarypoliceman
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
         state: govfor_mp
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/operationsofficerBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/operationsofficerBase.yml
@@ -52,8 +52,8 @@
       prefix: au14-job-prefix-govforplatop
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
-        state: govfor_po
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
+        state: old_govfor_platco
 
 - type: playTimeTracker
   id: AU14JobGOVFORPlatOp

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/radiotelephoneoperatorBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/radiotelephoneoperatorBase.yml
@@ -4,7 +4,7 @@
   id: AU14JobRadioTelephoneOperatorBaseAbstract
   name: au14-job-name-radiotelephoneoperator
   description: au14-job-description-radiotelephoneoperator
-  icon: "AU14JobIconPlatoonSarge"
+  icon: "AU14JobIconFTL"
   spawnMenuRoleName: Fireteam Leader (GOVFOR)
   startingGear: AU14GearGOVFORRadioTelephoneOperator
   dummyStartingGear: AU14GearGOVFORRadioTelephoneOperatorDummy
@@ -39,7 +39,7 @@
       prefix: au14-job-prefix-radiotelephoneoperator
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
         state: govfor_ftl
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/sectionsergeantBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/sectionsergeantBase.yml
@@ -4,7 +4,7 @@
   id: AU14JobSectionSergeantBaseAbstract
   name: au14-job-name-govforSSG
   description: au14-job-description-govforSSG
-  icon: "AU14JobIconPlatoonSarge"
+  icon: "AU14JobIconPlatoonSgt"
   spawnMenuRoleName: Platoon Sergeant (GOVFOR)
   startingGear: AU14GearGOVFORSectionSergeant
   dummyStartingGear: AU14GearGOVFORPlatoonSergeantDummy
@@ -53,8 +53,8 @@
       prefix: au14-job-prefix-govforSSG
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
-        state: govfor_platoonsergeant
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
+        state: old_govfor_platoonsergeant
 
 - type: playTimeTracker
   id: AU14JobGOVFORSectionSergeant

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/squadautomaticriflemanBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/squadautomaticriflemanBase.yml
@@ -53,7 +53,7 @@
       prefix: au14-job-prefix-govforsquadautomaticrifleman
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
         state: govfor_afn
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/squadcombattechBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/squadcombattechBase.yml
@@ -57,7 +57,7 @@
       prefix: au14-job-prefix-govforsquadcombattech
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
         state: govfor_ct
     - type: CMVendorUser
       id: AU14JobGOVFORSquadCombatTech

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/squadriflemanBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/squadriflemanBase.yml
@@ -43,8 +43,8 @@
       prefix: au14-job-prefix-govforsquadrifleman
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
-        state: govfor_background
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
+        state: rifleman
 
 - type: playTimeTracker
   id: AU14JobGOVFORSquadRifleman

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/squadsergeantBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/squadsergeantBase.yml
@@ -4,7 +4,7 @@
   id: AU14JobSquadSergeantBaseAbstract # Squad Leader Abstraction
   name: au14-job-name-govforsquadsergeant
   description: au14-job-description-govforsquadsergeant
-  icon: "AU14JobIconSarge"
+  icon: "AU14JobIconSquadSgt"
   spawnMenuRoleName: Squad Sergeant (GOVFOR)
   startingGear: AU14GearGOVFORSquadSergeant
   dummyStartingGear: AU14GearGOVFORSquadSergeantDummy
@@ -51,7 +51,7 @@
       prefix: au14-job-prefix-govforsquadsergeant
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
         state: govfor_sergeant
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/weaponsspecialistBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/weaponsspecialistBase.yml
@@ -42,7 +42,7 @@
       prefix: au14-job-prefix-govforweaponsspecialist
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
         state: govfor_ws
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonworkingjoe.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonworkingjoe.yml
@@ -5,7 +5,6 @@
   icon: "AU14JobIconGovWorkingJoe"
   spawnMenuRoleName: Working Joe (GOVFOR)
   supervisors: au14-job-supervisors-workingjoe-military
-  dummyStartingGear: AU14GearGOVFORWorkingJoe
   usePlayerProfile: false
   jobEntity: AU14MobWorkingJoeGOVFOR
   accessGroups:
@@ -56,16 +55,6 @@
       - CanPilot
       - FootstepSound
       - DoorBumpOpener
-
-- type: startingGear
-  parent: AU14GearWorkingJoeBase
-  id: AU14GearGOVFORWorkingJoe
-  equipment:
-    id: AU14IDCardGOVFORWorkingJoe
-    ears: AU14HeadsetWorkingJoe
-    ears2: RMCM5CameraGear
-    back: AU14IMPBackpackMarine
-    pocket1: AU14StampJoe
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonworkingjoe.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Default/platoonworkingjoe.yml
@@ -55,6 +55,10 @@
       - CanPilot
       - FootstepSound
       - DoorBumpOpener
+    - type: TacticalMapIcon
+      icon:
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
+        state: working_joe
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/auxiliarysupportsynth.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/auxiliarysupportsynth.yml
@@ -22,7 +22,7 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
         state: synth
 
 - type: startingGear

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/militaryauxtech.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/militaryauxtech.yml
@@ -1,7 +1,7 @@
 - type: job
   parent: AU14JobAuxTechBase
   id: AU14JobOPFORAuxTech
-  icon: "AU14JobIconOPFORRTO"
+  icon: "AU14JobIconOPFORAuxTech"
   spawnMenuRoleName: Auxiliary Technician (OPFOR)
   supervisors: au14-job-supervisors-opfor
   startingGear: AU14GearOPFORAuxTech
@@ -21,7 +21,7 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
         state: auxtech
 
 - type: startingGear

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/militarydoctor.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/militarydoctor.yml
@@ -22,7 +22,7 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
         state: doctor
 
 - type: startingGear

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/militarypoliceofficer.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/militarypoliceofficer.yml
@@ -1,7 +1,7 @@
 - type: job
   parent: AU14JobMilitaryPoliceBase
   id: AU14JobOPFORMilitaryPolice
-  icon: "AU14JobIconOPFORRFN"
+  icon: "AU14JobIconOPFORMP"
   spawnMenuRoleName: Military Policeman (OPFOR)
   supervisors: au14-job-supervisors-opforplatco
   startingGear: AU14GearOPFORMilitaryPoliceMan
@@ -22,7 +22,7 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
         state: mp
 
 - type: startingGear

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonadvisor.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonadvisor.yml
@@ -21,7 +21,7 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
         state: advisor
 
 - type: startingGear

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platooncommander.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platooncommander.yml
@@ -21,7 +21,7 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
         state: platco
 
 - type: startingGear

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platooncorpsman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platooncorpsman.yml
@@ -22,7 +22,7 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
         state: corpsman
 
 - type: startingGear

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoondropshipcrewchief.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoondropshipcrewchief.yml
@@ -23,7 +23,7 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
         state: dcc
 
 - type: startingGear

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonoperationsofficer.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonoperationsofficer.yml
@@ -21,8 +21,8 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
-        state: po
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
+        state: old_platco
 
 - type: startingGear
   id: AU14GearOpforPlatOp

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonpilotofficer.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonpilotofficer.yml
@@ -23,7 +23,7 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
         state: po
 
 - type: startingGear

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonradiotelephoneoperator.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonradiotelephoneoperator.yml
@@ -1,7 +1,7 @@
 - type: job
   parent: AU14JobRadioTelephoneOperatorBase
   id: AU14JobOpforRadioTelephoneOperator
-  icon: "AU14JobIconOPFORSarge"
+  icon: "AU14JobIconOPFORFTL"
   startingGear: AU14GearopforRadioTelephoneOperator
   dummyStartingGear: AU14GearopforRadioTelephoneOperatorDummy
   spawnMenuRoleName: Fireteam Leader (OPFOR)
@@ -21,7 +21,7 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
         state: ftl
 
 - type: startingGear

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonsectionsergeant.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonsectionsergeant.yml
@@ -1,7 +1,7 @@
 - type: job
   parent: AU14JobSectionSergeantBase
   id: AU14JobOpforSectionSergeant
-  icon: "AU14JobIconOPFORPlatoonSarge" # shares the same id as the opfor squad sergeant (platoonsquadsergeant.yml)
+  icon: "AU14JobIconOPFORPlatoonSgt"
   spawnMenuRoleName: Platoon Sergeant (OPFOR)
   supervisors: au14-job-supervisors-opfor
   startingGear: AU14GearopforSectionSergeant
@@ -21,8 +21,8 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
-        state: platoonsergeant
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
+        state: old_platoonsergeant
 
 - type: startingGear
   id: AU14GearopforSectionSergeant

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonsquadautomaticrifleman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonsquadautomaticrifleman.yml
@@ -21,7 +21,7 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
         state: afn
 
 - type: startingGear

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonsquadcombattech.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonsquadcombattech.yml
@@ -21,7 +21,7 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
         state: ct
     - type: CMVendorUser
       id: AU14JobOPFORSquadCombatTech

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonsquadrifleman.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonsquadrifleman.yml
@@ -21,8 +21,8 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
-        state: background
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
+        state: rifleman
 
 - type: startingGear
   id: AU14GearopforSquadRifleman

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonsquadsergeant.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonsquadsergeant.yml
@@ -1,7 +1,7 @@
 - type: job
   parent: AU14JobSquadSergeantBase
   id: AU14JobOpforSquadSergeant
-  icon: "AU14JobIconOPFORPlatoonSarge"
+  icon: "AU14JobIconOPFORSquadSgt"
   spawnMenuRoleName: Squad Sergeant (OPFOR)
   supervisors: au14-job-supervisors-opfor
   startingGear: AU14GearOpforSquadSergeant
@@ -21,7 +21,7 @@
       - OPFOR
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14opforhud.rsi
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
         state: sergeant
 
 - type: startingGear

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonworkingjoe.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonworkingjoe.yml
@@ -57,6 +57,10 @@
       - CanPilot
       - FootstepSound
       - DoorBumpOpener
+    - type: TacticalMapIcon
+      icon:
+        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
+        state: working_joe
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonworkingjoe.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Opfor/platoonworkingjoe.yml
@@ -5,7 +5,6 @@
   icon: "AU14JobIconOPFORWorkingJoe"
   spawnMenuRoleName: Working Joe (OPFOR)
   supervisors: au14-job-supervisors-workingjoe-military
-  dummyStartingGear: AU14GearOPFORWorkingJoe
   usePlayerProfile: false
   jobEntity: AU14MobWorkingJoeOPFOR
   accessGroups:
@@ -58,16 +57,6 @@
       - CanPilot
       - FootstepSound
       - DoorBumpOpener
-
-- type: startingGear
-  parent: AU14GearWorkingJoeBase
-  id: AU14GearOPFORWorkingJoe
-  equipment:
-    id: AU14IDCardOPFORWorkingJoe
-    ears: AU14HeadsetWorkingJoe
-    ears2: RMCM5CameraGear
-    back: AU14IMPBackpackMarine
-    pocket1: AU14StampJoe
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Util/ThirdPartyMember.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Util/ThirdPartyMember.yml
@@ -16,7 +16,6 @@
 - type: playTimeTracker
   id: AUThirdPartyMember
 
-
 - type: job
   abstract: true
   parent: CMJobBase

--- a/Resources/Prototypes/_AU14/Roles/Jobs/WeYu/colonycorporaassistant.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/WeYu/colonycorporaassistant.yml
@@ -43,13 +43,12 @@
       prefix: au14-job-prefix-civiliancorporateassistant
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: corporate_assistant
     - type: AssignSquad
       whitelist:
         tags:
         - SquadPMC
-  hidden: false
 
 - type: startingGear
   id: AU14GearCivilianCorporateAssistant

--- a/Resources/Prototypes/_AU14/Roles/Jobs/WeYu/colonycorporateadministrator.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/WeYu/colonycorporateadministrator.yml
@@ -45,8 +45,8 @@
       prefix: au14-job-prefix-civiliancorporateadministrator
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: /Textures/_RMC14/Interface/cm_job_icons.rsi
+        state: hudsquad_liaison
     - type: AssignSquad
       whitelist:
         tags:
@@ -119,13 +119,12 @@
       prefix: au14-job-prefix-civiliancorporateadminassistant
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
+        state: corporate_assistant
     - type: AssignSquad
       whitelist:
         tags:
         - SquadPMC
-  hidden: false
 
 - type: startingGear
   id: AU14GearCivilianCorporateAdminAssistant

--- a/Resources/Prototypes/_AU14/Roles/Jobs/WeYu/colonycorporateliaison.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/WeYu/colonycorporateliaison.yml
@@ -67,13 +67,12 @@
       prefix: au14-job-prefix-corporateliaison
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: _RMC14/Interface/cm_job_icons.rsi
+        state: hudsquad_liaison
     - type: AssignSquad
       whitelist:
         tags:
         - SquadPMC
-  hidden: false
 
 - type: startingGear
   id: AU14GearCivilianCorporateLiaison

--- a/Resources/Prototypes/_AU14/Roles/Jobs/WeYu/colonyscientist.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/WeYu/colonyscientist.yml
@@ -51,13 +51,12 @@
       prefix: au14-job-prefix-civilianscientist
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: _RMC14/Interface/cm_job_icons.rsi
+        state: weya_scientist
     - type: AssignSquad
       whitelist:
         tags:
         - SquadPMC
-  hidden: false
 
 - type: startingGear
   id: AU14GearCivilianScientist

--- a/Resources/Prototypes/_AU14/Roles/Jobs/WeYu/weyucorporateguard.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/WeYu/weyucorporateguard.yml
@@ -66,13 +66,12 @@
       prefix: au14-job-prefix-wyguard
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: synth
+        sprite: _RMC14/Interface/cm_job_icons.rsi
+        state: weya_goon_standard
     - type: AssignSquad
       whitelist:
         tags:
         - SquadPMC
-  hidden: false
 
 - type: startingGear
   id: AU14GearWYGuard

--- a/Resources/Prototypes/_AU14/Roles/squads_govfor.yml
+++ b/Resources/Prototypes/_AU14/Roles/squads_govfor.yml
@@ -12,12 +12,9 @@
     minimapBackground:
       sprite: /Textures/_RMC14/Interface/map_blips.rsi
       state: background_alpha
-    leaderIcon:
-      sprite: _RMC14/Interface/cm_job_icons.rsi
-      state: hudsquad_leader_a
 
 - type: entity
-  parent: SquadBase
+  parent: SquadGovfor
   id: SquadGovforBravo
   name: Bravo
   components:
@@ -26,15 +23,12 @@
     color: "#c7b646"
     group: GOVFOR
     radio: radioGovforBravo
-    accessLevels:
-    - AU14AccessGovforSquad
-    - AU14AccessOpfor
     minimapBackground:
      sprite: /Textures/_RMC14/Interface/map_blips.rsi
      state: background_bravo
 
 - type: entity
-  parent: SquadBase
+  parent: SquadGovfor
   id: SquadGovforCharlie
   name: Charlie
   components:
@@ -43,15 +37,12 @@
     group: GOVFOR
     color: "#9D3EF0"
     radio: radioGovforCharlie
-    accessLevels:
-    - AU14AccessGovforSquad
-    - AU14AccessOpfor
     minimapBackground:
      sprite: /Textures/_RMC14/Interface/map_blips.rsi
      state: background_charlie
 
 - type: entity
-  parent: SquadBase
+  parent: SquadGovfor
   id: SquadGovforIntel
   name: Auxiliary
   components:
@@ -60,9 +51,6 @@
     roundStart: true
     color: "#228B22"
     radio: radioGovforIntel
-    accessLevels:
-    - AU14AccessGovforSquad
-    - AU14AccessOpfor
     minimapBackground:
      sprite: /Textures/_RMC14/Interface/map_blips.rsi
      state: background_intel

--- a/Resources/Prototypes/_AU14/Roles/squads_opfor.yml
+++ b/Resources/Prototypes/_AU14/Roles/squads_opfor.yml
@@ -12,12 +12,9 @@
     minimapBackground:
       sprite: /Textures/_RMC14/Interface/map_blips.rsi
       state: background_sierra
-    leaderIcon:
-      sprite: _RMC14/Interface/cm_job_icons.rsi
-      state: hudsquad_leader_a
 
 - type: entity
-  parent: SquadBase
+  parent: SquadOpfor
   id: SquadOpforBravo
   name: Tango
   components:
@@ -26,15 +23,12 @@
     color: "#c6c1a8"
     group: OPFOR
     radio: radioOpforBravo
-    accessLevels:
-    - AU14AccessOpfor
-    - AU14AccessGovfor
     minimapBackground:
      sprite: /Textures/_RMC14/Interface/map_blips.rsi
      state: background_tango
 
 - type: entity
-  parent: SquadBase
+  parent: SquadOpfor
   id: SquadOpforCharlie
   name:  Uniform
   components:
@@ -43,15 +37,12 @@
     color: "#7A967E"
     radio: radioOpforCharlie
     group: OPFOR
-    accessLevels:
-    - AU14AccessOpfor
-    - AU14AccessGovfor
     minimapBackground:
      sprite: /Textures/_RMC14/Interface/map_blips.rsi
      state: background_uniform
 
 - type: entity
-  parent: SquadBase
+  parent: SquadOpfor
   id: SquadOpforIntel
   name: Intel # this will cause confusion, but better than x2 Auxiliary
   components:
@@ -60,9 +51,6 @@
     color: "#1E90FF"
     group: OPFOR
     radio: radioOpforIntel
-    accessLevels:
-    - AU14AccessOpfor
-    - AU14AccessGovfor
     minimapBackground:
      sprite: /Textures/_RMC14/Interface/map_blips.rsi
      state: background_intel

--- a/Resources/Prototypes/_AU14/Species/workingjoe.yml
+++ b/Resources/Prototypes/_AU14/Species/workingjoe.yml
@@ -2,7 +2,7 @@
   id: WorkingJoe
   name: species-name-workingjoe
   roundStart: false
-  prototype: AU14MobWorkingJoe
+  prototype: AU14MobWorkingJoeColony
   sprites: MobWorkingJoeSprites
   markingLimits: MobHumanMarkingLimits
   dollPrototype: MobHumanDummy

--- a/Resources/Prototypes/_AU14/thirdParties/WorkingJoes/thirdPartyWorkingJoes.yml
+++ b/Resources/Prototypes/_AU14/thirdParties/WorkingJoes/thirdPartyWorkingJoes.yml
@@ -3,7 +3,7 @@
   leadersToSpawn:
     AU14AICoreApolloCivilian: 1
   gruntsToSpawn:
-    AU14MobWorkingJoe: 2
+    AU14MobWorkingJoeColony: 2
   scalewithpop: false
   spawnTogether: true
 
@@ -20,9 +20,9 @@
 - type: partySpawn
   id: WorkingJoesNoAPOLLO
   leadersToSpawn:
-    AU14MobWorkingJoe: 1
+    AU14MobWorkingJoeColony: 1
   gruntsToSpawn:
-    AU14MobWorkingJoe: 1
+    AU14MobWorkingJoeColony: 1
   scalewithpop: false
   spawnTogether: true
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/universal_recorder.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/universal_recorder.yml
@@ -29,7 +29,6 @@
   - type: ContainerContainer
     containers:
       rmc_universal_recorder_tape: !type:ContainerSlot {}
-  - type: ItemSlots
   - type: UserInterface
     interfaces:
       enum.UniversalRecorderUiKey.Recorder:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/pamphlets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/pamphlets.yml
@@ -100,11 +100,11 @@
     giveMapBlip:
       sprite: /Textures/_RMC14/Interface/map_blips.rsi
       state: spotter
-    jobWhitelists:
-    - popup: rmc-pamphlets-rifleman-warning
-      jobProto: CMRifleman
-    - popup: rmc-pamphlets-rifleman-warning
-      jobProto: CMPVERifleman
+    # jobWhitelists:
+    # - popup: rmc-pamphlets-rifleman-warning
+    #   jobProto: CMRifleman
+    # - popup: rmc-pamphlets-rifleman-warning
+    #   jobProto: CMPVERifleman
 
 - type: entity
   parent: CMPamphlet
@@ -213,11 +213,11 @@
       sprite: /Textures/_RMC14/Interface/map_blips.rsi
       state: loader
     bypassLimit: true
-    jobWhitelists:
-    - popup: rmc-pamphlets-rifleman-warning
-      jobProto: CMRifleman
-    - popup: rmc-pamphlets-rifleman-warning
-      jobProto: CMPVERifleman
+    # jobWhitelists:
+    # - popup: rmc-pamphlets-rifleman-warning
+    #   jobProto: CMRifleman
+    # - popup: rmc-pamphlets-rifleman-warning
+    #   jobProto: CMPVERifleman
 
 - type: entity
   parent: CMPamphlet
@@ -244,11 +244,11 @@
       sprite: /Textures/_RMC14/Interface/map_blips.rsi
       state: mortar
     bypassLimit: true
-    jobWhitelists:
-    - popup: rmc-pamphlets-rifleman-warning
-      jobProto: CMRifleman
-    - popup: rmc-pamphlets-rifleman-warning
-      jobProto: CMPVERifleman
+    # jobWhitelists:
+    # - popup: rmc-pamphlets-rifleman-warning
+    #   jobProto: CMRifleman
+    # - popup: rmc-pamphlets-rifleman-warning
+    #   jobProto: CMPVERifleman
 
 - type: entity
   parent: CMPamphlet
@@ -286,9 +286,9 @@
       sprite: /Textures/_RMC14/Interface/map_blips.rsi
       state: honorguard
     bypassLimit: true
-    jobWhitelists:
-    - popup: rmc-pamphlets-mp-warning
-      jobProto: CMMilitaryPolice
+    # jobWhitelists:
+    # - popup: rmc-pamphlets-mp-warning
+    #   jobProto: CMMilitaryPolice
 
 # LANGUAGE / bypasses limit
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_attachment_base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_attachment_base.yml
@@ -44,6 +44,7 @@
     virtualRight: RMCVirtualDropshipGearRight
     virtualLeft: RMCVirtualDropshipGearLeft
   - type: Item
+    size: Ginormous
   - type: XenoCrusherChargable
     instantDestroy: true
   - type: VisiblyAcidOutsideContainer

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
@@ -7,8 +7,7 @@
   description: An automated gear rack for combat technicians.
   components:
   - type: AccessReader
-    access:
-    - [ "CMAccessCombatTechPrep" ]
+    access: [["CMAccessCombatTechPrep"], ["AU14AccessGovforEngineering"], ["AU14AccessOpforEngineering"]]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/combat_technician_gear.rsi
   - type: CMAutomatedVendor
@@ -212,8 +211,7 @@
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
   - type: AccessReader
-    access:
-    - [ "CMAccessCombatTechPrep" ]
+    access: [["CMAccessCombatTechPrep"], ["AU14AccessGovforEngineering"], ["AU14AccessOpforEngineering"]]
   - type: CMAutomatedVendor
     jobs:
     - CMCombatTech
@@ -336,8 +334,7 @@
   description: A vending machine that stores various extra tools that are useful on the field.
   components:
   - type: AccessReader
-    access:
-    - [ "CMAccessCombatTechPrep" ]
+    access: [["CMAccessCombatTechPrep"], ["AU14AccessGovforEngineering"], ["AU14AccessOpforEngineering"]]
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/tool.rsi
     layers:
@@ -346,8 +343,7 @@
     - state: "normal-unshaded"
       map: [ "enum.VendingMachineVisualLayers.BaseUnshaded" ]
   - type: CMAutomatedVendor
-    access:
-    - "CMAccessCombatTechPrep"
+    access: ["CMAccessCombatTechPrep", "AU14AccessGovforEngineering", "AU14AccessOpforEngineering"]
     hackable: true
     jobs:
     - CMCombatTech

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -492,7 +492,7 @@
     denyState: deny-unshaded
     ejectState: eject-unshaded
   - type: AccessReader
-    access: [ [ "AU14AccessGovforSecurity" ], [ "AU14AccessOpforSecurity" ] ]
+    access: [["AU14AccessGovforSecurity"], ["AU14AccessOpforSecurity"], ["CMAccessArmory"]]
 
 - type: vendingMachineInventory
   id: CMVendorSec

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_goon_medic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_goon_medic.yml
@@ -24,8 +24,8 @@
     - type: RMCAllowSuitStorage
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: goon_med
+        sprite: _RMC14/Interface/cm_job_icons.rsi
+        state: weya_goon_medic
       background:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: background_goon


### PR DESCRIPTION
- **🔧 forced punctuation by default - allow user preference**
- **📋 fixed being able to put CAS munitions into toolbox/storage via powerloader**
- **🔧 added CMB access to the military SecTech**
- **🔧 working joe loadout & mob spawn fix**
- **📋 removed legacy rifleman requirement from certain pamphlets**
- **📋 removed UPP amb from a UPP map & corporate gone**
- **🩹 fixes Govfor/Opfor getting the opposite faction access through their squads**
- **📋 indent fix - no changes**
- **🩹 wrap third party spawns in a try/catch block to halt faulty prototype impact**
- **🩹 apply OPFOR/GOVFOR radio channels on promotion instead of legacy MarineJTAC/MarineCommand**
- **🩹 updated TacMap blips - yes the ratio is skewed.**
- **📋 TestLoadAll failed because of duplicate 'rmc' key in .tomls?**
- **🩹 add error logging to tacmaps for client**
- **📋 uhm ok testcase v2**

## About the PR
- Working Joe would restart rounds because it's trying to spawn an abstract Mob entity
- Duplicate WJ loadouts fixed

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Being able to put CAS munitions into toolboxes or pouches (any storage) via Powerloader
- tweak: CMB access to the military SecTech (used by Hope's Retreat)
- fix: HRP roles holding the server hostage with WJ round restarts
- tweak: Pamphlets can be used by any marine that finds it
- fix: Govfor/Opfor getting opposite faction access from their squads
- code: Third Party spawns are wrapped in try/catch logs for entities/leader/members
- fix: OPFOR/GOVFOR radio channels are given on promotion - instead of old legacy JTAC/Command channels
- tweak: TacMap blips - yes the icon is still small but at least not mini - will be fixed
