### PR TITLE
Add Pyro Spec Kit to Weapon Specialist Vendors

### DIFF
--- a/Resources/Prototypes/_AU14/Entities/Vendors/generalvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/generalvendors.yml
@@ -468,6 +468,11 @@
         isAppendSquadRoleName: false
         givePrefix: rmc-job-prefix-weapons-specialist-shotgunner
         isAppendPrefix: true
+      - id: RMCPyroSpecEquipmentCase
+        giveSquadRoleName: rmc-job-name-weapons-specialist-pyro
+        isAppendSquadRoleName: false
+        giveprefix: au14-job-prefix-specialist-pyro
+        isAppendPrefix: true
 
 - type: entity
   parent: [ColMarTechBase, AU14VendorWeaponsSpecialistGearBase]

--- a/Resources/Prototypes/_AU14/Entities/Vendors/generalvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/generalvendors.yml
@@ -471,7 +471,7 @@
       - id: RMCPyroSpecEquipmentCase
         giveSquadRoleName: rmc-job-name-weapons-specialist-pyro
         isAppendSquadRoleName: false
-        giveprefix: au14-job-prefix-specialist-pyro
+        givePrefix: au14-job-prefix-specialist-pyro
         isAppendPrefix: true
 
 - type: entity

--- a/Resources/Prototypes/_AU14/Entities/Vendors/lacnvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/lacnvendors.yml
@@ -825,7 +825,7 @@
       - id: RMCPyroSpecEquipmentCase
         giveSquadRoleName: rmc-job-name-weapons-specialist-pyro
         isAppendSquadRoleName: false
-        giveprefix: au14-job-prefix-specialist-pyro
+        givePrefix: au14-job-prefix-specialist-pyro
         isAppendPrefix: true
         
 - type: entity

--- a/Resources/Prototypes/_AU14/Entities/Vendors/lacnvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/lacnvendors.yml
@@ -822,7 +822,12 @@
         isAppendSquadRoleName: false
         givePrefix: rmc-job-prefix-weapons-specialist-shotgunner
         isAppendPrefix: true
-
+      - id: RMCPyroSpecEquipmentCase
+        giveSquadRoleName: rmc-job-name-weapons-specialist-pyro
+        isAppendSquadRoleName: false
+        giveprefix: au14-job-prefix-specialist-pyro
+        isAppendPrefix: true
+        
 - type: entity
   parent: ColMarTechBase
   id: AU14MilitaryPolicemanVendorLACN

--- a/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
@@ -838,7 +838,7 @@
       - id: RMCPyroSpecEquipmentCase
         giveSquadRoleName: rmc-job-name-weapons-specialist-pyro
         isAppendSquadRoleName: false
-        giveprefix: au14-job-prefix-specialist-pyro
+        givePrefix: au14-job-prefix-specialist-pyro
         isAppendPrefix: true
 
 # Equipment Vendor (universal except UPP/RMC)

--- a/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/marinevendors.yml
@@ -835,6 +835,11 @@
         isAppendSquadRoleName: false
         givePrefix: rmc-job-prefix-weapons-specialist-plasmagunner
         isAppendPrefix: true
+      - id: RMCPyroSpecEquipmentCase
+        giveSquadRoleName: rmc-job-name-weapons-specialist-pyro
+        isAppendSquadRoleName: false
+        giveprefix: au14-job-prefix-specialist-pyro
+        isAppendPrefix: true
 
 # Equipment Vendor (universal except UPP/RMC)
 - type: entity

--- a/Resources/Prototypes/_AU14/Entities/Vendors/rmcvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/rmcvendors.yml
@@ -993,7 +993,12 @@
         isAppendSquadRoleName: false
         givePrefix: rmc-job-prefix-weapons-specialist-sniper
         isAppendPrefix: true
-
+      - id: RMCPyroSpecEquipmentCase
+        giveSquadRoleName: rmc-job-name-weapons-specialist-pyro
+        isAppendSquadRoleName: false
+        giveprefix: au14-job-prefix-specialist-pyro
+        isAppendPrefix: true
+        
 # AirCrew Weapons
 - type: entity
   parent: ColMarTechBase

