### PR TITLE
70 hour E7 rankup for Squad Leaders

### DIFF
--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/squadsergeantBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/squadsergeantBase.yml
@@ -31,6 +31,12 @@
   ranks:
     RMCRankCivilian: []
   chevrons:
+    RMCRankGunnerySergeant:
+      entity: AU14ChevronUSCMGunnerySergeant
+      requirements:
+      - !type:RoleTimeRequirement
+        role: AU14JobGOVFORSquadSergeant
+        time: 252000 # 70 hours
     RMCRankStaffSergeant:
       entity: AU14ChevronUSCMStaffSergeant
       requirements:


### PR DESCRIPTION
Just adds a 70 hour E7 rank for experienced SLs

I'm fairly biased and would very much like to be able to get E7 on SL in cmu, but I also think this serves some other purposes.

- Gives a greater incentive for more players to play SL more frequently. There's been something of a lack of consistent SL players. I consider myself as an SL main, but I've hardly ever seen the server full on SLs, and somewhat frequently there will be none. This kind of makes everyone's lives worse in ways that everyone probably understands, so maybe this would incentivize more SL play.
- This means that SLs can match the rank of MPs who go from E4-E7. I kind of find it strange that MPs would outrank SLs even when starting as a Corporal. I guess the E7s are sort of meant to be a stand in for Wardens, but still is odd.
- Giving marines the nickname of "Gunny" will help in the unending quest to get them to stop calling you "Sir"

If some other playtime seems like a better pick for this second rankup, then I'd totally change it over.

First PR here, so feel free to beat me with a stick if I did anything wrong.