### PR TITLE
E7 Rankup for Squad Leaders

### DIFF
--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/squadsergeantBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/squadsergeantBase.yml
@@ -31,6 +31,12 @@
   ranks:
     RMCRankCivilian: []
   chevrons:
+    RMCRankGunnerySergeant:
+      entity: AU14ChevronUSCMGunnerySergeant
+      requirements:
+      - !type:RoleTimeRequirement
+        role: AU14JobGOVFORSquadSergeant
+        time: 262000 # 70 hours
     RMCRankStaffSergeant:
       entity: AU14ChevronUSCMStaffSergeant
       requirements:


### PR DESCRIPTION
## About the PR
Adds an E7 rank at 70 hours for the Squad Leader role.

## Why / Balance
The game suffers from a lack of players willing to fill the SL role. This might convince more SLs to play more consistently for the role to see and use the higher rank. It's quite fun to be able to be a "Gunny" to your marines, and gives them another name to call you besides the dreaded "Sir." MP's ranks vary from E4-E7, making it so SLs can match them seems like a sensible choice as well. Including a second rankup for SLs doesn't otherwise change any other rank relationships, as everyone above them is still above them, and everyone below them is still below them. Otherwisel; full disclosure, I play a lot of SL and generally think that myself and the other SLs would enjoy this.

## Technical details
Added 6 lines of YAML in `SquadsergeantBase.yml`

## Media
Small Change

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Added an E7 rank for Squad Leaders at 70 hours of playtime.
