### PR TITLE
Ambassador Briefcase Flavoring

### DIFF
--- a/Resources/Locale/en-US/_AU14/radio-channels.ftl
+++ b/Resources/Locale/en-US/_AU14/radio-channels.ftl
@@ -31,5 +31,6 @@ chat-radio-uppsof = UPP
 chat-radio-uasof = UA
 chat-radio-twe = TWE
 chat-radio-icsc = ICSC
+chat-radio-cca = CCA
 chat-radio-vai = VAI
 chat-radio-part = Prodigy

--- a/Resources/Prototypes/_AU14/Entities/Clothing/Headset/colonyheadsets.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Headset/colonyheadsets.yml
@@ -136,50 +136,144 @@
     state: generic_headset
 
 # ├──[ AMBASSADORHEADSETS ]──────────────────────────────────────────┤
+
+- type: entity
+  parent: AU14EncryptionKey
+  id: AU14EncryptionKeyTWEAmb
+  name: twe commissioner encryption key
+  description: An encryption key used to communicate on the commissioner's radio channel.
+  suffix: Ambassador
+  components:
+  - type: EncryptionKey
+    channels:
+    - TWESOF
+    defaultChannel: Colony
+
 - type: entity
   parent: AU14ColonyAdminHeadset
   id: AU14ColonyAmbassadorTWEHeadset
   name: twe commissioner headset
   description: A headset used by TWE's commissioners to communicate.
-  suffix: Colony
+  suffix: Colony, Ambassador
   components:
-  - type: RMCHeadset
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - AU14EncryptionKeyTWEAmb
+      - AU14EncryptionKeyAdmin
+
+- type: entity
+  parent: AU14EncryptionKey
+  id: AU14EncryptionKeyUAAmb
+  name: ua ambassador encryption key
+  description: An encryption key used to communicate on the ambassador's radio channel.
+  suffix: Ambassador
+  components:
+  - type: EncryptionKey
     channels:
-    - TWESOF
+    - UASOF
+    defaultChannel: Colony
+
+- type: entity
+  parent: AU14EncryptionKey
+  id: AU14EncryptionKeyUAAmbVAI
+  name: VAI encryption key
+  description: An encryption key used to communicate to the ambassador.
+  components:
+  - type: EncryptionKey
+    channels:
+    - radioVAI
+    defaultChannel: Colony
 
 - type: entity
   parent: AU14ColonyAdminHeadset
   id: AU14AmbassadorUAHeadset
   name: ua ambassador headset
   description: A headset used by UA's ambassadors to communicate.
-  suffix: Colony
+  suffix: Colony, Ambassador
   components:
-  - type: RMCHeadset
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - AU14EncryptionKeyUAAmb
+      - AU14EncryptionKeyUAAmbVAI
+      - AU14EncryptionKeyAdmin
+
+- type: entity
+  parent: AU14EncryptionKey
+  id: AU14EncryptionKeyUPPAmb
+  name: upp ambassador encryption key
+  description: An encryption key used to communicate on the ambassador's radio channel.
+  suffix: Ambassador
+  components:
+  - type: EncryptionKey
     channels:
-    - UASOF
-    - radioVAI
+    - UPPSOF
+    defaultChannel: Colony
 
 - type: entity
   parent: AU14ColonyAdminHeadset
   id: AU14AmbassadorUPPHeadset
   name: upp ambassador headset
   description: A headset used by UPP's ambassadors to communicate.
-  suffix: Colony
+  suffix: Colony, Ambassador
   components:
-  - type: RMCHeadset
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - AU14EncryptionKeyUPPAmb
+      - AU14EncryptionKeyAdmin
+
+- type: entity
+  parent: AU14EncryptionKey
+  id: AU14EncryptionKeyICSCAmb
+  name: icsc ambassador encryption key
+  description: An encryption key used to communicate on the ambassador's radio channel.
+  suffix: Ambassador
+  components:
+  - type: EncryptionKey
     channels:
-    - UPPSOF
+    - ICSCSOF
+    defaultChannel: Colony
 
 - type: entity
   parent: AU14ColonyAdminHeadset
   id: AU14AmbassadorICSCHeadset
   name: icsc ambassador headset
-  description: A headset used by ICSC' ambassadors to communicate.
-  suffix: Colony
+  description: A headset used by ICSC's ambassadors to communicate.
+  suffix: Colony, Ambassador
   components:
