### PR TITLE
Update vending_machines.yml

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -517,6 +517,7 @@
     #ClueScanner: 3
     #Camera: 8
     #CameraFilm: 8
+    CMU14TearGasGrenade: 4
     RMCWhistle: 5
     RMCFoodDonut: 12
     RMCBoxDonut: 2 #Contraband


### PR DESCRIPTION

## About the PR
added 4 M19-NL Tear Gas grenades into sectech vendors

## Why / Balance
Better riot control since the riot control vendors aren't available most of the times

## Technical details
added 3 lines to Prototypes\_RMC14\Entities\Structures\Machines\Vending\vending_machines.yml

CMU14TearGasGrenade: 4 
CMMaskGas: 4
CMUGasMaskFilter: 8

## Media
<img width="528" height="541" alt="image" src="https://github.com/user-attachments/assets/3fe4614c-83f5-4523-b066-5399f9b3752e" />



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: added four M19-NL Tear Gas nades into SecTech vendors
- add: added four gas mask and eight filters
