### PR TITLE
Marine Orders hotfixz

### DIFF
--- a/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
@@ -164,7 +164,12 @@ public abstract partial class SharedMarineOrdersSystem : EntitySystem
 
         var leadershipSkill = _skills.GetSkill(orders.Owner, orders.Comp.Skill);
         if (leadershipSkill <= 0 && !HasComp<SquadLeaderComponent>(orders.Owner))
+        {
+            _actions.RemoveAction(orders.Owner, orders.Comp.FocusActionEntity);
+            _actions.RemoveAction(orders.Owner, orders.Comp.HoldActionEntity);
+            _actions.RemoveAction(orders.Owner, orders.Comp.MoveActionEntity);
             return false;
+        }
 
         var level = Math.Max(1, leadershipSkill);
         var duration = orders.Comp.Duration * (level + 1);

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Accessory/armorwebbing.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Accessory/armorwebbing.yml
@@ -67,6 +67,7 @@
       - CMMagazineSmg
       - CMMagazineSniper
       - RMCShellShotgun
+      - RMCShellShotgunHDSG
       - RMCMagazineSmartGun
   - type: FixedItemSizeStorage
   - type: Webbing
@@ -84,6 +85,7 @@
         - CMMagazineSmg
         - CMMagazineSniper
         - RMCShellShotgun
+        - RMCShellShotgunHDSG
         - RMCMagazineSmartGun
     - type: FixedItemSizeStorage
     - type: RMCStorageEjectHand
@@ -115,6 +117,7 @@
       - CMMagazineSmg
       - CMMagazineSniper
       - RMCShellShotgun
+      - RMCShellShotgunHDSG
   - type: FixedItemSizeStorage
   - type: Webbing
     components:
@@ -131,6 +134,7 @@
         - CMMagazineSmg
         - CMMagazineSniper
         - RMCShellShotgun
+        - RMCShellShotgunHDSG
     - type: FixedItemSizeStorage
     - type: RMCStorageEjectHand
       state: Open
@@ -232,6 +236,7 @@
     whitelist:
       tags:
       - RMCShellShotgun
+      - RMCShellShotgunHDSG
   - type: FixedItemSizeStorage
   - type: Webbing
     components:
@@ -242,6 +247,7 @@
       whitelist:
         tags:
         - RMCShellShotgun
+        - RMCShellShotgunHDSG
     - type: FixedItemSizeStorage
     - type: RMCStorageEjectHand
       state: Open

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -31,6 +31,7 @@
       tags:
       - Flare
       - RMCShellShotgun
+      - RMCShellShotgunHDSG
       - CMMagazinePistol
       - RMCMagazineRevolver
       - CMMagazineRifle
@@ -50,6 +51,7 @@
       tags:
       - CMMagazineRifle
       - RMCMagazineShotgun
+      - RMCShellShotgunHDSG
       - CMMagazineSmg
   - type: FixedItemSizeStorage
   - type: ItemCamouflage
@@ -316,6 +318,7 @@
       - PowerCell
       - CMFireExtinguisherPortable
       - RMCShellShotgun
+      - RMCShellShotgunHDSG
       - RMCNailgunCompact
       - RMCNailgunTactical
       - RMCSynthResetKey
@@ -515,6 +518,7 @@
       - CMMagazineSniper
       - RMCMagazineSmartGun
       - RMCShellShotgun
+      - RMCShellShotgunHDSG
       - Flare
   - type: FixedItemSizeStorage
   - type: IgnoreContentsSize
@@ -1448,6 +1452,7 @@
       - RMCWeaponShotgunXM51
       - RMCMagazineShotgunXM51
       - RMCShellShotgun # TODO RMC14 bullet handfuls
+      - RMCShellShotgunHDSG
   - type: FixedItemSizeStorage
   - type: CMHolster
     whitelist:
@@ -2409,6 +2414,7 @@
     whitelist:
       tags:
       - RMCShellShotgun
+      - RMCShellShotgunHDSG
   - type: FixedItemSizeStorage
   - type: CMHolster
   - type: LimitedStorage
@@ -2493,6 +2499,7 @@
       - Flashlight
       - CMMagazinePistol
       - RMCShellShotgun
+      - RMCShellShotgunHDSG
       - RMCMagazineRevolver
       - Donut
       - RMCGrenadeFlashBang

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/police.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/police.yml
@@ -19,6 +19,7 @@
       - Flashlight
       - CMMagazinePistol
       - RMCShellShotgun
+      - RMCShellShotgunHDSG
       - RMCMagazineRevolver
       - Donut
       - RMCGrenadeFlashBang

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
@@ -178,6 +178,7 @@
       - CMMagazineSmg
       - CMMagazineSniper
       - RMCShellShotgun
+      - RMCShellShotgunHDSG
       # TODO RMC14 m60 mag
   - type: FixedItemSizeStorage
 
@@ -273,12 +274,14 @@
     whitelist:
       tags:
       - RMCShellShotgun
+      - RMCShellShotgunHDSG
       - RMCCartridge458SOCOM
   - type: FixedItemSizeStorage
   - type: IgnoreContentsSize
     items:
       tags:
       - RMCShellShotgun
+c     - RMCShellShotgunHDSG
   - type: Tag
     tags:
     - Pouch
@@ -313,11 +316,13 @@
     whitelist:
       tags:
       - RMCShellShotgun
+      - RMCShellShotgunHDSG
       - RMCCartridge458SOCOM
   - type: IgnoreContentsSize
     items:
       tags:
       - RMCShellShotgun
+      - RMCShellShotgunHDSG
   - type: ItemMapper
     mapLayers:
       half:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/mk481_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/mk481_shotgun.yml
@@ -88,6 +88,7 @@
     - RMCHandful
     - Cartridge
     - RMCShellShotgunHDSG
+    - RMCShellShotgun
 
 - type: stack
   id: RMCShellShotgunHDSG


### PR DESCRIPTION
- **📋 RMCShellShotgunHDSG allowed where shotgun shells can be stored**
- **🩹 fixed being able to use MarineOrders without cooldown**

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed being able to use MarineOrders without cooldown as promoted SL
- fix: RMCShellShotgunHDSG was not able to be put in storage like other shells (pouches/vests etc.)