-  - type: RMCHeadset
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - AU14EncryptionKeyICSCAmb
+      - AU14EncryptionKeyAdmin
+
+- type: entity
+  parent: AU14EncryptionKey
+  id: AU14EncryptionKeyCCAAmb
+  name: cca ambassador encryption key
+  description: An encryption key used to communicate on the ambassador's radio channel.
+  suffix: Ambassador
+  components:
+  - type: EncryptionKey
     channels:
-    - ICSCSOF
+    - CCASOF
+    defaultChannel: Colony
+
+- type: entity
+  parent: AU14ColonyAdminHeadset
+  id: AU14AmbassadorCCAHeadset
+  name: cca ambassador headset
+  description: A headset used by CCA's ambassadors to communicate.
+  suffix: Colony, Ambassador
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - AU14EncryptionKeyCCAAmb
+      - AU14EncryptionKeyAdmin
+
 
 - type: entity
   parent: AU14EncryptionKey

--- a/Resources/Prototypes/_AU14/Entities/IDCards/ThirdParties/Ambassadors.yml
+++ b/Resources/Prototypes/_AU14/Entities/IDCards/ThirdParties/Ambassadors.yml
@@ -8,4 +8,49 @@
     job: AU14JobCivilianAmbassadorUA
   - type: ItemIFF
     factions:
+    - FactionUASOF
     - FactionVAI
+
+- type: entity
+  parent: CMIDCardBase
+  id: AU14IDCardTWEAmbassador
+  name: TWE ambassador ID card
+  components:
+  - type: PresetIdCard
+    job: AU14JobCivilianAmbassadorTWE
+  - type: ItemIFF
+    factions:
+    - FactionTWESOF
+
+- type: entity
+  parent: CMIDCardBase
+  id: AU14IDCardUPPAmbassador
+  name: UPP ambassador ID card
+  components:
+  - type: PresetIdCard
+    job: AU14JobCivilianAmbassadorUPP
+  - type: ItemIFF
+    factions:
+    - FactionUPPSOF
+
+- type: entity
+  parent: CMIDCardBase
+  id: AU14IDCardICSCAmbassador
+  name: ICSC ambassador ID card
+  components:
+  - type: PresetIdCard
+    job: AU14JobCivilianAmbassadorICSC
+  - type: ItemIFF
+    factions:
+    - FactionICSCSOF
+
+- type: entity
+  parent: CMIDCardBase
+  id: AU14IDCardCCAAmbassador
+  name: CCA ambassador ID card
+  components:
+  - type: PresetIdCard
+    job: AU14JobCivilianAmbassadorCCA
+  - type: ItemIFF
+    factions:
+    - FactionCCASOF

--- a/Resources/Prototypes/_AU14/Entities/IDCards/factionIFF.yml
+++ b/Resources/Prototypes/_AU14/Entities/IDCards/factionIFF.yml
@@ -36,4 +36,49 @@
     channels:
     - radioVAI
 
-# TODO: ICSCSOF, UASOF, TWESOF, UPPSOF, radioVAI, PART, Ambassadors/ThirdParty-callins
+- type: entity
+  id: FactionCCASOF
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: IFFFaction
+  - type: FactionFrequencies
+    channels:
+    - CCASOF
+
+- type: entity
+  id: FactionICSCSOF
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: IFFFaction
+  - type: FactionFrequencies
+    channels:
+    - ICSCSOF
+
+- type: entity
+  id: FactionUASOF
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: IFFFaction
+  - type: FactionFrequencies
+    channels:
+    - UASOF
+
+- type: entity
+  id: FactionTWESOF
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: IFFFaction
+  - type: FactionFrequencies
+    channels:
+    - TWESOF
+
+- type: entity
+  id: FactionUPPSOF
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: IFFFaction
+  - type: FactionFrequencies
+    channels:
+    - UPPSOF
+
+# TODO: PART

