### PR TITLE
CO's Silence Order

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -18,6 +18,7 @@ using Content.Shared._CMU14.Yautja;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Chat;
 using Content.Shared._RMC14.Mentor.ImaginaryFriend;
+using Content.Shared._AU14.Marines.Orders;
 using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.ActionBlocker;
@@ -292,6 +293,10 @@ public sealed partial class ChatSystem : SharedChatSystem
                 return;
             }
         }
+
+        // AU14: Silence Order forces speak → whisper for the duration.
+        if (desiredType == InGameICChatType.Speak && HasComp<AU14SilenceOrderComponent>(source))
+            desiredType = InGameICChatType.Whisper;
 
         // Otherwise, send whatever type.
         switch (desiredType)

--- a/Content.Server/_AU14/Marines/Orders/AU14SilenceOrderSystem.cs
+++ b/Content.Server/_AU14/Marines/Orders/AU14SilenceOrderSystem.cs
@@ -1,0 +1,123 @@
+using Content.Server.Actions;
+using Content.Shared._AU14.Marines.Orders;
+using Content.Shared._RMC14.Chat;
+using Content.Shared._RMC14.Marines;
+using Content.Shared.Chat;
+using Content.Shared.Humanoid;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Popups;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Content.Server._AU14.Marines.Orders;
+
+public sealed partial class AU14SilenceOrderSystem : EntitySystem
+{
+    [Dependency] private ActionsSystem _actions = default!;
+    [Dependency] private SharedCMChatSystem _cmChat = default!;
+    [Dependency] private EntityLookupSystem _entityLookup = default!;
+    [Dependency] private MobStateSystem _mobState = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private IGameTiming _timing = default!;
+
+    private readonly HashSet<Entity<MarineComponent>> _receivers = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AU14SilenceOrderAbilityComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<AU14SilenceOrderAbilityComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<AU14SilenceOrderAbilityComponent, AU14SilenceActionEvent>(OnSilenceAction);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var time = _timing.CurTime;
+        var query = EntityQueryEnumerator<AU14SilenceOrderComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (comp.ExpiresAt < time)
+                RemCompDeferred<AU14SilenceOrderComponent>(uid);
+        }
+    }
+
+    private void OnStartup(Entity<AU14SilenceOrderAbilityComponent> ent, ref ComponentStartup args)
+    {
+        var comp = ent.Comp;
+        _actions.AddAction(ent, ref comp.SilenceActionEntity, comp.SilenceAction);
+        _actions.SetUseDelay(comp.SilenceActionEntity, comp.Cooldown);
+    }
+
+    private void OnShutdown(Entity<AU14SilenceOrderAbilityComponent> ent, ref ComponentShutdown args)
+    {
+        _actions.RemoveAction(ent.Owner, ent.Comp.SilenceActionEntity);
+    }
+
+    private void OnSilenceAction(Entity<AU14SilenceOrderAbilityComponent> ent, ref AU14SilenceActionEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!TryComp(ent, out TransformComponent? xform) || _mobState.IsDead(ent))
+            return;
+
+        args.Handled = true;
+
+        _actions.StartUseDelay(ent.Comp.SilenceActionEntity);
+
+        var expiresAt = _timing.CurTime + ent.Comp.Duration;
+
+        _receivers.Clear();
+        _entityLookup.GetEntitiesInRange(xform.Coordinates, ent.Comp.Range, _receivers);
+
+        var noticeMsg = Loc.GetString("au14-silence-order-notice");
+
+        foreach (var receiver in _receivers)
+        {
+            if (receiver.Owner == ent.Owner)
+                continue;
+
+            if (_mobState.IsDead(receiver))
+                continue;
+
+            var silence = EnsureComp<AU14SilenceOrderComponent>(receiver);
+            silence.ExpiresAt = expiresAt;
+
+            _popup.PopupEntity(noticeMsg, receiver, receiver, PopupType.Small);
+            _cmChat.ChatMessageToOne(noticeMsg, receiver, ChatChannel.Local, colorOverride: new Color(0.75f, 0.75f, 1f, 1f));
+        }
+
+        SendSilenceEmote(ent.Owner);
+    }
+
+    private void SendSilenceEmote(EntityUid source)
+    {
+        var pronoun = Loc.GetString("au14-silence-order-emote-pronoun-other");
+        if (TryComp<HumanoidAppearanceComponent>(source, out var appearance))
+        {
+            pronoun = appearance.Sex switch
+            {
+                Sex.Male => Loc.GetString("au14-silence-order-emote-pronoun-male"),
+                Sex.Female => Loc.GetString("au14-silence-order-emote-pronoun-female"),
+                _ => pronoun,
+            };
+        }
+
+        var entityName = FormattedMessage.EscapeText(Name(Identity.Entity(source, EntityManager)));
+        var emoteAction = Loc.GetString("au14-silence-order-emote-action", ("pronoun", pronoun));
+        var wrappedMessage = $"[font size=14][bold][color=#C4A35A]{entityName} {emoteAction}[/color][/bold][/font]";
+
+        _cmChat.ChatMessageToMany(
+            emoteAction,
+            wrappedMessage,
+            Filter.Pvs(source),
+            ChatChannel.Emotes,
+            source
+        );
+    }
+}

