### PR TITLE
Debugging Commands (serverlogs/serversawmills)

### DIFF
--- a/Content.Server/_CMU14/Blackfoot/VehicleRejuvenateSystem.cs
+++ b/Content.Server/_CMU14/Blackfoot/VehicleRejuvenateSystem.cs
@@ -1,0 +1,73 @@
+using System.Linq;
+using Content.Shared._CMU14.Blackfoot;
+using Content.Shared._RMC14.Vehicle;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Damage;
+using Content.Shared.Rejuvenate;
+using Content.Shared.Vehicle.Components;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Containers;
+
+namespace Content.Server._CMU14.Blackfoot;
+
+public sealed partial class VehicleRejuvenateSystem : EntitySystem
+{
+    [Dependency] private DamageableSystem _damageable = default!;
+    [Dependency] private HardpointSystem _hardpoint = default!;
+    [Dependency] private VehicleTopologySystem _topology = default!;
+    [Dependency] private VehicleHardpointAmmoSystem _ammo = default!;
+    [Dependency] private SharedContainerSystem _container = default!;
+    [Dependency] private SharedGunSystem _gun = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<VehicleComponent, RejuvenateEvent>(OnRejuvenateVehicle);
+    }
+
+    private void OnRejuvenateVehicle(EntityUid uid, VehicleComponent component, RejuvenateEvent args)
+    {
+        if (TryComp<DamageableComponent>(uid, out var damageable))
+            _damageable.SetDamage(uid, damageable, new DamageSpecifier());
+
+        _hardpoint.ResetAllHardpointsToFullHealth(uid); // heal hardpoints & recalc integrity
+        _hardpoint.ClearAllFailures(uid); // bulk resets failures, repair/progress + refresh UI
+
+        if (TryComp<BlackfootFuelPowerComponent>(uid, out var fuelPower))
+        {
+            fuelPower.Fuel = fuelPower.MaxFuel;
+            fuelPower.Battery = fuelPower.MaxBattery;
+            Dirty(uid, fuelPower);
+        }
+
+        RearmAllHardpoints(uid);
+    }
+
+    private void RearmAllHardpoints(EntityUid vehicle)
+    {
+        if (!TryComp<HardpointSlotsComponent>(vehicle, out var hardpoints)
+            || !TryComp<ItemSlotsComponent>(vehicle, out var itemSlots))
+            return;
+
+        foreach (var mounted in _topology.GetMountedSlots(vehicle, hardpoints, itemSlots))
+        {
+            if (mounted.Item is not { } item)
+                continue;
+
+            if (!TryComp<VehicleHardpointAmmoComponent>(item, out var hardpointAmmo)
+                    || !TryComp<BallisticAmmoProviderComponent>(item, out var ammoProvider))
+                continue;
+
+            if (_container.TryGetContainer(item, ammoProvider.Container.ID, out var container))
+                foreach (var ent in container.ContainedEntities.ToArray())
+                    Del(ent); // clear ammo
+            _gun.SetBallisticUnspawned((item, ammoProvider), ammoProvider.Capacity); // refill ammo
+            Dirty(item, ammoProvider);
+
+            var magazineSize = _ammo.GetMagazineSize(hardpointAmmo, ammoProvider);
+            var maxStored = _ammo.GetMaxStoredRounds(hardpointAmmo, magazineSize);
+            _ammo.SetStoredRounds((item, hardpointAmmo), maxStored, magazineSize);
+        }
+    }
+}