--- a/Resources/Prototypes/_AU14/Entities/Objects/Devices/ambassador_briefcases.yml
+++ b/Resources/Prototypes/_AU14/Entities/Objects/Devices/ambassador_briefcases.yml
@@ -1,0 +1,355 @@
+- type: entity
+  parent: RMCPortableVendor
+  id: AU14PortableVendorUA
+  name: United Americas automated storage briefcase
+  description: A suitcase-sized automated storage and retrieval system. Designed to efficiently store and selectively dispense small items. This one has the star and stripes of the United Americas embossed on its side.
+  components:
+  - type: CMAutomatedVendor
+    jobs:
+    - AU14JobCivilianAmbassadorUA # UNIQUIFIED
+    sections:
+    - name: Incentives
+      entries:
+      - id: RMCSpaceCash1000 # TODO RMC14 counterfiet
+        name: $1000 USD, unmarked bills
+        points: 20
+    - name: Smokables
+      entries:
+      - id: RMCCigarettePackLuckySloths
+        points: 5
+      - id: AU14CigaretteLadyFingers
+        points: 5
+      - id: AU14CigaretteKoorlander
+        points: 5
+      - id: RMCCigarCase
+        points: 5
+      - id: RMCZippo
+        points: 5
+      - id: RMCZippoGold
+        points: 10
+    - name: Drinkables
+      entries:
+      - id: RMCDrinkAlcoholWhiskey
+        points: 5
+      - id: RMCDrinkAlcoholRum
+        points: 5
+      - id: RMCDrinkAlcoholTequila
+        points: 5
+      - id: RMCDrinkAlcoholKahlua
+        points: 5
+      - id: RMCDrinkAlcoholDavenport
+        points: 5
+      - id: RMCDrinkGlass
+        points: 1
+    - name: Stationary
+      entries:
+      - id: CMPenClicky
+        points: 1
+      - id: CMPaper
+        points: 1
+      - id: CMClipboard
+        points: 1
+    - name: Misc
+      entries:
+      - id: RMCHollowCane
+        name: hollow cane
+        points: 10
+      - id: AU14PatchUAFlag
+        points: 1
+    - name: Weapons & Ammo
+      entries:
+      - id: CMWeaponPistolM1984
+        points: 30
+      - id: CMMagazinePistolM1984
+        points: 15
+      - id: RMCWeaponRevolverM44
+        points: 30
+      - id: RMCSpeedLoaderM44
+        points: 15
+      - id: RMCScabbardCeremonialFilled
+        points: 30
+    - name: Radio keys
+      entries:
+      - id: CMEncryptionKeyColony
+        points: 5
+      - id: AU14EncryptionKeyUAAmb
+        points: 5
+
+- type: entity
+  parent: RMCPortableVendor
+  id: AU14PortableVendorTWE
+  name: Three World Empire automated storage briefcase
+  description: A suitcase-sized automated storage and retrieval system. Designed to efficiently store and selectively dispense small items. This one has the emblem of the Three World Empire embossed on its side.
+  components:
+  - type: CMAutomatedVendor
+    jobs:
+    - AU14JobCivilianAmbassadorTWE # UNIQUIFIED
+    sections:
+    - name: Incentives
+      entries:
+      - id: RMCSpaceCash1000 # TODO RMC14 counterfiet
+        name: $1000 USD, unmarked bills
+        points: 20
+    - name: Smokables
+      entries:
+      - id: RMCCigarettePackExecutiveSelect
+        points: 5
+      - id: AU14CigaretteLadyFingers
+        points: 5
+      - id: AU14CigaretteKoorlander
+        points: 5
+      - id: RMCShioRoyalsCase
+        points: 5
+      - id: RMCZippo
+        points: 5
+      - id: RMCZippoGold
+        points: 10
+    - name: Drinkables
+      entries:
+      - id: RMCDrinkAlcoholSake
+        points: 5
+      - id: RMCDrinkAlcoholRum
+        points: 5
+      - id: RMCDrinkAlcoholKahlua
+        points: 5
+      - id: RMCDrinkAlcoholGin
+        points: 5
+      - id: CMDrinkCanTonic
+        points: 1
+      - id: RMCDrinkGlass
+        points: 1
+    - name: Stationary
+      entries:
+      - id: CMPenClicky
+        points: 1
+      - id: CMPaper
+        points: 1
+      - id: CMClipboard
+        points: 1
+    - name: Misc
+      entries:
+      - id: RMCHollowCane
+        name: hollow cane
+        points: 10
+      - id: AU14TWEPatch
+        points: 1
+    - name: Weapons & Ammo
+      entries:
+      - id: RMCWeaponPistolL54
+        points: 30
+      - id: RMCMagazinePistolL54
+        points: 15
+      - id: RMCScabbardKatanaFilled
+        points: 30
+      - id: RMCTantoB
+        points: 5
+    - name: Radio keys
+      entries:
+      - id: CMEncryptionKeyColony
+        points: 5
+      - id: AU14EncryptionKeyTWEAmb
+        points: 5
+
+- type: entity
+  parent: RMCPortableVendor
+  id: AU14PortableVendorUPP
+  name: Union of Progressive Peoples automated storage briefcase
+  description: A suitcase-sized automated storage and retrieval system. Designed to efficiently store and selectively dispense small items. This one has the stars of the UPP embossed on its side.
+  components:
+  - type: CMAutomatedVendor
+    jobs:
+    - AU14JobCivilianAmbassadorUPP # UNIQUIFIED
+    sections:
+    - name: Incentives
+      entries:
+      - id: RMCSpaceCash1000 # TODO RMC14 counterfiet
+        name: $1000 USD, unmarked bills
+        points: 20
+    - name: Smokables
+      entries:
+      - id: AU14CigaretteLadyFingers
+        points: 5
+      - id: AU14CigaretteKoorlander
+        points: 5
+      - id: RMCCigarCase
+        points: 5
+      - id: RMCZippo
+        points: 5
+    - name: Drinkables
+      entries:
+      - id: RMCDrinkAlcoholVodka
+        points: 5
+      - id: CMDrinkCanBoda
+        points: 1
+      - id: CMDrinkCanBodaPlyus
+        points: 2
+      - id: RMCDrinkGlass
+        points: 1
+    - name: Stationary
+      entries:
+      - id: CMPenClicky
+        points: 1
+      - id: CMPaper
+        points: 1
+      - id: CMClipboard
+        points: 1
+    - name: Misc
+      entries:
+      - id: RMCHollowCane
+        name: hollow cane
+        points: 10
+      - id: AU14PatchUPP
+        points: 1
+    - name: Weapons & Ammo
+      entries:
+      - id: RMCWeaponPistolT73
+        points: 30
+      - id: RMCMagazinePistolT73
+        points: 15
+      - id: RMCWeaponPistolNP92
+        points: 30
+      - id: RMCMagazinePistolNP92
+        points: 15
+      - id: RMCWeaponPistolNPZ92
+        points: 30
+      - id: RMCCombatUtilityKnifeB
+        points: 5
+    - name: Radio keys
+      entries:
+      - id: CMEncryptionKeyColony
+        points: 5
+      - id: AU14EncryptionKeyUPPAmb
+        points: 5
+
+- type: entity
+  parent: RMCPortableVendor
+  id: AU14PortableVendorICSC
+  name: Independent Core System Colonies automated storage briefcase
+  description: A suitcase-sized automated storage and retrieval system. Designed to efficiently store and selectively dispense small items. This one has the logo of the ICSC embossed on its side.
+  components:
+  - type: CMAutomatedVendor
+    jobs:
+    - AU14JobCivilianAmbassadorICSC # UNIQUIFIED
+    sections:
+    - name: Incentives
+      entries:
+      - id: RMCSpaceCash1000 # TODO RMC14 counterfiet
+        name: $1000 USD, unmarked bills
+        points: 20
+    - name: Smokables
+      entries:
+      - id: RMCCigarettePackElectroGolds
+        points: 5
+      - id: RMCCigarettePackEmeraldGreens
+        points: 5
+      - id: RMCCigarettePackSolRedsTurquoise
+        points: 5
+      - id: RMCCigarettePackSolRedsYellow
+        points: 5
+      - id: RMCCigarCase
+        points: 5
+      - id: RMCZippo
+        points: 5
+    - name: Drinkables
+      entries:
+      - id: RMCDrinkAlcoholPurpleWine
+        points: 5
+      - id: RMCDrinkAlcoholPatron
+        points: 5
+      - id: RMCDrinkAlcoholCognac
+        points: 5
+      - id: RMCDrinkAlcoholAbsinthe
+        points: 5
+      - id: RMCDrinkGlass
+        points: 1
+    - name: Stationary
+      entries:
+      - id: CMPenClicky
+        points: 1
+      - id: CMPaper
+        points: 1
+      - id: CMClipboard
+        points: 1
+    - name: Misc
+      entries:
+      - id: RMCHollowCane
+        name: hollow cane
+        points: 10
+    - name: Weapons & Ammo
+      entries:
+      - id: AU14WeaponRevolverM2019
+        points: 30
+      - id: RMCSpeedLoader357
+        points: 15
+      - id: RMCSawtoothDaggerB
+        points: 5
+    - name: Radio keys
+      entries:
+      - id: CMEncryptionKeyColony
+        points: 5
+      - id: AU14EncryptionKeyICSCAmb
+        points: 5
+
+- type: entity
+  parent: RMCPortableVendor
+  id: AU14PortableVendorCCA
+  name: Central Confederation of Africa automated storage briefcase
+  description: A suitcase-sized automated storage and retrieval system. Designed to efficiently store and selectively dispense small items. This one has the rising banner of the CCA embossed on its side.
+  components:
+  - type: CMAutomatedVendor
+    jobs:
+    - AU14JobCivilianAmbassadorCCA # UNIQUIFIED
+    sections:
+    - name: Incentives
+      entries:
+      - id: RMCSpaceCash1000 # CCA IS RICH, UA DOLLARS GETCHO GOOFY ASS OUT
+        amount: 2
+        name: $2000 USD, unmarked bills
+        points: 20
+    - name: Smokables
+      entries:
+      - id: RMCCigarettePackLuckySloths
+        points: 5
+      - id: RMCCigarettePackArcturianAce
+        points: 5
+      - id: RMCCigarCase
+        points: 5
+      - id: RMCZippo
+        points: 5
+      - id: RMCZippoGold
+        points: 10
+    - name: Drinkables
+      entries:
+      - id: RMCDrinkAlcoholWhiskey
+        points: 5
+      - id: RMCDrinkAlcoholRum
+        points: 5
+      - id: RMCDrinkAlcoholVodka
+        points: 5
+      - id: RMCDrinkAlcoholAbsinthe
+        points: 5
+      - id: RMCDrinkGlass
+        points: 1
+    - name: Stationary
+      entries:
+      - id: CMPenClicky
+        points: 1
+      - id: CMPaper
+        points: 1
+      - id: CMClipboard
+        points: 1
+    - name: Misc
+      entries:
+      - id: RMCHollowCane
+        name: hollow cane
+        points: 10
+    - name: Weapons & Ammo
+      entries:
+      - id: RMCSawtoothDaggerB
+        points: 5
+    - name: Radio keys
+      entries:
+      - id: CMEncryptionKeyColony
+        points: 5
+      - id: AU14EncryptionKeyCCAAmb
+        points: 5

