### PR TITLE
Fix UPP APC Portgun slot taking anything

### DIFF
--- a/Resources/Prototypes/_RMC14/Vehicles/APC/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/APC/vehicles.yml
@@ -305,8 +305,8 @@
 - type: entity
   parent: VehicleAPCBase
   id: VehicleSPPAPC
-  name: SPP armored personnel carrier
-  description: An armored personnel carrier configured for SPP forces.
+  name: UPP armored personnel carrier
+  description: An armored personnel carrier configured for UPP forces.
   components:
   - type: GridVehicleMover
     maxSpeed: 5
@@ -343,8 +343,14 @@
     slots:
       port-gun-north:
         startingItem: null
+        whitelist:
+          components:
+          - VehiclePortGun
       port-gun-south:
         startingItem: null
+        whitelist:
+          components:
+          - VehiclePortGun
       primary:
         startingItem: VehicleSPPAPCTurret
         disableEject: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Why does the APC keep taking my maintenance jack and putting it on a tripod??? This PR fixes UPP APC taking your tools from you when you're trying to fix the damn thing.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The slot being used is a PortGun slot that begins without a portgun and without a whitelist. Try repairing your UPP APC now and rejoice.
## Technical details
<!-- Summary of code changes for easier review. -->
Whitelist portgun slots of UPP APC to portgun only.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed UPP APC eating your tools for use later.