--- a/Content.Server/_CMU14/Profiling/CMUServerLogsCommand.cs
+++ b/Content.Server/_CMU14/Profiling/CMUServerLogsCommand.cs
@@ -1,0 +1,453 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+using Robust.Shared.Utility;
+using Robust.Shared.Player;
+
+namespace Content.Server._CMU14.Profiling;
+
+[AdminCommand(AdminFlags.Host)]
+public sealed partial class ServerLogsCommand : LocalizedCommands
+{
+    public override string Command => "serverlogs";
+    public override string Description => "Prints the server (or specified file) logs to the client's console, with --tail to chat.";
+    public override string Help => $"Usage: {Command} [filter] [lines] | {Command} --list | {Command} --file <path> [filter] | {Command} --follow [filter] | {Command} --stop";
+
+    [Dependency] private IPlayerManager _playerManager = default!;
+    [Dependency] private IEntityManager _entityManager = default!;
+
+    private static readonly string logDir = Environment.CurrentDirectory;
+    private static readonly string primaryClr = Color.Green.ToHex();
+    private static readonly string secondaryClr = Color.Yellow.ToHex();
+    private static readonly int maxLines = 5000; // client default: con.max_entries=3000
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Contains("--stop"))
+        {
+            if (shell.Player == null)
+                return;
+
+            if (!_playerManager.TryGetSessionById(shell.Player.UserId, out var session))
+                return;
+
+            if (session.AttachedEntity is { } uid && _entityManager.HasComponent<ServerLogsFollowerComponent>(uid))
+            {
+                _entityManager.RemoveComponent<ServerLogsFollowerComponent>(uid);
+                shell.WriteLine("Follow (tail) stopped for server logs.");
+            }
+            else
+                shell.WriteError("No active logs follow to stop.");
+
+            return;
+        }
+
+        if (args.Length >= 1 && args[0] == "--list")
+        {
+            ListLogFiles(shell);
+            return;
+        }
+
+        var (followMode, filter, lineCount, explicitFile) = ParseArgs(args);
+        FileInfo? logFile = ResolveLogFile(explicitFile);
+        if (logFile == null)
+        {
+            shell.WriteError(string.IsNullOrEmpty(explicitFile)
+                ? "No default server log file found, try specifying one."
+                : $"Log file '{explicitFile}' not found.");
+            return;
+        }
+
+        try
+        {
+            var lines = ReadLastLines(logFile.FullName, lineCount).Where(l => !l.Contains("serverlogs")).ToList();
+            var output = new StringBuilder();
+            var filterPrefix = !string.IsNullOrEmpty(filter) ? $"filtered '{filter}' on " : "";
+            output.AppendLine($"[color={primaryClr}]--- {logFile.Name} ({filterPrefix}last {lines.Count} lines) ---[/color]");
+
+            foreach (var line in lines)
+            {
+                if (filter != null && !line.Contains(filter, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                // logs are saved with ANSI coloring
+                var markupLine = ConvertAnsiToMarkup(line);
+                output.AppendLine($">{markupLine}");
+            }
+
+            output.AppendLine($"[color={primaryClr}]--- end of {filterPrefix}{lines.Count} log lines ---[/color]");
+            shell.WriteMarkup(output.ToString());
+
+            if (followMode)
+            {
+                if (shell.Player == null) return;
+                if (!_playerManager.TryGetSessionById(shell.Player.UserId, out var session))
+                {
+                    shell.WriteError("Unable to find your session...");
+                    return;
+                }
+
+                if (session.AttachedEntity is not { } uid)
+                {
+                    shell.WriteError("You must have a mind (spawned), to subscribe to server logs tail.");
+                    return;
+                }
+
+                var comp = _entityManager.EnsureComponent<ServerLogsFollowerComponent>(uid);
+                comp.FilePath = logFile.FullName;
+                comp.LastPosition = logFile.Length; // start from end
+                comp.Filter = filter;
+                comp.Session = session;
+
+                if (string.IsNullOrEmpty(filter))
+                    shell.WriteMarkup($"[color={secondaryClr}]No filter set, consider using a filter to reduce noise.[/color]");
+
+                shell.WriteMarkup($"[color={primaryClr}]Now following {logFile.Name} for '{filter}', use 'serverlogs --stop' to cancel.[/color]");
+                return;
+            }
+        }
+        catch (Exception ex) { shell.WriteError($"Failed to read log file '{logFile.Name}': {ex.Message}"); }
+    }
+
+    private void ListLogFiles(IConsoleShell shell)
+    {
+        var fileInfos = Directory.GetFiles(logDir, "*.log").Select(f => new FileInfo(f)).ToList();
+
+        var logsSub = Path.Combine(logDir, "logs");
+        if (Directory.Exists(logsSub))
+            fileInfos.AddRange(Directory.GetFiles(logsSub, "*.log").Select(f => new FileInfo(f)));
+
+        fileInfos = fileInfos.OrderBy(f => f.LastWriteTimeUtc).ToList();
+
+        if (fileInfos.Count == 0)
+        {
+            shell.WriteLine("No log files found.");
+            return;
+        }
+
+        shell.WriteMarkup($"[color={primaryClr}]--- {fileInfos.Count} log file(s) in {logDir} ---[/color]");
+
+        foreach (var file in fileInfos)
+        {
+            var color = file.Length == 0 ? secondaryClr : primaryClr;
+            var sizeStr = file.Length > 0 ? $"{file.Length,8:N0} B" : "  empty  ";
+
+            shell.WriteMarkup($"[color={color}]{file.Name,-40}[/color]" +
+                $" [color={secondaryClr}]{sizeStr}  {file.LastWriteTimeUtc:yyyy-MM-dd HH:mm:ss} UTC[/color]");
+        }
+    }
+
+    private FileInfo? ResolveLogFile(string? explicitFile)
+    {
+        static FileInfo? TryFind(string fileName)
+        {
+            foreach (var sub in new[] { "", "logs/" })
+            {
+                var fullPath = Path.GetFullPath(Path.Combine(logDir, sub, fileName));
+                if (fullPath.StartsWith(Path.GetFullPath(logDir)) && File.Exists(fullPath))
+                    return new FileInfo(fullPath);
+            }
+            return null;
+        }
+
+        if (!string.IsNullOrEmpty(explicitFile))
+            return TryFind(explicitFile);
+
+        return TryFind("server.log")
+            ?? Directory.GetFiles(logDir, "server*.log")
+                .Concat(Directory.Exists(Path.Combine(logDir, "logs"))
+                    ? Directory.GetFiles(Path.Combine(logDir, "logs"), "server*.log")
+                    : Array.Empty<string>())
+                .Select(f => new FileInfo(f)).OrderByDescending(f => f.LastWriteTimeUtc).FirstOrDefault();
+    }
+
+    // supports standard SGR colours (30‑37 + 90‑97) and reset (0)
+    internal static string ConvertAnsiToMarkup(string ansiLine)
+    {
+        var sb = new StringBuilder();
+        int i = 0;
+        bool inColor = false;
+
+        while (i < ansiLine.Length)
+        {
+            // detect ANSI escape start \e[ or \e] & handle OSC sequences
+            if (ansiLine[i] == '\e' && i + 1 < ansiLine.Length && ansiLine[i + 1] == ']')
+            {
+                if (inColor)
+                {
+                    sb.Append("[/color]");
+                    inColor = false;
+                }
+
+                // scan forward to hit the terminator \a (BEL) or \e\\ (ST)
+                int j = i + 2;
+                while (j < ansiLine.Length && ansiLine[j] != '\a'
+                       && !(ansiLine[j] == '\e' && j + 1 < ansiLine.Length && ansiLine[j + 1] == '\\'))
+                    j++;
+
+                // advance past the terminator
+                if (j < ansiLine.Length)
+                {
+                    if (ansiLine[j] == '\a')
+                        i = j + 1;
+                    else // \e\\
+                        i = j + 2;
+                }
+                else
+                    i = ansiLine.Length; // unterminated OSC, eat rest of line
+
+                continue;
+            }
+
+            // handle CSI sequences (SGR colours)
+            if (ansiLine[i] == '\e' && i + 1 < ansiLine.Length && ansiLine[i + 1] == '[')
+            {
+                if (inColor)
+                {
+                    sb.Append("[/color]");
+                    inColor = false;
+                }
+
+                // scan forward to terminator
+                int j = i + 2;
+                while (j < ansiLine.Length && !char.IsAsciiLetter(ansiLine[j]))
+                    j++;
+
+                if (j < ansiLine.Length && ansiLine[j] == 'm')
+                {
+                    string sequence = ansiLine[(i + 2)..j];
+                    i = j + 1;
+
+                    foreach (var codeStr in sequence.Split(';'))
+                    {
+                        if (int.TryParse(codeStr, out int code) && TryGetColorMarkup(code, out string? color))
+                        {
+                            sb.Append($"[color={color}]");
+                            inColor = true;
+                        }
+                    }
+                }
+                else
+                    // eat non color escape (e.g., \e[2J, \e[K)
+                    i = j < ansiLine.Length ? j + 1 : ansiLine.Length;
+
+                continue;
+            }
+
+            // unrecognised escape, skip the \e & next char, to avoid infinite loop
+            if (ansiLine[i] == '\e')
+            {
+                if (inColor)
+                {
+                    sb.Append("[/color]");
+                    inColor = false;
+                }
+                i += 2;
+                continue;
+            }
+
+            int nextEscape = ansiLine.IndexOf('\e', i);
+            if (nextEscape == -1) nextEscape = ansiLine.Length;
+            string text = ansiLine[i..nextEscape];
+            sb.Append(FormattedMessage.EscapeText(text));
+            i = nextEscape;
+        }
+
+        if (inColor)
+            sb.Append("[/color]");
+
+        return sb.ToString();
+    }
+
+    internal static bool TryGetColorMarkup(int ansiCode, out string? colorName)
+    {
+        switch (ansiCode)
+        {
+            case 30: colorName = "black"; break;
+            case 31: colorName = "red"; break;
+            case 32: colorName = "green"; break;
+            case 33: colorName = "yellow"; break;
+            case 34: colorName = "blue"; break;
+            case 35: colorName = "magenta"; break;
+            case 36: colorName = "cyan"; break;
+            case 37: colorName = "white"; break;
+            case 90: colorName = "darkgray"; break;
+            case 91: colorName = "red"; break;
+            case 92: colorName = "green"; break;
+            case 93: colorName = "yellow"; break;
+            case 94: colorName = "blue"; break;
+            case 95: colorName = "magenta"; break;
+            case 96: colorName = "cyan"; break;
+            case 97: colorName = "white"; break;
+
+            default:
+                colorName = null;
+                return false;
+        }
+        return true;
+    }
+
+    private static (bool followMode, string? filter, int lineCount, string? explicitFile) ParseArgs(string[] args)
+    {
+        bool followMode = false;
+        string? filter = null;
+        int lineCount = 50;
+        string? explicitFile = null;
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            if (arg.Equals("--follow") || arg.Equals("--tail"))
+                followMode = true;
+            else if (arg.Equals("--filter") && i + 1 < args.Length)
+                filter = args[++i];
+            else if (arg.Equals("--file") && i + 1 < args.Length)
+                explicitFile = args[++i];
+            else if (int.TryParse(arg, out var n))
+                lineCount = Math.Clamp(n, 1, maxLines);
+            else
+                filter = arg;
+        }
+
+        return (followMode, filter, lineCount, explicitFile);
+    }
+    // single 64KB chunk, scan in mem for \n, read forward -> avoids O(n) disk seeks and large heap allocations of earlier approaches
+    private static List<string> ReadLastLines(string filePath, int lineCount)
+    {
+        var result = new List<string>();
+        if (lineCount <= 0) return result;
+
+        using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        long fileSize = fs.Length;
+        if (fileSize == 0) return result;
+
+        // needed bytes ~150B per \n, clamped at 64KB and 1MB.
+        int estimatedNeededBytes = lineCount * 150;
+        int bufferSize = Math.Clamp(estimatedNeededBytes, 65536, 1048576);
+        long startPos = Math.Max(0, fileSize - bufferSize);
+        int bytesToRead = (int)(fileSize - startPos);
+
+        byte[] buffer = new byte[bytesToRead];
+        fs.Position = startPos;
+        fs.ReadExactly(buffer, 0, bytesToRead);
+
+        int newlineCount = 0;
+        long targetPosition = startPos;
+
+        // scan membuf backward
+        for (int i = bytesToRead - 1; i >= 0; i--)
+        {
+            // ignore trailing \n at absolut eof (backward scan)
+            if (startPos + i == fileSize - 1 && buffer[i] == '\n')
+                continue;
+
+            if (buffer[i] == '\n')
+            {
+                newlineCount++;
+                if (newlineCount > lineCount)
+                {
+                    targetPosition = startPos + i + 1; // cutoff point
+                    break;
+                }
+            }
+        }
+
+        // read forward from cutoff & ensure targetPosition valid UTF-8 byte
+        if (targetPosition > 0)
+        {
+            fs.Position = targetPosition;
+            int b = fs.ReadByte();
+            while (targetPosition > 0 && b >= 0x80 && b < 0xC0)
+            {
+                targetPosition--;
+                fs.Position = targetPosition;
+                b = fs.ReadByte();
+            }
+        }
+        fs.Position = targetPosition; // reset after read forward
+
+        using var reader = new StreamReader(fs, Encoding.UTF8);
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+            if (!string.IsNullOrWhiteSpace(line))
+                result.Add(line);
+
+        // trailing empty line (forward read)
+        while (result.Count > 0 && string.IsNullOrWhiteSpace(result[^1]))
+            result.RemoveAt(result.Count - 1);
+
+        // small file? trim
+        if (result.Count > lineCount)
+            return result.Skip(result.Count - lineCount).ToList();
+
+        return result;
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 0 || (args.Length == 1 && string.IsNullOrEmpty(args[0])))
+            return CompletionResult.FromHintOptions(
+                new[] { "--list", "--follow", "--stop", "--file", "--filter" },
+                "option");
+
+        bool completingEmpty = string.IsNullOrEmpty(args[^1]);
+        string currentArg = completingEmpty ? "" : args[^1];
+
+        if (completingEmpty)
+        {
+            string prevArg = args.Length >= 2 ? args[^2] : "";
+            if (prevArg == "--filter")
+                return CompletionResult.FromHint("filter pattern");
+            if (prevArg == "--file")
+                return CompletionResult.FromHintOptions(GetLogFileCompletions(currentArg), "log file");
+            return CompletionResult.FromHint("filter pattern or number of lines");
+        }
+
+        if (currentArg.StartsWith('-'))
+        {
+            var usedFlags = args.Where(a => a.StartsWith('-')).ToHashSet();
+            var flags = new List<string>();
+            if (!usedFlags.Contains("--list")) flags.Add("--list");
+            if (!usedFlags.Contains("--follow") && !usedFlags.Contains("--tail")) { flags.Add("--follow"); flags.Add("--tail"); }
+            if (!usedFlags.Contains("--stop")) flags.Add("--stop");
+            if (!usedFlags.Contains("--file")) flags.Add("--file");
+            if (!usedFlags.Contains("--filter")) flags.Add("--filter");
+            return CompletionResult.FromHintOptions(flags, "flag");
+        }
+
+        var options = new List<CompletionOption>
+        {
+            new("50", "number of lines (default)"),
+            new("200", "number of lines"),
+            new(maxLines.ToString(), "number of lines (max)"),
+        };
+
+        return CompletionResult.FromHintOptions(options, "filter pattern or number of lines");
+    }
+
+    private List<CompletionOption> GetLogFileCompletions(string filter)
+    {
+        var completions = new List<CompletionOption>();
+        try
+        {
+            string dir = logDir;
+            var files = Directory.GetFiles(dir, "*.log", SearchOption.TopDirectoryOnly);
+            string logsSubDir = Path.Combine(dir, "logs");
+            if (Directory.Exists(logsSubDir))
+                files = files.Concat(Directory.GetFiles(logsSubDir, "*.log", SearchOption.TopDirectoryOnly)).ToArray();
+
+            foreach (var fullPath in files)
+            {
+                string relPath = Path.GetRelativePath(dir, fullPath);
+                if (relPath.StartsWith(filter, StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty(filter))
+                    completions.Add(new CompletionOption(relPath, "log file"));
+            }
+        }
+        catch { }
+        return completions;
+    }
+}