--- a/Resources/Prototypes/_AU14/Entities/Structures/Towers/comms_tower.yml
+++ b/Resources/Prototypes/_AU14/Entities/Structures/Towers/comms_tower.yml
@@ -62,6 +62,7 @@
     - CMUYautjaOverseer
     - CMUYautjaBadBlood
     - radioVAI
+    - CCASOF
     - ICSCSOF
     - UASOF
     - TWESOF
@@ -112,6 +113,7 @@
     state: Off
     channels:
     - radioVAI
+    - CCASOF
     - ICSCSOF
     - UASOF
     - TWESOF

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/ccaambassador.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/ccaambassador.yml
@@ -33,7 +33,7 @@
         RMCSkillIntel: 1
         RMCSkillOverwatch: 1
     - type: CMVendorUser
-      id: AU14JobCivilianCorporateLiaison
+      id: AU14JobCivilianAmbassadorCCA
       points: 70
     - type: JobPrefix
       prefix: au14-job-prefix-civilianambassadorcca
@@ -53,12 +53,12 @@
   equipment:
     jumpsuit: AU14CivilianWorkwearYellow
     shoes: RMCShoesLaceupBrown
-    id: AU14IDCardColonyCorporateLiaison
+    id: AU14IDCardCCAAmbassador
     outerClothing: AU14CivilianJacketTanPufferVest