--- a/Resources/Prototypes/_AU14/Entities/Vendors/rmcvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/rmcvendors.yml
@@ -996,7 +996,7 @@
       - id: RMCPyroSpecEquipmentCase
         giveSquadRoleName: rmc-job-name-weapons-specialist-pyro
         isAppendSquadRoleName: false
-        giveprefix: au14-job-prefix-specialist-pyro
+        givePrefix: au14-job-prefix-specialist-pyro
         isAppendPrefix: true
         
 # AirCrew Weapons

--- a/Resources/Prototypes/_AU14/Entities/Vendors/wypmcvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/wypmcvendors.yml
@@ -822,6 +822,11 @@
         isAppendSquadRoleName: false
         givePrefix: rmc-job-prefix-weapons-specialist-shotgunner
         isAppendPrefix: true
+      - id: RMCPyroSpecEquipmentCase
+        giveSquadRoleName: rmc-job-name-weapons-specialist-pyro
+        isAppendSquadRoleName: false
+        giveprefix: au14-job-prefix-specialist-pyro
+        isAppendPrefix: true
 
 - type: entity
   parent: ColMarTechCargo

--- a/Resources/Prototypes/_AU14/Entities/Vendors/wypmcvendors.yml
+++ b/Resources/Prototypes/_AU14/Entities/Vendors/wypmcvendors.yml
@@ -825,7 +825,7 @@
       - id: RMCPyroSpecEquipmentCase
         giveSquadRoleName: rmc-job-name-weapons-specialist-pyro
         isAppendSquadRoleName: false
-        giveprefix: au14-job-prefix-specialist-pyro
+        givePrefix: au14-job-prefix-specialist-pyro
         isAppendPrefix: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
@@ -306,8 +306,8 @@
     - id: RMCBackpackBroiler
     - id: RMCWeaponFlamerSpec
     - id: RMCTankFlamerLarge
-    - id: RMCTankFlamerlargeB
-    - id: RMCTankFlamerlargeX
+    - id: RMCTankFlamerLargeB
+    - id: RMCTankFlamerLargeX
     - id: RMCPouchFuelTank
     - id: CMFireExtinguisher
     - id: CMFireExtinguisherPortable

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
@@ -306,13 +306,12 @@
     - id: RMCBackpackBroiler
     - id: RMCWeaponFlamerSpec
     - id: RMCTankFlamerLarge
+    - id: RMCTankFlamerlargeB
+    - id: RMCTankFlamerlargeX
     - id: RMCPouchFuelTank
     - id: CMFireExtinguisher
     - id: CMFireExtinguisherPortable
-    - id: RMCMK80
-    - id: CMMagazinePistolMK80
-      amount: 2
-    - id: RMCBinoculars
+    - id: RMCBinoculars #Note, removed the MK80 (VP-78) and it's two mags since most factions don't have access to further ammo (bar TWE)
   - type: CMChangeUserOnVend
     addComponents:
     - type: PyroWhitelist

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
@@ -311,7 +311,10 @@
     - id: RMCPouchFuelTank
     - id: CMFireExtinguisher
     - id: CMFireExtinguisherPortable
-    - id: RMCBinoculars #Note, removed the MK80 (VP-78) and it's two mags since most factions don't have access to further ammo (bar TWE)
+    - id: RMCBinoculars 
+    #- id: RMCMK80
+    #- id: CMMagazinePistolMK80
+    #  amount: 2
   - type: CMChangeUserOnVend
     addComponents:
     - type: PyroWhitelist


### PR DESCRIPTION
## About the PR
Adds the pyro specialist kit to select weapon specialist faction vendors (LACN/USCM/WY/RMC).

## Why / Balance
The M240-T was removed from req without adding to it weapon spec vendors.

## Technical details
Added the pyro kit to select factions (LACN/USCM/WY/TW)
Removed the MK80 (VP78) since most factions outside of TWE don't have access to squash head.
Gave the kit one tank of Napalm B & Napalm X since the kit was missing additional fuel.

Fixed the syntax muck-up so it tests shouldn't fail.

**Changelog**
:cl:
- add: Added the Pyro spec kit to select Factions WS Vendors (LACN/USCM/TWE/WY)
