### PR TITLE
Put queen time requirements back

### DIFF
--- a/Resources/Prototypes/_AU14/Roles/Jobs/Util/threatLeader.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Util/threatLeader.yml
@@ -18,10 +18,10 @@
   description: au-job-description-threat-leader
   setPreference: true
   playTimeTracker: AUJobThreatLeader
-  # requirements:
-  # - !type:RoleTimeRequirement
-  #   role: AUJobThreatMember
-  #   time: 7200 # 2 hours
+  requirements:
+  - !type:RoleTimeRequirement
+     role: AUJobThreatMember
+     time: 10800 # 3 hours
   hidden: false
   supervisors: nobody
   icon: "AU14JobIconThreatLeader"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

People who didn't even have a minute of xeno picking queen was a huge problem so I'm adding the requirement back.
Additionally made it 3 hours instead of 2. Not a big difference but still enough to keep baby xenos from picking the role

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Queen has time requirements again
