### PR TITLE
Warlock and Reaper buffs

### DIFF
--- a/Content.Shared/_CMU14/Threats/Mobs/Xeno/Caste/Warlock/CMUXenoWarlockSystem.cs
+++ b/Content.Shared/_CMU14/Threats/Mobs/Xeno/Caste/Warlock/CMUXenoWarlockSystem.cs
@@ -452,7 +452,7 @@ public sealed partial class CMUXenoWarlockSystem : EntitySystem
     public const float PsychicShieldHalfThickness = 0.5f;
     public const float PsychicShieldHalfWidth = 1.5f;
     public const float PsychicShieldProjectileStopOffset = 0.1f;
-    public const float PsychicShieldReflectionSpreadDegrees = 50f;
+    public const float PsychicShieldReflectionSpreadDegrees = 80f;
 
     private const float WarlockDirectedParticleVelocity = 7f;
     private readonly HashSet<EntityUid> _affected = new();

--- a/Content.Shared/_CMU14/Threats/Mobs/Xeno/Caste/Warlock/CMUXenoWarlockSystem.cs
+++ b/Content.Shared/_CMU14/Threats/Mobs/Xeno/Caste/Warlock/CMUXenoWarlockSystem.cs
@@ -439,20 +439,20 @@ public sealed partial class CMUXenoWarlockSystem : EntitySystem
     private static readonly FixedPoint2 PsychicCrushMechDamageMultiplier = FixedPoint2.New(2.3f);
     public const string PsychicBlastFireSoundPath = "/Audio/_CMU14/Xeno/Warlock/volkite_4.ogg";
     public const string PsychicBlastImpactSoundPath = "/Audio/_CMU14/Xeno/Warlock/EMPulse.ogg";
-    public const int PsychicCrushBaseDamage = 30;
-    public const int PsychicCrushDamagePerPulse = 10;
+    public const int PsychicCrushBaseDamage = 65;
+    public const int PsychicCrushDamagePerPulse = 35;
     public const int PsychicCrushMaxAreaRadius = 2;
     public const int PsychicCrushMaxPulses = 5;
     public const int PsychicCrushPlasmaPerPulse = 40;
     public const float PsychicCrushTargetRangeValue = 9f;
     public const float PsychicBlastKnockbackSpeed = 8f;
     public const int PsychicShieldIntegrityValue = 650;
-    public const int PsychicShieldMaxFrozenProjectilesValue = 8;
+    public const int PsychicShieldMaxFrozenProjectilesValue = 10;
     public const int PsychicShieldPlasmaCost = 200;
     public const float PsychicShieldHalfThickness = 0.5f;
     public const float PsychicShieldHalfWidth = 1.5f;
     public const float PsychicShieldProjectileStopOffset = 0.1f;
-    public const float PsychicShieldReflectionSpreadDegrees = 80f;
+    public const float PsychicShieldReflectionSpreadDegrees = 50f;
 
     private const float WarlockDirectedParticleVelocity = 7f;
     private readonly HashSet<EntityUid> _affected = new();

--- a/Content.Shared/_RMC14/Xenonids/Reaper/XenoReaperComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Reaper/XenoReaperComponent.cs
@@ -19,10 +19,10 @@ public sealed partial class XenoReaperComponent : Component
     public int MaxFleshResin = 1000;
 
     [DataField, AutoNetworkedField]
-    public int MeleeGain = 6;
+    public int MeleeGain = 5;
 
     [DataField, AutoNetworkedField]
-    public int PassiveGain = 3;
+    public int PassiveGain = 2;
 
     [DataField, AutoNetworkedField]
     public TimeSpan PassiveGainEvery = TimeSpan.FromSeconds(1);
@@ -67,7 +67,7 @@ public sealed partial class XenoReaperComponent : Component
     public int RedGasCost = 20;
 
     [DataField, AutoNetworkedField]
-    public int RedGasRange = 8;
+    public int RedGasRange = 7;
 
     [DataField, AutoNetworkedField]
     public EntProtoId RedGasPrototype = "XenoReaperRedGas";

--- a/Content.Shared/_RMC14/Xenonids/Reaper/XenoReaperComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Reaper/XenoReaperComponent.cs
@@ -31,7 +31,7 @@ public sealed partial class XenoReaperComponent : Component
     public TimeSpan NextPassiveGainAt;
 
     [DataField, AutoNetworkedField]
-    public int PassiveGainMaxFleshResin = 400;
+    public int PassiveGainMaxFleshResin = 300;
 
     [DataField, AutoNetworkedField]
     public int FleshHarvestGain = 150;

--- a/Content.Shared/_RMC14/Xenonids/Reaper/XenoReaperComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Reaper/XenoReaperComponent.cs
@@ -19,10 +19,10 @@ public sealed partial class XenoReaperComponent : Component
     public int MaxFleshResin = 1000;
 
     [DataField, AutoNetworkedField]
