### PR TITLE
Readds burst to scout spec

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_rifle.yml
@@ -198,9 +198,22 @@
   - type: Clothing
     sprite: _RMC14/Objects/Weapons/Guns/Rifles/m5spr2.rsi
   - type: RMCSelectiveFire
-    recoilUnwielded: 1
-    scatterWielded: 4
-    baseFireRate: 2.8
+    baseFireModes:
+    - SemiAuto
+    - Burst
+    recoilWielded: 1
+    recoilUnwielded: 4
+    scatterWielded: 2.5
+    scatterUnwielded: 8
+    baseFireRate: 1.8
+    burstFireRateMultiplier: 15
+    modifiers:
+      Burst:
+        fireDelay: 0.01
+        maxScatterModifier: 10
+        useBurstScatterMult: false
+        unwieldedScatterMultiplier: 2
+        shotsToMaxScatter: 6
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_scout_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_scout_rifle.yml
@@ -21,6 +21,7 @@
   - type: RMCSelectiveFire
     baseFireModes:
     - SemiAuto
+    - Burst
     recoilWielded: 1
     recoilUnwielded: 4
     scatterWielded: 2.5
@@ -29,9 +30,9 @@
     burstFireRateMultiplier: 15
     modifiers:
       Burst:
-        # fireDelay: 0.01
+        fireDelay: 0.01
         maxScatterModifier: 10
-        useBurstScatterMult: true
+        useBurstScatterMult: false
         unwieldedScatterMultiplier: 2
         shotsToMaxScatter: 6
   - type: RMCWeaponAccuracy


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Readded burst to the scout DMRs
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Returning the glory of the old scout burst mode from CM13, because I think its a cool feature and can open up new avenues of approach for scout players, either playing with their team to secure kills with triple impact hits, or playing solo with incen to pick off T1 xenos in the back line alone. I think this should make a return to the CM series and shouldnt cause too many issues, also "chambering" doesnt apply to the current scout spec DMR, so as long as no one adds it we shouldnt have the incen impact meta issue!
## Technical details
<!-- Summary of code changes for easier review. -->
YAML
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added Scout Burst to both Scout DMRs (from CM13)