--- a/Content.Server/_CMU14/Profiling/CMUServerLogsFollowerComponent.cs
+++ b/Content.Server/_CMU14/Profiling/CMUServerLogsFollowerComponent.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.Player;
+
+namespace Content.Server._CMU14.Profiling;
+
+[RegisterComponent]
+public sealed partial class ServerLogsFollowerComponent : Component
+{
+    /// <summary>Absolute path to the log file currently being tailed.</summary>
+    public string FilePath = string.Empty;
+
+    /// <summary>Where we last read to (file offset in bytes).</summary>
+    public long LastPosition;
+
+    public string? Filter;
+
+    /// <summary>The admin session that should receive.</summary>
+    [ViewVariables] public ICommonSession? Session;
+}

--- a/Content.Server/_CMU14/Profiling/CMUServerLogsFollowerSystem.cs
+++ b/Content.Server/_CMU14/Profiling/CMUServerLogsFollowerSystem.cs
@@ -1,0 +1,115 @@
+using System.IO;
+using System.Text;
+using Robust.Server.Player;
+using Robust.Shared.Player;
+using Content.Server.Chat.Managers;
+using Content.Shared.Chat;
+
+namespace Content.Server._CMU14.Profiling;
+
+public sealed partial class ServerLogsFollowerSystem : EntitySystem
+{
+    [Dependency] private IPlayerManager _playerManager = default!;
+    [Dependency] private IChatManager _chatManager = default!;
+
+    private const int MaxLinesPerTick = 20;
+    private const float UpdateRate = 0.5f; // in seconds
+    private float _updateAccumulator;
+    private static readonly string[] _noiseFilters = new[]
+    {
+        "MainLoop: Cannot keep up!",
+        "] admin.logs: ", // sawmill chunk as not to excl. "admin.logs" itself
+        "] db.op: ",
+        "] battlebuddy: ",
+        "] con: ",
+        "] net.ent: ",
+        "ms | Net: (" // System.Console.Title
+    };
+
+    public override void Update(float frameTime)
+    {
+        _updateAccumulator += frameTime;
+        if (_updateAccumulator < UpdateRate)
+            return;
+        _updateAccumulator = 0f;
+
+
+        var query = EntityQueryEnumerator<ServerLogsFollowerComponent>();
+        while (query.MoveNext(out var uid, out var follower))
+        {
+            if (follower.Session == null || !_playerManager.TryGetSessionById(follower.Session.UserId, out _))
+            {
+                RemComp<ServerLogsFollowerComponent>(uid);
+                continue;
+            }
+
+            try { UpdateFollower(follower, uid); }
+            catch (Exception ex)
+            {
+                // send error to admin and stop following
+                SendLine(follower.Session, $"Follow error: {ex.Message}");
+                RemComp<ServerLogsFollowerComponent>(uid);
+            }
+        }
+    }
+
+    private void UpdateFollower(ServerLogsFollowerComponent follower, EntityUid uid)
+    {
+        if (follower.Session == null)
+            return;
+
+        var fileInfo = new FileInfo(follower.FilePath);
+        if (!fileInfo.Exists)
+        {
+            SendLine(follower.Session, $"Log file '{follower.FilePath}' no longer exists.");
+            RemComp<ServerLogsFollowerComponent>(uid);
+            return;
+        }
+
+        long newSize = fileInfo.Length;
+        if (newSize <= follower.LastPosition)
+        {
+            // file change, reset to new content
+            if (newSize < follower.LastPosition)
+                follower.LastPosition = newSize;
+            return;
+        }
+
+        using var fs = new FileStream(follower.FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        fs.Seek(follower.LastPosition, SeekOrigin.Begin);
+        using var reader = new StreamReader(fs, Encoding.UTF8);
+
+        string? line;
+        int linesSent = 0;
+        int linesRead = 0;
+        const int MaxLinesReadPerTick = 500;
+
+        long consumed = follower.LastPosition;
+        while ((line = reader.ReadLine()) != null
+            && linesSent < MaxLinesPerTick
+            && linesRead < MaxLinesReadPerTick)
+        {
+            linesRead++;
+            consumed += Encoding.UTF8.GetByteCount(line) + 1; // based on linux server (\n line endings)
+
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            if (line.Contains("[TAIL]")) continue; // feedback loop
+            if (Array.Exists(_noiseFilters, f => line.Contains(f))) continue;
+            if (follower.Filter != null && !line.Contains(follower.Filter, StringComparison.OrdinalIgnoreCase)) continue;
+
+            SendLine(follower.Session, line);
+            linesSent++;
+        }
+
+        follower.LastPosition = consumed; // update read offset (not eof)
+    }
+
+    private void SendLine(ICommonSession session, string line)
+    {
+        var markupLine = ServerLogsCommand.ConvertAnsiToMarkup(line);
+        if (string.IsNullOrWhiteSpace(markupLine)) return;
+
+        var message = $"[color=yellow][TAIL][/color] {markupLine}";
+        _chatManager.ChatMessageToOne(ChatChannel.Admin, message, message, EntityUid.Invalid, false, session.Channel);
+    }
+}

--- a/Content.Server/_CMU14/Profiling/CMUServerSawmillsCommand.cs
+++ b/Content.Server/_CMU14/Profiling/CMUServerSawmillsCommand.cs
@@ -1,0 +1,140 @@
+using System.Linq;
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server._CMU14.Profiling;
+
+[AdminCommand(AdminFlags.Host)]
+public sealed partial class ServerSawmillsCommand : LocalizedCommands
+{
+    [Dependency] private ILogManager _logManager = default!;
+
+    public override string Command => "serversawmills";
+    public override string Description => "Lists sawmills (non-inherited) log level (or use --all/filters).";
+    public override string Help => $"Usage: {Command} [--all] [filter|level] [level]";
+
+    private static readonly string primaryClr = Color.Green.ToHex();
+    private static readonly string secondaryClr = Color.Yellow.ToHex();
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        bool explicitAll = false;
+        var filterArgs = new List<string>();
+        foreach (var arg in args)
+        {
+            if (arg.Equals("--all", StringComparison.OrdinalIgnoreCase))
+                explicitAll = true;
+            else
+                filterArgs.Add(arg);
+        }
+
+        if (!TryParseFilterArgs(shell, filterArgs, out var nameFilter, out var hasLevelFilter, out var wantInherited, out var levelFilter))
+            return;
+
+        bool showAll = nameFilter != null || hasLevelFilter || explicitAll;
+        var sawmills = _logManager.AllSawmills.Where(s => nameFilter == null || s.Name.Contains(nameFilter, StringComparison.OrdinalIgnoreCase))
+            .Where(s =>
+            {
+                if (hasLevelFilter)
+                    return wantInherited ? s.Level == null : s.Level == levelFilter;
+                if (!showAll) // skip inherited/default
+                    return s.Level != null;
+                return true;
+            }).OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase).ToList();
+
+        if (sawmills.Count == 0)
+        {
+            shell.WriteMarkup($"[color={secondaryClr}]No sawmills matching criteria.[/color]");
+            return;
+        }
+
+        int col = Math.Max(40, sawmills.Max(s => s.Name.Length) + 2);
+        foreach (var sawmill in sawmills)
+        {
+            var (levelText, colour) = GetLevelTextAndColour(sawmill.Level);
+            var line = $"[color={primaryClr}]{sawmill.Name.PadRight(col)}[/color]" +
+                $" [color={colour.ToHex()}]{levelText}[/color]";
+            shell.WriteMarkup(line);
+        }
+
+        var suffix = showAll ? " (all)" : " (only overridden)";
+        if (hasLevelFilter)
+            suffix += wantInherited ? " with inherited level" : $" with level '{levelFilter}'";
+
+        shell.WriteMarkup($"[color={secondaryClr}]--- {sawmills.Count} sawmill(s){suffix} ---[/color]");
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        bool hasAll = args.Any(a => a.Equals("--all", StringComparison.OrdinalIgnoreCase));
+        var cleanedArgs = args.Where(a => !a.Equals("--all", StringComparison.OrdinalIgnoreCase)).ToArray();
+        return cleanedArgs.Length switch
+        {
+            0 => CompletionResult.FromHintOptions(new[] { "--all" }, "[--all]"),
+            1 => CompletionResult.FromHintOptions(new[] { "--all" }.Concat(Enum.GetNames<LogLevel>()).Append("null")
+                    .Concat(_logManager.AllSawmills.Select(s => s.Name).OrderBy(s => s, StringComparer.OrdinalIgnoreCase)), "<name or level>"),
+            2 => CompletionResult.FromHintOptions(Enum.GetNames<LogLevel>().Append("null"), "<level filter>"),
+            _ => CompletionResult.Empty
+        };
+    }
+
+    private static (string text, Color colour) GetLevelTextAndColour(LogLevel? level)
+    {
+        return level switch
+        {
+            null => ("inherited", Color.DarkGray),
+            LogLevel.Verbose => ("Verbose", Color.DarkGray),
+            LogLevel.Debug => ("Debug", Color.Gray),
+            LogLevel.Info => ("Info", Color.Cyan),
+            LogLevel.Warning => ("Warning", Color.Yellow),
+            LogLevel.Error => ("Error", Color.Red),
+            LogLevel.Fatal => ("Fatal", Color.Magenta),
+            _ => (level!.Value.ToString(), Color.White)
+        };
+    }
+
+    private static bool TryParseFilterArgs(IConsoleShell shell, List<string> filterArgs, out string? nameFilter,
+    out bool hasLevelFilter, out bool wantInherited, out LogLevel? levelFilter)
+    {
+        nameFilter = null;
+        hasLevelFilter = false;
+        wantInherited = false;
+        levelFilter = null;
+
+        if (filterArgs.Count == 0)
+            return true;
+
+        bool firstIsLevel = filterArgs[0] == "null"
+            || Enum.TryParse<LogLevel>(filterArgs[0], ignoreCase: true, out _);
+        if (firstIsLevel)
+        {
+            hasLevelFilter = true;
+            wantInherited = filterArgs[0] == "null";
+            if (!wantInherited)
+            {
+                Enum.TryParse<LogLevel>(filterArgs[0], ignoreCase: true, out var parsed);
+                levelFilter = parsed;
+            }
+            return true;
+        }
+
+        nameFilter = filterArgs[0].Length > 0 ? filterArgs[0] : null;
+        if (filterArgs.Count > 1)
+        {
+            hasLevelFilter = true;
+            wantInherited = filterArgs[1] == "null";
+            if (!wantInherited)
+            {
+                if (!Enum.TryParse<LogLevel>(filterArgs[1], ignoreCase: true, out var parsed))
+                {
+                    shell.WriteError($"Unknown level '{filterArgs[1]}'. Valid: {string.Join(", ", Enum.GetNames<LogLevel>())}, null");
+                    return false;
+                }
+                levelFilter = parsed;
+            }
+        }
+
+        return true;
+    }
+}

