### PR TITLE
Experimental meson goggles for GOVFOR synths

### DIFF
--- a/Resources/Prototypes/_AU14/Roles/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_AU14/Roles/Loadouts/loadout_groups.yml
@@ -890,6 +890,39 @@
   - GlassesSecurityRMC
 
 - type: loadoutGroup
+  id: GOVFORSynthGlassesAU14
+  name: rmc-loadout-group-synthetic-glasses
+  minLimit: 0
+  maxLimit: 2
+  loadouts:
+  - GlassesMedicalHUDGlassesAU14
+  - AviatorsRMC
+  - EyepatchRMC
+  - GlassesRPGRMC
+  - GlassesRPGRMCOld
+  - GlassesPrescriptionRMC
+  - GogglesRMC
+  - GogglesPrescriptionRMC
+  - GogglesBlackRMC
+  - GogglesOrangeRMC # TODO add prescription variants of all the goggles
+  - GogglesAdvancedRMC
+  - GogglesM1A1RMC
+  - PersonalShadesRMC
+  - SunglassesRMC # TODO prescription sunglasses
+  - GlassesTriMaxYellowRMC
+  - GlassesTriMaxBronzeRMC
+  - GlassesTriMaxBlackRMC
+  - GogglesRedRMC
+  - GogglesBlueRMC
+  - GogglesPurpleRMC
+  - GogglesYellowRMC
+  - GogglesPolarizedBlueRMC
+  - GogglesPolarizedOrangeRMC
+  - GogglesM1A1BlueRMC
+  - GlassesSecurityRMC
+  - RMCGlassesExperimentalMeson
+
+- type: loadoutGroup
   id: SynthUniformAU14
   name: rmc-loadout-group-synthetic-uniform
   minLimit: 1

--- a/Resources/Prototypes/_AU14/Roles/Loadouts/role_loadouts_military.yml
+++ b/Resources/Prototypes/_AU14/Roles/Loadouts/role_loadouts_military.yml
@@ -227,7 +227,7 @@
   - SynthPouchesRightAU14
   - SynthGlovesAU14
   - SynthHeadwearAU14
-  - SynthGlassesAU14
+  - GOVFORSynthGlassesAU14
   - SynthUniformAU14
   - SynthUniformAccessoriesRMC
   - SynthSuitAU14


### PR DESCRIPTION
## About the PR
Re-added experimental meson goggles for GOVFOR synthetics.

## Why / Balance
Experimental meson goggles in my experience were only used for recovering bodies and avoiding danger. I've never used the meson goggles in combat as a GOVFOR synth, and if I have, it was for self-defense. Colony synthetics on insurgency should not get the meson goggles because they're the ones who are usually killed and converted into rogue synths. The goggles are also experimental... meaning the colony shouldn't have access to this piece of technology as it would be too expensive.

## Technical details

- Added a new group to `role_loadouts_military.yml` called `GOVFORSynthGlassesAU14`
-  removed the old group in  `role_loadouts_military.yml` called `SynthGlassesAU14`
-  added a new loadoutgroup in `loadout_groups.yml` under the id of `GOVFORSynthGlassesAU14` and added all the glasses which `SynthGlassesAU14` had, including the `RMCGlassesExperimentalMeson`, making it so colony synths don't get the experimental meson goggles, but GOVFOR synths get them.

## Requirements
* [x]  I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
* [x]  I have added media to this PR or it does not require an ingame showcase.
* [x]  I have included a **brief** detail of the major changes for this PR in the changelog below.
* [x]  By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

## Changelog
:cl:
* add: Re-added experimental meson goggles for GOVFOR synthetics only.
