### PR TITLE
Fix increased gun scatter persisting post queen screech

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Screech/ScreechBlindComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/ScreechBlindComponent.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.GameStates;
+using Robust.Shared.GameObjects;
 
 namespace Content.Shared._RMC14.Xenonids.Screech;
 
@@ -13,4 +14,7 @@ public sealed partial class ScreechBlindComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public float Radius = 2f;
+
+    [ViewVariables]
+    public readonly HashSet<EntityUid> ModifiedGuns = new();
 }

--- a/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
@@ -125,7 +125,7 @@ public sealed partial class XenoScreechSystem : EntitySystem
 
     private void OnScreechBlindStartup(Entity<ScreechBlindComponent> ent, ref ComponentStartup args)
     {
-        AddScatterToHeldGuns(ent.Owner, ent.Comp);
+        AddScatterToTrackedGuns(ent.Owner, ent.Comp);
     }
 
     private void OnScreechBlindShutdown(Entity<ScreechBlindComponent> ent, ref ComponentShutdown args)

--- a/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
@@ -164,7 +164,7 @@ public sealed partial class XenoScreechSystem : EntitySystem
     {
         foreach (var gun in blind.ModifiedGuns)
         {
-            if (Deleted(gun))
+            if (TerminatingOrDeleted(gun))
                 continue;
 
             if (RemComp<ScreechScatterComponent>(gun))

--- a/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
@@ -125,15 +125,15 @@ public sealed partial class XenoScreechSystem : EntitySystem
 
     private void OnScreechBlindStartup(Entity<ScreechBlindComponent> ent, ref ComponentStartup args)
     {
-        AddScatterToHeldGuns(ent);
+        AddScatterToHeldGuns(ent.Owner, ent.Comp);
     }
 
     private void OnScreechBlindShutdown(Entity<ScreechBlindComponent> ent, ref ComponentShutdown args)
     {
-        RemoveScatterFromHeldGuns(ent);
+        RemoveScatterFromTrackedGuns(ent.Comp);
     }
 
-    private void AddScatterToHeldGuns(EntityUid user)
+    private void AddScatterToHeldGuns(EntityUid user, ScreechBlindComponent blind)
     {
         if (!TryComp<HandsComponent>(user, out var hands))
             return;
@@ -148,30 +148,30 @@ public sealed partial class XenoScreechSystem : EntitySystem
                 if (!HasComp<GunComponent>(held))
                     continue;
 
-                EnsureComp<ScreechScatterComponent>(held);
+                if (!HasComp<ScreechScatterComponent>(held))
+                {
+                    EnsureComp<ScreechScatterComponent>(held);
+                    blind.ModifiedGuns.Add(held);
+                }
+
                 _gun.RefreshModifiers(held);
             }
         }
     }
 
-    private void RemoveScatterFromHeldGuns(EntityUid user)
+    private void RemoveScatterFromTrackedGuns(
+        ScreechBlindComponent blind)
     {
-        if (!TryComp<HandsComponent>(user, out var hands))
-            return;
-
-        foreach (var name in hands.Hands.Keys)
+        foreach (var gun in blind.ModifiedGuns)
         {
-            if (!_container.TryGetContainer(user, name, out var container))
+            if (Deleted(gun))
                 continue;
 
-            foreach (var held in container.ContainedEntities)
-            {
-                if (!RemComp<ScreechScatterComponent>(held))
-                    continue;
-
-                _gun.RefreshModifiers(held);
-            }
+            if (RemComp<ScreechScatterComponent>(gun))
+                _gun.RefreshModifiers(gun);
         }
+
+        blind.ModifiedGuns.Clear();
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
@@ -133,7 +133,7 @@ public sealed partial class XenoScreechSystem : EntitySystem
         RemoveScatterFromTrackedGuns(ent.Comp);
     }
 
-    private void AddScatterToHeldGuns(EntityUid user, ScreechBlindComponent blind)
+    private void AddScatterToTrackedGuns(EntityUid user, ScreechBlindComponent blind)
     {
         if (!TryComp<HandsComponent>(user, out var hands))
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed a bug where guns affected by queen scream could permanently retain their increased scatter if they were no longer being held when the effect expired.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug

## Technical details
Added a `ModifiedGuns` `HashSet<EntityUid>` to `ScreechBlindComponent` for tracking every weapon that receives a temporary `ScreechScatterComponent`.
Updated `AddScatterToHeldGuns()` to track weapons in `ModifiedGuns` when applying the scatter modifier.
Updated `ScreechBlindComponent` to remove `ScreechScatterComponent` from all tracked weapons and refresh their modifiers.

The old implementation relied on the player's currently held weapons for cleanup rather than tracking the weapons that had actually received the scatter modifier, causing dropped weapons to keep the scatter effect permanently.
I would've made it so upon the gun being dropped the scatter is removed, but that felt too hacky+easy to exploit so it's this now


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed a bug where guns affected by queen scream could permanently retain their increased scatter if they were no longer being held when the effect expired.