--- a/Content.Server/_RMC14/Toolshed/MappingCommands/RenameCommand.cs
+++ b/Content.Server/_RMC14/Toolshed/MappingCommands/RenameCommand.cs
@@ -1,22 +1,21 @@
 using Content.Server.Administration;
-using Content.Shared._RMC14.Teleporter;
 using Content.Shared.Administration;
 using Robust.Shared.Toolshed;
 
 namespace Content.Server._RMC14.Toolshed.MappingCommands;
 
 [ToolshedCommand, AdminCommand(AdminFlags.Query)]
-internal sealed class RenameCommand : ToolshedCommand
+internal sealed class MapRenameCommand : ToolshedCommand
 {
     private MetaDataSystem? _metaData;
+
     [CommandImplementation]
-    public void StairwellProjector([PipedArgument] IEnumerable<EntityUid> input, string name)
+    public void RenameEntities([PipedArgument] IEnumerable<EntityUid> input, string name)
     {
         _metaData ??= Sys<MetaDataSystem>();
         foreach (var entity in input)
         {
             _metaData.SetEntityName(entity, name);
         }
-        return;
     }
 }

--- a/Content.Shared/_RMC14/Vehicle/Hardpoint/HardpointSystem.cs
+++ b/Content.Shared/_RMC14/Vehicle/Hardpoint/HardpointSystem.cs
@@ -2718,4 +2718,54 @@ public sealed partial class HardpointSystem : EntitySystem
         tool = held.Value;
         return true;
     }
