### PR TITLE
Sheperds' quick fix & additions

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1272,7 +1272,7 @@
     - DoorBumpOpener
     - FootstepSound
   - type: GhostRole
-    prob: 0.25
+    prob: 0
     name: ghost-role-information-kangaroo-name
     description: ghost-role-information-kangaroo-description
     rules: ghost-role-information-nonantagonist-rules
@@ -3141,7 +3141,7 @@
     factions:
     - Syndicate
   - type: Access
-    tags: 
+    tags:
     - NuclearOperative
     - SyndicateAgent
   - type: MeleeWeapon

--- a/Resources/Prototypes/_AU14/Entities/JobStuff/crates.yml
+++ b/Resources/Prototypes/_AU14/Entities/JobStuff/crates.yml
@@ -113,3 +113,45 @@
       amount: 3
     - id: AU14ToolPickaxe
       amount: 3
+
+- type: entity
+  id: CMUCrateLivestockWeYu
+  parent: CrateLivestock
+  name: experiment subject crate
+  description: A crate containing an experiment subject.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: CMUCrateLivestockWeYuRandomSelection
+
+- type: entityTable
+  id: CMUCrateLivestockWeYuRandomSelection
+  table: !type:GroupSelector
+    children:
+    - !type:GroupSelector
+      children:
+      - id: MobCow
+      - id: MobGoat
+      - id: MobGorilla
+      - id: MobKangaroo
+      - id: MobPig
+      - !type:GroupSelector
+        weight: 0.75
+        children:
+        - id: RMCMobSmallHostFarwa
+          amount: 3
+        - id: CMMobSmallHostKobold
+          amount: 3
+          weight: 2
+        - id: CMMobSmallHostMonkey
+          amount: 3
+          weight: 4
+        - id: RMCMobSmallHostNeaera
+          amount: 3
+        - id: RMCMobSmallHostStok
+          amount: 3
+        - id: RMCMobSmallHostYiren
+          amount: 3
+        - id: CMUMobCarp
+          amount: 3

--- a/Resources/Prototypes/_AU14/objectives/destroyobjectives.yml
+++ b/Resources/Prototypes/_AU14/objectives/destroyobjectives.yml
@@ -48,27 +48,3 @@
     entitytodestroy: AU14ObjectiveItemAIProcessor
     useanyentity: true
     amounttodestroy: 1
-
-- type: entity
-  name: Destroy Carp
-  parent: MarkerBase
-  id: destroy_carp
-  description: "Destroy a carp"
-  components:
-  - type: Sprite
-    state: red
-  - type: AuObjective
-    id: destroycarp
-    factioneutral: false
-    applicableModes:
-    - Insurgency
-    possiblefactions:
-    - clf
-    repeating: true
-    objectivelevel: 1
-    custompoints: 5
-    ObjectiveDescription: "Destroy a carp"
-  - type: DestroyObjective
-    entitytodestroy: CMUMobCarp
-    useanyentity: true
-    amounttodestroy: 1

--- a/Resources/Prototypes/_AU14/objectives/killobjectives.yml
+++ b/Resources/Prototypes/_AU14/objectives/killobjectives.yml
@@ -264,3 +264,25 @@
   - type: KillObjective
     amounttokill: 1
     specificjob: AU14JobThreatMember
+
+- type: entity
+  name: Kill the Carp
+  parent: MarkerBase
+  id: killcarpobjective
+  components:
+  - type: Sprite
+    state: red
+  - type: AuObjective
+    id: killcarpobj
+    factioneutral: false
+    applicableModes:
+    - insurgency
+    possiblefactions:
+    - clf
+    repeating: true
+    objectivelevel: 1
+    custompoints: 5
+    ObjectiveDescription: "Kill the Carp"
+  - type: KillObjective
+    mobtokill: CMUMobCarp
+    factiontokill: SimpleNeutral


### PR DESCRIPTION
## About the PR
Added observer spawn point (to hopefully fix tacmap issues). Non-working destroy carp objective replaced with working kill carp objective. Added preliminary experiment subject crate to specimen chamber at Labs. (It will eventually have a chance to contain deadlier test subjects) Removed Kangaroo ghost role chance.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Sheperds': Ghost spawn point (fix tacmap?)
- add: Sheperds': Preliminary experiment subject crate
- fix: Sheperds': Kill carp objective for CLF