### PR TITLE
Fix Type 19 ammo box not showing up in Cardboard BUI

### DIFF
--- a/Resources/Prototypes/_CMU14/Entities/Objects/Weapons/Ammunition/bullet_boxes.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/Weapons/Ammunition/bullet_boxes.yml
@@ -394,7 +394,7 @@
   parent: RMCBoxBulletsPistol
   id: CMUBoxBulletsPistolType73
   name: pistol ammunition box (7.62×25mm)
-  description: A 7.62×25mm ammunition box. Used to refill Type 73 and Type-19 magazines. It comes with a leather strap allowing to wear it on the back.
+  description: A 7.62×25mm ammunition box. Used to refill Type 73 magazines. It comes with a leather strap allowing to wear it on the back.
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/magazine_box_crafting.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/magazine_box_crafting.yml
@@ -579,7 +579,7 @@
   startNode: start
   targetNode: CMUBoxBulletsPistolType73Empty
   category: construction-category-cm-box-magazine
-  description: A 7.62x25mm ammunition box. Used to refill Type 73 and Type-19 magazines. It comes with a leather strap allowing to wear it on the back.
+  description: A 7.62x25mm ammunition box. Used to refill Type 73 magazines. It comes with a leather strap allowing to wear it on the back.
   iconColor: "#727e90"
   objectType: Item
 # .45

--- a/Resources/Prototypes/_RMC14/Recipes/Materials/cardboard.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Materials/cardboard.yml
@@ -102,6 +102,7 @@
   - RMCBoxBulletsSMGAPEmptyBuild
   - CMUBoxBulletsSMGP90EmptyBuild
   - CMUBoxBulletsSMGP90APEmptyBuild
+  - CMUBoxBulletsSMGType19EmptyBuild
   - CMUBoxBulletsSMG9MMEmptyBuild
   - RMCBoxBulletsPistolEmptyBuild
   - RMCBoxBulletsPistolAPEmptyBuild
@@ -207,7 +208,13 @@
   id: CMUBoxBulletsSMGP90APEmptyBuild
   name: SMG ammunition box (5.7×28mm AP)
   prototype: CMUBoxBulletsSMGP90APEmpty  
-
+  
+- type: rmcConstruction
+  parent: RMCCardboardBuildBase
+  id: CMUBoxBulletsSMGType19EmptyBuild
+  name: SMG ammunition box (7.62×25mm)
+  prototype: CMUBoxBulletsSMGType19Empty
+  
 - type: rmcConstruction
   parent: RMCCardboardBuildBase
   id: CMUBoxBulletsSMG9MMEmptyBuild


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Type 19 shit. Title
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Type 19 ammo box is now craftable