+
+    // Used to Rejuv (Content.Server/_CMU14/Blackfoot/VehicleRejuvenateSystem)
+    public void ResetAllHardpointsToFullHealth(EntityUid vehicle)
+    {
+        if (!TryComp<HardpointSlotsComponent>(vehicle, out var hardpoints)
+                || !TryComp<ItemSlotsComponent>(vehicle, out var itemSlots))
+            return;
+
+        foreach (var mounted in _topology.GetMountedSlots(vehicle, hardpoints, itemSlots))
+        {
+            if (mounted.Item is { } item
+                && TryComp<HardpointIntegrityComponent>(item, out var integrity))
+            {
+                integrity.Integrity = integrity.MaxIntegrity;
+                Dirty(item, integrity);
+            }
+        }
+
+        RefreshVehicleFrameIntegrityFromHardpoints(vehicle, hardpoints, itemSlots);
+    }
+
+    public void ClearAllFailures(EntityUid uid)
+    {
+        if (TryComp<VehicleHardpointFailureComponent>(uid, out var frameFailures))
+        {
+            var failuresCopy = frameFailures.ActiveFailures.ToArray();
+            foreach (var failure in failuresCopy)
+                RemoveHardpointFailure(uid, uid, failure, frameFailures);
+        }
+
+        if (TryComp<HardpointSlotsComponent>(uid, out var hardpoints)
+         && TryComp<ItemSlotsComponent>(uid, out var itemSlots))
+        {
+            foreach (var mounted in _topology.GetMountedSlots(uid, hardpoints, itemSlots))
+            {
+                if (mounted.Item is not { } item)
+                    continue;
+
+                if (TryComp<VehicleHardpointFailureComponent>(item, out var itemFailures))
+                {
+                    var failuresCopy = itemFailures.ActiveFailures.ToArray();
+                    foreach (var failure in failuresCopy)
+                        RemoveHardpointFailure(uid, item, failure, itemFailures);
+                }
+            }
+        }
+
+        UpdateHardpointUi(uid);
+        RaiseHardpointSlotsChanged(uid);
+    }
 }