-    public int MeleeGain = 5;
+    public int MeleeGain = 6;
 
     [DataField, AutoNetworkedField]
-    public int PassiveGain = 2;
+    public int PassiveGain = 3;
 
     [DataField, AutoNetworkedField]
     public TimeSpan PassiveGainEvery = TimeSpan.FromSeconds(1);
@@ -31,7 +31,7 @@ public sealed partial class XenoReaperComponent : Component
     public TimeSpan NextPassiveGainAt;
 
     [DataField, AutoNetworkedField]
-    public int PassiveGainMaxFleshResin = 300;
+    public int PassiveGainMaxFleshResin = 400;
 
     [DataField, AutoNetworkedField]
     public int FleshHarvestGain = 150;
@@ -40,7 +40,7 @@ public sealed partial class XenoReaperComponent : Component
     public TimeSpan FleshHarvestDelay = TimeSpan.FromSeconds(4);
 
     [DataField, AutoNetworkedField]
-    public int RaptureGain = 30;
+    public int RaptureGain = 60;
 
     [DataField, AutoNetworkedField]
     public EntProtoId RaptureEffect = "RMCEffectExtraSlash";
@@ -49,7 +49,7 @@ public sealed partial class XenoReaperComponent : Component
     public SoundSpecifier RaptureSound = new SoundCollectionSpecifier("AlienClaw");
 
     [DataField, AutoNetworkedField]
-    public int FleshBloomCost = 120;
+    public int FleshBloomCost = 100;
 
     [DataField, AutoNetworkedField]
     public EntProtoId FleshBloomPrototype = "XenoFleshBloom";
@@ -64,10 +64,10 @@ public sealed partial class XenoReaperComponent : Component
     public SoundSpecifier FleshBloomSound = new SoundCollectionSpecifier("XenoResinBreak");
 
     [DataField, AutoNetworkedField]
-    public int RedGasCost = 10;
+    public int RedGasCost = 20;
 
     [DataField, AutoNetworkedField]
-    public int RedGasRange = 7;
+    public int RedGasRange = 8;
 
     [DataField, AutoNetworkedField]
     public EntProtoId RedGasPrototype = "XenoReaperRedGas";
@@ -91,7 +91,7 @@ public sealed partial class XenoReaperComponent : Component
     };
 
     [DataField, AutoNetworkedField]
-    public int CarrionMantleCost = 150;
+    public int CarrionMantleCost = 120;
 
     [DataField, AutoNetworkedField]
     public TimeSpan CarrionMantleDuration = TimeSpan.FromSeconds(8);
@@ -100,7 +100,7 @@ public sealed partial class XenoReaperComponent : Component
     public FixedPoint2 CarrionMantleShieldAmount = FixedPoint2.New(200);
 
     [DataField, AutoNetworkedField]
-    public int CarrionMantleShieldDecay = 100;
+    public int CarrionMantleShieldDecay = 80;
 
     [DataField, AutoNetworkedField]
     public string CarrionMantleShieldVisualState = "king-shield";
@@ -134,13 +134,13 @@ public sealed partial class XenoFleshBloomComponent : Component
     [DataField, AutoNetworkedField]
     public DamageSpecifier Damage = new()
     {
-        DamageDict = { ["Poison"] = 4 },
+        DamageDict = { ["Poison"] = 8 },
     };
 
     [DataField, AutoNetworkedField]
     public DamageSpecifier Heal = new()
     {
-        DamageDict = { ["Blunt"] = -2, ["Slash"] = -2 },
+        DamageDict = { ["Blunt"] = -8, ["Slash"] = -8 },
     };
 }
 
@@ -158,7 +158,7 @@ public sealed partial class XenoReaperRedGasComponent : Component
 
     public DamageSpecifier Damage = new()
     {
-        DamageDict = { ["Poison"] = 5 },
+        DamageDict = { ["Poison"] = 10 },
     };
 }
 

--- a/Content.Tests/Shared/_CMU14/Xenonids/CMUXenoWarlockTest.cs
+++ b/Content.Tests/Shared/_CMU14/Xenonids/CMUXenoWarlockTest.cs
@@ -18,14 +18,14 @@ public sealed class CMUXenoWarlockTest
     [Test]
     public void GetPsychicCrushDamageScalesWithCompletedPulses()
     {
-        Assert.That(CMUXenoWarlockSystem.GetPsychicCrushDamage(1), Is.EqualTo(40));
+        Assert.That(CMUXenoWarlockSystem.GetPsychicCrushDamage(1), Is.EqualTo(100));
         Assert.That(CMUXenoWarlockSystem.GetPsychicCrushDamage(5), Is.EqualTo(80));
     }
 
     [Test]
     public void GetPsychicCrushDamageClampsToValidPulseRange()
     {
-        Assert.That(CMUXenoWarlockSystem.GetPsychicCrushDamage(-1), Is.EqualTo(30));
+        Assert.That(CMUXenoWarlockSystem.GetPsychicCrushDamage(-1), Is.EqualTo(65));
         Assert.That(CMUXenoWarlockSystem.GetPsychicCrushDamage(8), Is.EqualTo(80));
     }
 