--- a/Content.Shared/_AU14/Marines/Orders/AU14SilenceOrderAbilityComponent.cs
+++ b/Content.Shared/_AU14/Marines/Orders/AU14SilenceOrderAbilityComponent.cs
@@ -1,0 +1,35 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._AU14.Marines.Orders;
+
+/// <summary>
+/// Added to the GOVFOR Platoon Commander. Grants the Silence Order ability with its own independent cooldown.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class AU14SilenceOrderAbilityComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntProtoId SilenceAction = "ActionMarineGovforSilence";
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? SilenceActionEntity;
+
+    /// <summary>
+    /// Cooldown in seconds between uses. Independent from other marine orders.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// How long targets remain whisper-only.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan Duration = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Radius of the effect in tiles.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Range = 7f;
+}

--- a/Content.Shared/_AU14/Marines/Orders/AU14SilenceOrderComponent.cs
+++ b/Content.Shared/_AU14/Marines/Orders/AU14SilenceOrderComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._AU14.Marines.Orders;
+
+/// <summary>
+/// Added to entities under the Silence Order effect. Forces whisper-only speech for the duration.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class AU14SilenceOrderComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan ExpiresAt;
+}

--- a/Content.Shared/_AU14/Marines/Orders/AU14SilenceOrderEvents.cs
+++ b/Content.Shared/_AU14/Marines/Orders/AU14SilenceOrderEvents.cs
@@ -1,0 +1,5 @@
+using Content.Shared.Actions;
+
+namespace Content.Shared._AU14.Marines.Orders;
+
+public sealed partial class AU14SilenceActionEvent : InstantActionEvent;

--- a/Resources/Locale/en-US/_AU14/chat/silence-order.ftl
+++ b/Resources/Locale/en-US/_AU14/chat/silence-order.ftl
@@ -1,0 +1,6 @@
+## Silence Order — CO ability
+au14-silence-order-notice = You feel the presence of a high ranking officer.
+au14-silence-order-emote-action = clears { $pronoun } throat loudly.
+au14-silence-order-emote-pronoun-male = his
+au14-silence-order-emote-pronoun-female = her
+au14-silence-order-emote-pronoun-other = their

--- a/Resources/Prototypes/_AU14/Actions/Marines/silence_order_action.yml
+++ b/Resources/Prototypes/_AU14/Actions/Marines/silence_order_action.yml
@@ -1,0 +1,13 @@
+- type: entity
+  parent: ActionMarineBase
+  id: ActionMarineGovforSilence
+  name: Issue Order - Silence
+  description: Commands the area into silence. Nearby personnel can only whisper for 10 seconds.
+  components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _RMC14/Actions/xeno_actions.rsi
+      state: psychic_whisper
+  - type: InstantAction
+    event: !type:AU14SilenceActionEvent

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/commanderBase.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Military/Base/commanderBase.yml
@@ -55,6 +55,7 @@
       preset: AU14SkillPresetPlatoonCommander
     - type: JobPrefix
       prefix: au14-job-prefix-govforplatco
+    - type: AU14SilenceOrderAbility
     - type: RMCSpeechBubbleSpecificStyle
       speechStyleClass: commanderSpeech
     - type: TacticalMapIcon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Commanding Officers are now able to issue a Silence order, an order that would force marines around them to only whisper for 10 seconds, with a 10 second cooldown.

**⚠️ The action icon needs a sprite! A xeno sprite has been used as a placeholder!**
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
For hopefully, more organized briefings
(this will definitely not backlash with spam-pointing)
## Technical details
<!-- Summary of code changes for easier review. -->
New `Silence Order` ability for the GOVFOR Platoon Commander. It runs completely separate from the existing Move/Focus/Hold order system so it has its own cooldown and doesn't interfere with those at all.

**What's new:**
- `AU14SilenceOrderAbilityComponent` sits on the CO (added via job `AddComponentSpecial`). It stores the action ref, a 10s cooldown, 10s effect duration and a 7 tile range.
- `AU14SilenceOrderComponent` is a networked component that gets slapped onto affected marines for the duration. It just tracks an `ExpiresAt` time and gets cleaned up by the system's `Update` loop when it runs out.

**Server system (`AU14SilenceOrderSystem`):**

Registers the action on startup, removes it on shutdown. When the action fires it sets its own use delay (does NOT touch Move/Focus/Hold cooldowns), grabs all `MarineComponent` entities in range, applies `AU14SilenceOrderComponent` to each one (reuse refreshes the timer), sends each target a private chat notice and popup, then sends the CO's throat-clear emote. The CO is skipped from the silence effect. Pronoun in the emote (his/her/their) is pulled from `HumanoidAppearanceComponent.Sex`. The emote bypasses the normal `SendEntityEmote` path so we can control font size and color directly via `SharedCMChatSystem.ChatMessageToMany` with a hand-built `wrappedMessage`.

**Chat hook (`ChatSystem.TrySendInGameICMessage`):**

Two lines added just before the `InGameICChatType` switch. If the message type is `Speak` and the source has `AU14SilenceOrderComponent`, it gets quietly redirected to `Whisper`. Simple and clean, works across all normal speech paths.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

https://github.com/user-attachments/assets/b1b7f3d4-f69e-4d5c-8f65-6e44d2a36bbc

<img width="325" height="257" alt="Discord_88mjLUneY8" src="https://github.com/user-attachments/assets/805f021f-b749-479f-aa47-afed7a84852c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: GOVFOR Platoon Commanders have a new Silence Order ability. Activating it forces nearby marines to whisper only for 10 seconds and sends them a subtle notification. The CO emotes a loud throat clear instead of shouting a callout. Has its own 10 second cooldown separate from the other orders.