### PR TITLE
Gave Spotter Kit's Missing Spotter Pamphlet

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
@@ -804,6 +804,7 @@
     - id: RMCScoutShoes
     - id: CMBackpackSniper
     - id: RMCVisorNightVision
+    - id: CMPamphletSpotter
   - type: Tag
     tags:
     - AU14KitSpotter


### PR DESCRIPTION

## About the PR
Gave Spotter kit's (M96S/XM43E1) the pamphlet needed to use Spotter Bino's. 

## Why / Balance
It was missing.

## Technical details
Simple one line tweak, however this was down via web editing and is my first PR, also directly PR'd.