@@ -300,7 +300,7 @@ public sealed class CMUXenoWarlockTest
         Assert.That(CMUXenoWarlockSystem.GetPsychicShieldCooldownDuration().TotalSeconds, Is.EqualTo(10).Within(0.001));
         Assert.That(CMUXenoWarlockSystem.GetPsychicShieldIntegrity(), Is.EqualTo(FixedPoint2.New(650)));
         Assert.That(CMUXenoWarlockSystem.GetPsychicShieldBreakStunDuration().TotalSeconds, Is.EqualTo(1).Within(0.001));
-        Assert.That(CMUXenoWarlockSystem.GetPsychicShieldMaxFrozenProjectiles(), Is.EqualTo(8));
+        Assert.That(CMUXenoWarlockSystem.GetPsychicShieldMaxFrozenProjectiles(), Is.EqualTo(10));
     }
 
     [Test]

--- a/Content.Tests/Shared/_CMU14/Xenonids/CMUXenoWarlockTest.cs
+++ b/Content.Tests/Shared/_CMU14/Xenonids/CMUXenoWarlockTest.cs
@@ -19,14 +19,14 @@ public sealed class CMUXenoWarlockTest
     public void GetPsychicCrushDamageScalesWithCompletedPulses()
     {
         Assert.That(CMUXenoWarlockSystem.GetPsychicCrushDamage(1), Is.EqualTo(100));
-        Assert.That(CMUXenoWarlockSystem.GetPsychicCrushDamage(5), Is.EqualTo(80));
+        Assert.That(CMUXenoWarlockSystem.GetPsychicCrushDamage(5), Is.EqualTo(240));
     }
 
     [Test]
     public void GetPsychicCrushDamageClampsToValidPulseRange()
     {
         Assert.That(CMUXenoWarlockSystem.GetPsychicCrushDamage(-1), Is.EqualTo(65));
-        Assert.That(CMUXenoWarlockSystem.GetPsychicCrushDamage(8), Is.EqualTo(80));
+        Assert.That(CMUXenoWarlockSystem.GetPsychicCrushDamage(8), Is.EqualTo(240));
     }
 
     [Test]

--- a/Resources/Prototypes/_CMU14/Effects/warlock.yml
+++ b/Resources/Prototypes/_CMU14/Effects/warlock.yml
@@ -213,7 +213,7 @@
       radius: 1.25
       damage:
         types:
-          Blunt: 35
+          Blunt: 55
       slow: 1.5
       impactSound:
         path: /Audio/_CMU14/Xeno/Warlock/EMPulse.ogg


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Warlock and Reaper have had their ability values buffed up from what they were previously.
Both T3 castes were severely lacking in performance, and were considered noob traps/throw picks. 

Reaper:
Rapture gives 60 flesh resin, up from 30
Flesh Bloom's cost is 100, down from 120
Bloom heals for 240, up from 65.
Bloom's damage is 210, up from 120
Red Gas's range is 8, up from 7
Gas does 180 toxin, up from 120.
Gas costs 20 resin, up from 10.
Carrion Mantle's cost is 120, down from 150
Mantle's shield decay is 80, down from 100

Warlock:
Psychic Crush damage is 65, up from 30
Crush dmg per pulse is 35, up from 10
Psychic Blast's damage is 55, up from 35
Psychic Shield max projectile block is 10, up from 8

## Why / Balance
Reaper's flesh resin concept made it awkward to work with despite no longer passively decaying, and its gas and bloom did not have a meaningful impact. For being a support T3, it could not do that very well if at all. The only thing that was remotely good was the shield and building, but that by itself wasn't enough of a reason to pick Reaper. 
Warlock's abilities simply did not do enough damage, especially Psychic Crush. The long windup for maximum damage is now rewarded.

As a note, Reaper's damage values here are finicky as both the gas and bloom are inconsistent in where they apply the most damage, so this is only listing the maximum damage you can take while holding still.

## Technical details
Reaper has had its component modified as a .yml file doesn't exist for it for some reason.
Warlock's system file has also been directly modified as it lacks both a proper component, with only one .yml file that allows changing of psychic blast's damage, with the rest being in system.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Reaper's values for its Rapture ability, Bloom ability, Gas ability, and Mantle have been increased to better its viability.
- tweak: Warlock's damage has been increased for all of its abilities, with a slight buff to its shield bullet cap.