-    ears: AU14ColonyAdminHeadset
+    ears: AU14AmbassadorCCAHeadset
     pocket1: AU14StampCCAA
   inhand:
-  - RMCPortableVendorCorporate
+  - AU14PortableVendorCCA
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/icscambassador.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/icscambassador.yml
@@ -33,7 +33,7 @@
         RMCSkillIntel: 1
         RMCSkillOverwatch: 1
     - type: CMVendorUser
-      id: AU14JobCivilianCorporateLiaison
+      id: AU14JobCivilianAmbassadorICSC
       points: 70
     - type: JobPrefix
       prefix: au14-job-prefix-civilianambassadoricsc
@@ -53,12 +53,12 @@
   equipment:
     jumpsuit: CMJumpsuitLiaisonBlack
     shoes: RMCShoesLaceupBrown
-    id: AU14IDCardColonyCorporateLiaison
+    id: AU14IDCardICSCAmbassador
     outerClothing: RMCJacketCorporateBlack
     ears: AU14AmbassadorICSCHeadset
     pocket1: AU14StampISCSA
   inhand:
-  - RMCPortableVendorCorporate
+  - AU14PortableVendorICSC
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/tweambassador.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/tweambassador.yml
@@ -33,7 +33,7 @@
         RMCSkillIntel: 1
         RMCSkillOverwatch: 1
     - type: CMVendorUser