--- a/Resources/Locale/en-US/_RMC14/commands/rmc-toolshed-commands.ftl
+++ b/Resources/Locale/en-US/_RMC14/commands/rmc-toolshed-commands.ftl
@@ -89,7 +89,7 @@ command-description-gridtile = Gets TileRefs for a grid that a specified entity 
 
 command-description-movespeed = Changes the max movement speed for given entities.
 
-command-description-rename = changes the MetaData entityName field.
+command-description-maprename = changes the MetaData entityName field.
 
 command-description-stairwell = Sets the teleportation offset for the given Teleporter entities.
 command-description-stairwellprojector = Sets the projection id for the given TeleporterView entities.


### PR DESCRIPTION
- **✨ serverlogs & serversawmills for debugging (host only)**
- **✨ rejuv to vehicles apc/tank/blackfoot**
- **🪲 Duplicate toolshed command: rename**

## About the PR
- What's playtest debugging without live server logs?

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: 'serverlogs' & 'serversawmills' commands for live log access in-game (host-only restricted perms), with a --tail option that sends server-side logs into admin-chat as they arrive & use --filter to cut out noise. Adjust the Sawmill (log group) verbosity level in-game with 'loglevel' <sawmill> and use 'serversawmills' to search/list all ~3500! groups and their current overrides
- admin: the rejuvenate verb/trick now fully repairs vehicles/blackfoot - resets damage & hardpoint health + integrity, clears all failure states and refills fuel/battery - also rearms all the vehicle's mounted weaponry
- fix: removed duplicate "rename" command that caused toolshed warnings