-      id: AU14JobCivilianCorporateLiaison
+      id: AU14JobCivilianAmbassadorTWE
       points: 70
     - type: JobPrefix
       prefix: au14-job-prefix-civilianambassadortwe
@@ -53,12 +53,12 @@
   equipment:
     jumpsuit: AU14CivilianWorkwearPink
     shoes: RMCShoesLaceupBrown
-    id: AU14IDCardColonyCorporateLiaison
+    id: AU14IDCardTWEAmbassador
     outerClothing: AU14CivilianJacketOldCoat
     ears: AU14ColonyAmbassadorTWEHeadset
     pocket1: AU14StampTWEA
   inhand:
-  - RMCPortableVendorCorporate
+  - AU14PortableVendorTWE
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/uaambassador.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/uaambassador.yml
@@ -33,7 +33,7 @@
         RMCSkillIntel: 1
         RMCSkillOverwatch: 1
     - type: CMVendorUser
-      id: AU14JobCivilianCorporateLiaison
+      id: AU14JobCivilianAmbassadorUA
       points: 70
     - type: JobPrefix
       prefix: au14-job-prefix-civilianambassadorua
@@ -59,7 +59,7 @@
     ears: AU14AmbassadorUAHeadset
     pocket1: AU14StampUAA
   inhand:
-  - RMCPortableVendorCorporate
+  - AU14PortableVendorUA
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/uppambassador.yml
+++ b/Resources/Prototypes/_AU14/Roles/Jobs/Colony/orbital/uppambassador.yml
@@ -33,7 +33,7 @@
         RMCSkillIntel: 1
         RMCSkillOverwatch: 1
     - type: CMVendorUser
-      id: AU14JobCivilianCorporateLiaison
+      id: AU14JobCivilianAmbassadorUPP
       points: 70
     - type: JobPrefix
       prefix: au14-job-prefix-civilianambassadorupp
@@ -53,12 +53,12 @@
   equipment:
     jumpsuit: CMJumpsuitSPPCiv4
     shoes: RMCShoesLaceupBrown
-    id: AU14IDCardColonyCorporateLiaison
+    id: AU14IDCardUPPAmbassador
     outerClothing: RMCCoatSPP
     ears: AU14AmbassadorUPPHeadset
     pocket1: AU14StampUPPA
   inhand:
-  - RMCPortableVendorCorporate
+  - AU14PortableVendorUPP
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_AU14/radio_channels.yml
+++ b/Resources/Prototypes/_AU14/radio_channels.yml
@@ -258,6 +258,15 @@
   tower: true
 
 - type: radioChannel
+  id: CCASOF
+  name: chat-radio-cca
+  keycode: "8"
+  frequency: 1537
+  color: "#ffae00"
+  longRange: true
+  tower: true
+
+- type: radioChannel
   id: radioVAI
   name: chat-radio-vai
   keycode: "z"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Ambassadors now have their own unique briefcases with different spreads of items to choose from with some overlap.

Ambassadors can now add their frequencies to telecomms.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Most ambassadors get flavoursome guns, UA gets a ceremonial sword, TWE the beloved Katana (folded only once sadly). UPP gets a silenced pistol option. ICSC gets the M2019 revolver. CCA gets no gun but their mighty dollars which translates into more dosh (wonga) in their briefcase.

All ambassadors get a flavor knife option, encryption keys for their own backstabbing embassies and mainly other stuff from the WY Liaison briefcase.

All ambassadors except for ICSC and CCA (who dont have any) get their turbo larp flag patches.

Booze.

GUN PRICES ARE PROBABLY TOO HIGH.

## Technical details
<!-- Summary of code changes for easier review. -->

Vaguely fixed the third party freq channels for ambassadors by use of mystic arts revealed to me in a dream.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Ambassador Briefcases with some flavor.