### PR TITLE
Send Threat Roll Fails to Lobby

### DIFF
--- a/Content.Client/Launcher/LauncherConnectingGui.xaml.cs
+++ b/Content.Client/Launcher/LauncherConnectingGui.xaml.cs
@@ -18,7 +18,7 @@ namespace Content.Client.Launcher
     [GenerateTypedNameReferences]
     public sealed partial class LauncherConnectingGui : Control
     {
-        private const float RedialWaitTimeSeconds = 25f;
+        private const float RedialWaitTimeSeconds = 30f;
         private readonly LauncherConnecting _state;
         private float _waitTime;
 

--- a/Content.IntegrationTests/_RMC14/XenoReaperTest.cs
+++ b/Content.IntegrationTests/_RMC14/XenoReaperTest.cs
@@ -598,7 +598,7 @@ public sealed class XenoReaperTest
 
             Assert.Multiple(() =>
             {
-                Assert.That(CountPrototype(entMan, "XenoReaperRedGas"), Is.EqualTo(4));
+                Assert.That(CountPrototype(entMan, "XenoReaperRedGas"), Is.EqualTo(2));
                 Assert.That(entMan.GetComponent<XenoReaperComponent>(reaper).FleshResin, Is.Zero);
             });
 

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -365,10 +365,10 @@ namespace Content.Server.GameTicking
                     try
                     {
                         _threatSystem.SpawnThreatAtRoundStart(selectedThreat, DefaultMap, assignedJobs);
+
                         if (_sawmill.Level <= LogLevel.Debug)
                         {
-                            AuAssignmentCounts afterThreatCounts = GameTicker.CountAuAssignments(assignedJobs);
-
+                            AuAssignmentCounts afterThreatCounts = CountAuAssignments(assignedJobs);
                             _sawmill.Debug(
                                 $"[RoundStart] Threat spawn returned for '{selectedThreat.ID}'; remainingThreatLeaders={
                                     afterThreatCounts.ThreatLeaders}, remainingThreatMembers={
@@ -376,6 +376,24 @@ namespace Content.Server.GameTicking
                                     }.");
                         }
 
+                        // Return unselected threat players to lobby so they can JIP
+                        var threatLosers = new List<(NetUserId UserId, ICommonSession Session)>();
+                        foreach ((NetUserId userId, (ProtoId<JobPrototype>? job, EntityUid _)) in assignedJobs)
+                        {
+                            if ((job != AuThreatLeaderJob && job != AuThreatMemberJob)
+                                || !readySessions.TryGetValue(userId, out ICommonSession? session))
+                                continue;
+
+                            threatLosers.Add((userId, session));
+                        }
+                        _sawmill.Debug($"[RoundStart] Returning {threatLosers.Count} unselected threat player(s) to lobby.");
+                        foreach ((NetUserId userId, ICommonSession session) in threatLosers)
+                        {
+                            assignedJobs.Remove(userId);
+                            PlayerJoinLobby(session);
+                            _chatManager.DispatchServerMessage(session,
+                                Loc.GetString("au14-threat-not-selected-return-to-lobby"));
+                        }
                     }
                     catch (Exception threatEx)
                     {

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -1,14 +1,21 @@
-using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using Content.Server._CMU14.Ops.ThirdParty;
 using Content.Server._CMU14.Threats;
+using Content.Server._RMC14.Announce;
+using Content.Server._RMC14.Xenonids.Hive;
 using Content.Server.Administration.Managers;
 using Content.Server.Administration.Systems;
+using Content.Server.AU14.Allegiance;
+using Content.Server.AU14.Origin;
+using Content.Server.AU14.Round;
+using Content.Server.AU14.Scenario;
 using Content.Server.GameTicking.Events;
 using Content.Server.Spawners.Components;
-using Content.Server.Speech.Components;
 using Content.Server.Station.Components;
+using Content.Shared._CMU14.Threats;
+using Content.Shared._RMC14.Rules;
+using Content.Shared.AU14.util;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
 using Content.Shared.GameTicking;
@@ -28,18 +35,13 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
-using Content.Server._RMC14.Announce;
-using Content.Server._RMC14.Xenonids.Hive;
-using Content.Server.AU14.Round;
-using Content.Server.AU14.Scenario;
-using Content.Shared.AU14.util;
 
 namespace Content.Server.GameTicking
 {
+
     public sealed partial class GameTicker
     {
         [Dependency] private XenoHiveSystem _hive = default!;
-
         [Dependency] private IAdminManager _adminManager = default!;
         [Dependency] private SharedJobSystem _jobs = default!;
         [Dependency] private AdminSystem _admin = default!;
@@ -48,27 +50,28 @@ namespace Content.Server.GameTicking
         [Dependency] private ScenarioPlanSystem _scenarioPlan = default!;
         [Dependency] private ThreatSystem _threatSystem = default!;
         [Dependency] private ThreatVoteSystem _threatVoteSystem = default!;
-        [Dependency] private ThirdPartySystem _ThirdParty = default!;
-        [Dependency] private Content.Server.AU14.Allegiance.AllegianceSystem _allegianceSystem = default!;
-        [Dependency] private Content.Server.AU14.Origin.OriginSystem _originSystem = default!;
+        [Dependency] private ThirdPartySystem _thirdParty = default!;
+        [Dependency] private AllegianceSystem _allegianceSystem = default!;
+        [Dependency] private OriginSystem _originSystem = default!;
+
+        public static readonly EntProtoId ObserverPrototypeName = "MobObserver";
+        public static readonly EntProtoId AdminObserverPrototypeName = "RMCAdminObserver";
 
         private const string AuThreatLeaderJob = "AU14JobThreatLeader";
         private const string AuThreatMemberJob = "AU14JobThreatMember";
         private const string AuThirdPartyLeaderJob = "AU14JobThirdPartyLeader";
         private const string AuThirdPartyMemberJob = "AU14JobThirdPartyMember";
 
-        public static readonly EntProtoId ObserverPrototypeName = "MobObserver";
-        public static readonly EntProtoId AdminObserverPrototypeName = "RMCAdminObserver";
+        // Mainly to avoid allocations.
+        private readonly List<EntityCoordinates> _possiblePositions = new();
 
-        private readonly record struct AuAssignmentCounts(
-            int NoJob,
-            int ThreatLeaders,
-            int ThreatMembers,
-            int ThirdPartyLeaders,
-            int ThirdPartyMembers);
+        /// <summary>
+        ///     How many players have joined the round through normal methods.
+        ///     Useful for game rules to look at. Doesn't count observers, people in lobby, etc.
+        /// </summary>
+        public int PlayersJoinedRoundNormally;
 
-        private static AuAssignmentCounts CountAuAssignments(
-            Dictionary<NetUserId, (ProtoId<JobPrototype>?, EntityUid)> assignedJobs)
+        private static AuAssignmentCounts CountAuAssignments(Dictionary<NetUserId, (ProtoId<JobPrototype>?, EntityUid)> assignedJobs)
         {
             var noJob = 0;
             var threatLeaders = 0;
@@ -76,7 +79,7 @@ namespace Content.Server.GameTicking
             var thirdPartyLeaders = 0;
             var thirdPartyMembers = 0;
 
-            foreach (var (_, (job, _)) in assignedJobs)
+            foreach ((NetUserId _, (ProtoId<JobPrototype>? job, EntityUid _)) in assignedJobs)
             {
                 if (job == null)
                     noJob++;
@@ -90,7 +93,7 @@ namespace Content.Server.GameTicking
                     thirdPartyMembers++;
             }
 
-            return new AuAssignmentCounts(
+            return new(
                 noJob,
                 threatLeaders,
                 threatMembers,
@@ -99,8 +102,8 @@ namespace Content.Server.GameTicking
         }
 
         /// <summary>
-        /// Determines which platoon a job belongs to based on its ID.
-        /// Returns null if the job doesn't belong to a specific platoon.
+        ///     Determines which platoon a job belongs to based on its ID.
+        ///     Returns null if the job doesn't belong to a specific platoon.
         /// </summary>
         private PlatoonPrototype? GetPlatoonForJob(string? jobId)
         {
@@ -116,48 +119,42 @@ namespace Content.Server.GameTicking
             return null;
         }
 
-        private ScenarioPlanValidationRequest BuildScenarioPlanRuntimeRequest(string? presetId, int playerCount)
-        {
-            return new ScenarioPlanValidationRequest(
-                presetId ?? string.Empty,
-                playerCount,
-                _platoonSpawnRuleSystem.SelectedGovforPlatoon?.ID,
-                _platoonSpawnRuleSystem.SelectedOpforPlatoon?.ID,
-                _auRoundSystem.GetSelectedPlanetId(),
-                _auRoundSystem.GetSelectedPlanet()?.MapId,
-                _auRoundSystem.SelectedThreat?.ID,
-                _auRoundSystem.GetSelectedGovforShip(),
-                _auRoundSystem.GetSelectedOpforShip());
-        }
+        private ScenarioPlanValidationRequest BuildScenarioPlanRuntimeRequest(string? presetId, int playerCount) => new(
+            presetId ?? string.Empty,
+            playerCount,
+            _platoonSpawnRuleSystem.SelectedGovforPlatoon?.ID,
+            _platoonSpawnRuleSystem.SelectedOpforPlatoon?.ID,
+            _auRoundSystem.GetSelectedPlanetId(),
+            _auRoundSystem.GetSelectedPlanet()?.MapId,
+            _auRoundSystem.SelectedThreat?.ID,
+            _auRoundSystem.GetSelectedGovforShip(),
+            _auRoundSystem.GetSelectedOpforShip());
 
         private static bool ShouldGenerateScenarioPlanShadow(string? presetId)
-        {
-            return presetId != null &&
-                   (presetId.Equals("DistressSignal", StringComparison.OrdinalIgnoreCase) ||
-                    presetId.Equals("Insurgency", StringComparison.OrdinalIgnoreCase) ||
-                    presetId.Equals("ColonyFall", StringComparison.OrdinalIgnoreCase));
-        }
+            => presetId != null
+                && (presetId.Equals("DistressSignal", StringComparison.OrdinalIgnoreCase)
+                    || presetId.Equals("Insurgency", StringComparison.OrdinalIgnoreCase)
+                    || presetId.Equals("ColonyFall", StringComparison.OrdinalIgnoreCase));
 
         /// <summary>
-        /// Resolves the correct character profile for a player based on allegiance.
-        /// If the player is ignoring allegiance or the job/platoon has no requirements, returns the selected profile.
-        /// If the selected profile doesn't match, searches other profiles.
-        /// Returns null if no matching profile is found and the player isn't ignoring allegiance.
+        ///     Resolves the correct character profile for a player based on allegiance.
+        ///     If the player is ignoring allegiance or the job/platoon has no requirements, returns the selected profile.
+        ///     If the selected profile doesn't match, searches other profiles.
+        ///     Returns null if no matching profile is found and the player isn't ignoring allegiance.
         /// </summary>
-        private HumanoidCharacterProfile? ResolveProfileForAllegiance(
-            NetUserId userId,
+        private HumanoidCharacterProfile? ResolveProfileForAllegiance(NetUserId userId,
             HumanoidCharacterProfile selectedProfile,
             string? jobId)
         {
             HumanoidCharacterProfile? FindMatchingProfile(Func<HumanoidCharacterProfile, bool> predicate)
             {
-                if (_prefsManager.TryGetCachedPreferences(userId, out var prefs))
+                if (!_prefsManager.TryGetCachedPreferences(userId, out PlayerPreferences? cachedPrefs))
+                    return null;
+
+                foreach ((int _, ICharacterProfile profile) in cachedPrefs.Characters)
                 {
-                    foreach (var (_, profile) in prefs.Characters)
-                    {
-                        if (profile is HumanoidCharacterProfile humanoid && predicate(humanoid))
-                            return humanoid;
-                    }
+                    if (profile is HumanoidCharacterProfile humanoid && predicate(humanoid))
+                        return humanoid;
                 }
 
                 return null;
@@ -169,7 +166,7 @@ namespace Content.Server.GameTicking
 
             JobPrototype? jobProto = null;
             if (jobId != null)
-                _prototypeManager.TryIndex<JobPrototype>(jobId, out jobProto);
+                _prototypeManager.TryIndex(jobId, out jobProto);
 
             bool MeetsJobRequirements(HumanoidCharacterProfile profile)
             {
@@ -177,73 +174,46 @@ namespace Content.Server.GameTicking
                     return true;
 
                 return _allegianceSystem.DoesCharacterMeetJobAllegiance(profile, jobProto)
-                       && _allegianceSystem.DoesCharacterMeetJobOrigin(profile, jobProto);
+                    && _allegianceSystem.DoesCharacterMeetJobOrigin(profile, jobProto);
             }
 
-            var platoon = GetPlatoonForJob(jobId);
+            PlatoonPrototype? platoon = GetPlatoonForJob(jobId);
 
             // No platoon for this job = no allegiance restriction
             if (platoon == null)
-            {
-                if (MeetsJobRequirements(selectedProfile))
-                    return selectedProfile;
-
-                return FindMatchingProfile(MeetsJobRequirements);
-            }
+                return MeetsJobRequirements(selectedProfile) ? selectedProfile : FindMatchingProfile(MeetsJobRequirements);
 
             // No allegiance set on the platoon = no restriction
             if (platoon.Allegiance == null)
-            {
-                if (MeetsJobRequirements(selectedProfile))
-                    return selectedProfile;
-
-                return FindMatchingProfile(MeetsJobRequirements);
-            }
+                return MeetsJobRequirements(selectedProfile) ? selectedProfile : FindMatchingProfile(MeetsJobRequirements);
 
             // Job ignores allegiance
             if (jobProto is { IgnoreAllegiance: true })
-            {
-                if (MeetsJobRequirements(selectedProfile))
-                    return selectedProfile;
-
-                return FindMatchingProfile(MeetsJobRequirements);
-            }
+                return MeetsJobRequirements(selectedProfile) ? selectedProfile : FindMatchingProfile(MeetsJobRequirements);
 
             // Check if the selected profile matches
             if (_allegianceSystem.IsAllegianceApplicableForPlatoon(selectedProfile, platoon, jobProto))
                 return selectedProfile;
 
             // Selected doesn't match — search all character profiles
-            if (_prefsManager.TryGetCachedPreferences(userId, out var prefs))
-            {
-                var match = _allegianceSystem.FindApplicableCharacterForPlatoon(
-                    prefs.Characters,
-                    prefs.SelectedCharacterIndex,
-                    platoon,
-                    jobProto);
+            if (!_prefsManager.TryGetCachedPreferences(userId, out PlayerPreferences? prefs))
+                return null;
 
-                if (match != null)
-                    return match;
-            }
+            HumanoidCharacterProfile? match = _allegianceSystem.FindApplicableCharacterForPlatoon(
+                prefs.Characters,
+                prefs.SelectedCharacterIndex,
+                platoon,
+                jobProto);
 
-            // No matching profile found
-            return null;
+            return match ?? null;
         }
-
-        /// <summary>
-        /// How many players have joined the round through normal methods.
-        /// Useful for game rules to look at. Doesn't count observers, people in lobby, etc.
-        /// </summary>
-        public int PlayersJoinedRoundNormally;
-
-        // Mainly to avoid allocations.
-        private readonly List<EntityCoordinates> _possiblePositions = new();
 
         private List<EntityUid> GetSpawnableStations()
         {
             var spawnableStations = new List<EntityUid>();
-            var query = EntityQueryEnumerator<StationJobsComponent, StationSpawningComponent>();
-            while (query.MoveNext(out var uid, out _, out _))
+            EntityQueryEnumerator<StationJobsComponent, StationSpawningComponent> query
+                = EntityQueryEnumerator<StationJobsComponent, StationSpawningComponent>();
+            while (query.MoveNext(out EntityUid uid, out _, out _))
             {
                 spawnableStations.Add(uid);
             }
@@ -252,8 +222,7 @@ namespace Content.Server.GameTicking
         }
 
         private static Dictionary<NetUserId, HumanoidCharacterProfile> GetGamemodeAssignmentProfiles(
-            Dictionary<NetUserId, HumanoidCharacterProfile> profiles,
-            string? presetId)
+            Dictionary<NetUserId, HumanoidCharacterProfile> profiles, string? presetId)
         {
             if (string.IsNullOrWhiteSpace(presetId))
                 return profiles.ShallowClone();
@@ -273,7 +242,7 @@ namespace Content.Server.GameTicking
             // has already been loaded by LoadMaps and CMDistressSignalRuleSystem.OnRulePlayerSpawning
             // won't run, so map-placed weeds/tunnels need their hive assigned here. CMDistressSignal
             // handles its own assignment after it loads the planet via SpawnXenoMap.
-            if (!IsGameRuleActive<Content.Shared._RMC14.Rules.CMDistressSignalRuleComponent>())
+            if (!IsGameRuleActive<CMDistressSignalRuleComponent>())
                 _distressSignal.SetFriendlyHives(_distressSignal.TheHive);
 
             // Allow game rules to spawn players by themselves if needed. (For example, nuke ops or wizard)
@@ -281,7 +250,7 @@ namespace Content.Server.GameTicking
 
             var readySessions = new Dictionary<NetUserId, ICommonSession>(readyPlayers.Count);
             var playerNetIds = new HashSet<NetUserId>(readyPlayers.Count);
-            foreach (var player in readyPlayers)
+            foreach (ICommonSession player in readyPlayers)
             {
                 readySessions[player.UserId] = player;
                 playerNetIds.Add(player.UserId);
@@ -293,7 +262,7 @@ namespace Content.Server.GameTicking
             {
                 var toRemove = new RemQueue<NetUserId>();
 
-                foreach (var (player, _) in profiles)
+                foreach ((NetUserId player, HumanoidCharacterProfile _) in profiles)
                 {
                     if (playerNetIds.Contains(player))
                         continue;
@@ -301,32 +270,39 @@ namespace Content.Server.GameTicking
                     toRemove.Add(player);
                 }
 
-                foreach (var player in toRemove)
+                foreach (NetUserId player in toRemove)
                 {
                     profiles.Remove(player);
                 }
             }
 
-            var presetId = CurrentPreset?.ID ?? Preset?.ID ?? _auRoundSystem.SelectedPreset?.ID;
-            var assignmentProfiles = GetGamemodeAssignmentProfiles(profiles, presetId);
+            string? presetId = CurrentPreset?.ID ?? Preset?.ID ?? _auRoundSystem.SelectedPreset?.ID;
+            Dictionary<NetUserId, HumanoidCharacterProfile> assignmentProfiles
+                = GameTicker.GetGamemodeAssignmentProfiles(profiles, presetId);
 
-            this._threatVoteSystem.ClearRoundJoinBlocks();
-            var usesPostRoundstartThreatVote = _auRoundSystem.UsesPostRoundstartThreatVote();
+            _threatVoteSystem.ClearRoundJoinBlocks();
+            bool usesPostRoundstartThreatVote = _auRoundSystem.UsesPostRoundstartThreatVote();
             var threatVotePrepared = false;
+
             _sawmill.Debug(
-                $"[RoundStart] SpawnPlayers begin: preset={presetId ?? "null"}, readyPlayers={readyPlayers.Count}, profiles={profiles.Count}, assignmentProfiles={assignmentProfiles.Count}, defaultMap={DefaultMap}, planet={_auRoundSystem.GetSelectedPlanet()?.MapId ?? "null"}, selectedThreat={_auRoundSystem.SelectedThreat?.ID ?? "null"}, postRoundstartThreatVote={usesPostRoundstartThreatVote}");
+                $"[RoundStart] SpawnPlayers begin: preset={presetId ?? "null"}, readyPlayers={readyPlayers.Count
+                }, profiles={profiles.Count}, assignmentProfiles={assignmentProfiles.Count}, defaultMap={DefaultMap
+                }, planet={_auRoundSystem.GetSelectedPlanet()?.MapId ?? "null"}, selectedThreat={
+                    _auRoundSystem.SelectedThreat?.ID ?? "null"}, postRoundstartThreatVote={usesPostRoundstartThreatVote
+                    }");
+
             if (usesPostRoundstartThreatVote)
             {
                 _sawmill.Debug("[RoundStart] Preparing post-roundstart threat vote.");
                 try
                 {
-                    threatVotePrepared = this._threatVoteSystem.TryPrepareThreatVote(assignmentProfiles, DefaultMap);
+                    threatVotePrepared = _threatVoteSystem.TryPrepareThreatVote(assignmentProfiles, DefaultMap);
                     _sawmill.Debug($"[RoundStart] TryPrepareThreatVote result={threatVotePrepared}.");
                 }
                 catch (Exception threatVoteEx)
                 {
                     Log.Error($"TryPrepareThreatVote threw - round will continue without a threat vote. {threatVoteEx}");
-                    this._threatVoteSystem.ClearRoundJoinBlocks();
+                    _threatVoteSystem.ClearRoundJoinBlocks();
                     _auJobSelectionSystem.ForcedJobAssignments.Clear();
                 }
             }
@@ -336,7 +312,7 @@ namespace Content.Server.GameTicking
                 _auJobSelectionSystem.AssignThreatAndThirdPartyJobs(assignmentProfiles);
             }
 
-            if (ShouldGenerateScenarioPlanShadow(presetId))
+            if (GameTicker.ShouldGenerateScenarioPlanShadow(presetId))
             {
                 try
                 {
@@ -352,89 +328,109 @@ namespace Content.Server.GameTicking
                 }
             }
 
-            var spawnableStations = GetSpawnableStations();
+            List<EntityUid> spawnableStations = GetSpawnableStations();
             _sawmill.Debug($"[RoundStart] Found {spawnableStations.Count} spawnable station(s).");
-            var assignedJobs = _stationJobs.AssignJobs(assignmentProfiles, spawnableStations);
-            if (_sawmill.Level <= Robust.Shared.Log.LogLevel.Debug)
+            Dictionary<NetUserId, (ProtoId<JobPrototype>?, EntityUid)> assignedJobs
+                = _stationJobs.AssignJobs(assignmentProfiles, spawnableStations);
+            if (_sawmill.Level <= LogLevel.Debug)
             {
-                var stationAssignmentCounts = CountAuAssignments(assignedJobs);
+                AuAssignmentCounts stationAssignmentCounts = GameTicker.CountAuAssignments(assignedJobs);
                 _sawmill.Debug(
-                    $"[RoundStart] Station job assignment complete: assigned={assignedJobs.Count}, noJob={stationAssignmentCounts.NoJob}, threatLeaders={stationAssignmentCounts.ThreatLeaders}, threatMembers={stationAssignmentCounts.ThreatMembers}, thirdPartyLeaders={stationAssignmentCounts.ThirdPartyLeaders}, thirdPartyMembers={stationAssignmentCounts.ThirdPartyMembers}");
+                    $"[RoundStart] Station job assignment complete: assigned={assignedJobs.Count}, noJob={
+                        stationAssignmentCounts.NoJob}, threatLeaders={stationAssignmentCounts.ThreatLeaders
+                        }, threatMembers={stationAssignmentCounts.ThreatMembers}, thirdPartyLeaders={
+                            stationAssignmentCounts.ThirdPartyLeaders}, thirdPartyMembers={
+                                stationAssignmentCounts.ThirdPartyMembers}");
             }
 
             // Defensive: any exception inside SpawnPlayers propagates to StartRound's
             // EXCEPTION_TOLERANCE catch (only enabled in Release/Tools builds), which calls
             // RestartRound() — making the round appear to "instantly restart at start" in
             // production. Wrap the threat spawn so a single subsystem can't take the round down.
-            var selectedThreat = _auRoundSystem.SelectedThreat;
-            if (!usesPostRoundstartThreatVote && selectedThreat != null)
+            ThreatPrototype? selectedThreat = _auRoundSystem.SelectedThreat;
+            switch (usesPostRoundstartThreatVote)
             {
-                if (_sawmill.Level <= Robust.Shared.Log.LogLevel.Debug)
+                case false when selectedThreat != null:
                 {
-                    var beforeThreatCounts = CountAuAssignments(assignedJobs);
-                    _sawmill.Debug(
-                        $"[RoundStart] Starting immediate threat spawn for '{selectedThreat.ID}' on map {DefaultMap}; assignedThreatLeaders={beforeThreatCounts.ThreatLeaders}, assignedThreatMembers={beforeThreatCounts.ThreatMembers}.");
-                }
-
-                try
-                {
-                    this._threatSystem.SpawnThreatAtRoundStart(selectedThreat, DefaultMap, assignedJobs);
-                    if (_sawmill.Level <= Robust.Shared.Log.LogLevel.Debug)
+                    if (_sawmill.Level <= LogLevel.Debug)
                     {
-                        var afterThreatCounts = CountAuAssignments(assignedJobs);
+                        AuAssignmentCounts beforeThreatCounts = GameTicker.CountAuAssignments(assignedJobs);
+
                         _sawmill.Debug(
-                            $"[RoundStart] Threat spawn returned for '{selectedThreat.ID}'; remainingThreatLeaders={afterThreatCounts.ThreatLeaders}, remainingThreatMembers={afterThreatCounts.ThreatMembers}.");
+                            $"[RoundStart] Starting immediate threat spawn for '{selectedThreat.ID}' on map {DefaultMap
+                            }; assignedThreatLeaders={beforeThreatCounts.ThreatLeaders}, assignedThreatMembers={
+                                beforeThreatCounts.ThreatMembers}.");
                     }
+
+                    try
+                    {
+                        _threatSystem.SpawnThreatAtRoundStart(selectedThreat, DefaultMap, assignedJobs);
+                        if (_sawmill.Level <= LogLevel.Debug)
+                        {
+                            AuAssignmentCounts afterThreatCounts = GameTicker.CountAuAssignments(assignedJobs);
+
+                            _sawmill.Debug(
+                                $"[RoundStart] Threat spawn returned for '{selectedThreat.ID}'; remainingThreatLeaders={
+                                    afterThreatCounts.ThreatLeaders}, remainingThreatMembers={
+                                        afterThreatCounts.ThreatMembers
+                                    }.");
+                        }
+
+                    }
+                    catch (Exception threatEx)
+                    {
+                        Log.Error($"SpawnThreatAtRoundStart threw — round will continue without threat spawn. {threatEx}");
+                        int removed = ThreatSystem.RemoveThreatJobAssignments(assignedJobs);
+                        if (removed > 0)
+                        {
+                            Log.Warning($"Removed {removed} "
+                                + $"threat assignment(s) after threat spawning failed so overflow assignment can handle those players.");
+                        }
+                    }
+
+                    break;
                 }
-                catch (Exception threatEx)
-                {
-                    Log.Error($"SpawnThreatAtRoundStart threw — round will continue without threat spawn. {threatEx}");
-                    var removed = ThreatSystem.RemoveThreatJobAssignments(assignedJobs);
-                    if (removed > 0)
-                        Log.Warning($"Removed {removed} threat assignment(s) after threat spawning failed so overflow assignment can handle those players.");
-                }
-            }
-            else if (usesPostRoundstartThreatVote)
-            {
-                _sawmill.Debug("[RoundStart] Threat spawn deferred until post-roundstart threat vote finishes.");
-            }
-            else
-            {
-                Log.Debug("SpawnThreatAtRoundStart debug — no threat selected, skipping threat spawn.");
+                case true: _sawmill.Debug("[RoundStart] Threat spawn deferred until post-roundstart threat vote finishes."); break;
+                default:   Log.Debug("SpawnThreatAtRoundStart debug — no threat selected, skipping threat spawn."); break;
             }
 
             _stationJobs.AssignOverflowJobs(ref assignedJobs, playerNetIds, assignmentProfiles, spawnableStations);
-            if (_sawmill.Level <= Robust.Shared.Log.LogLevel.Debug)
+            if (_sawmill.Level <= LogLevel.Debug)
             {
-                var overflowAssignmentCounts = CountAuAssignments(assignedJobs);
+                AuAssignmentCounts overflowAssignmentCounts = GameTicker.CountAuAssignments(assignedJobs);
+
                 _sawmill.Debug(
-                    $"[RoundStart] Overflow assignment complete: assigned={assignedJobs.Count}, noJob={overflowAssignmentCounts.NoJob}, threatLeaders={overflowAssignmentCounts.ThreatLeaders}, threatMembers={overflowAssignmentCounts.ThreatMembers}, thirdPartyLeaders={overflowAssignmentCounts.ThirdPartyLeaders}, thirdPartyMembers={overflowAssignmentCounts.ThirdPartyMembers}");
+                    $"[RoundStart] Overflow assignment complete: assigned={assignedJobs.Count}, noJob={
+                        overflowAssignmentCounts.NoJob}, threatLeaders={overflowAssignmentCounts.ThreatLeaders
+                        }, threatMembers={overflowAssignmentCounts.ThreatMembers}, thirdPartyLeaders={
+                            overflowAssignmentCounts.ThirdPartyLeaders}, thirdPartyMembers={
+                                overflowAssignmentCounts.ThirdPartyMembers}");
             }
 
             // Calculate extended access for stations.
-            var stationJobCounts = spawnableStations.ToDictionary(e => e, _ => 0);
-            foreach (var (netUser, (job, station)) in assignedJobs)
+            Dictionary<EntityUid, int> stationJobCounts = spawnableStations.ToDictionary(e => e, _ => 0);
+            foreach ((NetUserId netUser, (ProtoId<JobPrototype>? job, EntityUid station)) in assignedJobs)
             {
                 if (job == null)
                 {
-                    if (readySessions.TryGetValue(netUser, out var playerSession))
-                    {
-                        var evNoJobs = new NoJobsAvailableSpawningEvent(playerSession); // Used by gamerules to wipe their antag slot, if they got one
-                        RaiseLocalEvent(evNoJobs);
+                    if (!readySessions.TryGetValue(netUser, out ICommonSession? playerSession))
+                        continue;
 
-                        _chatManager.DispatchServerMessage(playerSession, Loc.GetString("job-not-available-wait-in-lobby"));
-                    }
+                    var evNoJobs = new NoJobsAvailableSpawningEvent(
+                        playerSession); // Used by gamerules to wipe their antag slot, if they got one
+                    RaiseLocalEvent(evNoJobs);
+
+                    _chatManager.DispatchServerMessage(playerSession,
+                        Loc.GetString("job-not-available-wait-in-lobby"));
                 }
                 else
-                {
                     stationJobCounts[station] += 1;
-                }
             }
 
             _stationJobs.CalcExtendedAccess(stationJobCounts);
 
             // Spawn everybody in!
-            foreach (var (player, (job, station)) in assignedJobs)
+            foreach ((NetUserId player, (ProtoId<JobPrototype>? job, EntityUid station)) in assignedJobs)
             {
                 // Threat jobs are intentionally skipped here — ThreatSystem.SpawnThreatAtRoundStart
                 // (called above) already spawns those entities at threat markers and mind-transfers
@@ -449,15 +445,16 @@ namespace Content.Server.GameTicking
                 // pipeline so they have a body even if SpawnThirdParty later no-ops.
                 if (job != null && (job == "AU14JobThreatLeader" || job == "AU14JobThreatMember"))
                     continue;
+
                 if (job == null)
                     continue;
 
-                if (!readySessions.TryGetValue(player, out var playerSession))
+                if (!readySessions.TryGetValue(player, out ICommonSession? playerSession))
                     continue;
 
                 // Allegiance check: resolve the correct character profile for this player's job/platoon
-                var selectedProfile = profiles[player];
-                var resolvedProfile = ResolveProfileForAllegiance(player, selectedProfile, job);
+                HumanoidCharacterProfile selectedProfile = profiles[player];
+                HumanoidCharacterProfile? resolvedProfile = ResolveProfileForAllegiance(player, selectedProfile, job);
 
                 if (resolvedProfile == null)
                 {
@@ -472,70 +469,74 @@ namespace Content.Server.GameTicking
 
             RefreshLateJoinAllowed();
 
-            // Defensive: same rationale as the SpawnThreatAtRoundStart try/catch above. Without
-            // this, an exception inside third-party spawning kills the entire round at start.
-            if (threatVotePrepared)
+            switch (threatVotePrepared)
             {
-                _sawmill.Debug("[RoundStart] Starting prepared post-roundstart threat vote.");
-                try
-                {
-                    this._threatVoteSystem.StartPreparedThreatVote(assignedJobs);
-                    _sawmill.Debug("[RoundStart] Prepared threat vote started; threat and third-party spawn will continue from vote completion.");
-                }
-                catch (Exception threatVoteEx)
-                {
-                    Log.Error($"StartPreparedThreatVote threw - round will continue without a threat vote. {threatVoteEx}");
-                    this._threatVoteSystem.ClearRoundJoinBlocks();
-                    var removed = ThreatSystem.RemoveThreatJobAssignments(assignedJobs);
-                    if (removed > 0)
-                        Log.Warning($"Removed {removed} held threat assignment(s) after threat vote start failed.");
-                }
-            }
-            if (!threatVotePrepared)
-            {
-                selectedThreat = _auRoundSystem.SelectedThreat;
-                if (selectedThreat != null)
-                {
-                    if (_sawmill.Level <= Robust.Shared.Log.LogLevel.Debug)
-                    {
-                        var roundstartThirdParties = 0;
-                        foreach (var party in _auRoundSystem.SelectedThirdParties)
-                        {
-                            if (party.RoundStart)
-                                roundstartThirdParties++;
-                        }
-
-                        _sawmill.Debug(
-                            $"[RoundStart] Starting third-party spawning for threat '{selectedThreat.ID}'; selectedThirdParties={_auRoundSystem.SelectedThirdParties.Count}, roundstartThirdParties={roundstartThirdParties}.");
-                    }
-
+                // Defensive: same rationale as the SpawnThreatAtRoundStart try/catch above. Without
+                // this, an exception inside third-party spawning kills the entire round at start.
+                case true:
+                    _sawmill.Debug("[RoundStart] Starting prepared post-roundstart threat vote.");
                     try
                     {
-                        _ThirdParty.StartThirdPartySpawning(selectedThreat, assignedJobs);
-                        _sawmill.Debug($"[RoundStart] StartThirdPartySpawning returned for threat '{selectedThreat.ID}'.");
+                        _threatVoteSystem.StartPreparedThreatVote(assignedJobs);
+                        _sawmill.Debug("[RoundStart] Prepared threat vote started; threat and third-party spawn will continue from vote completion.");
                     }
-                    catch (Exception thirdPartyEx)
+                    catch (Exception threatVoteEx)
                     {
-                        Log.Error($"StartThirdPartySpawning threw — round will continue without third-party spawn. {thirdPartyEx}");
+                        Log.Error($"StartPreparedThreatVote threw - round will continue without a threat vote. {threatVoteEx}");
+
+                        _threatVoteSystem.ClearRoundJoinBlocks();
+                        int removed = ThreatSystem.RemoveThreatJobAssignments(assignedJobs);
+                        if (removed > 0)
+                            Log.Warning($"Removed {removed} held threat assignment(s) after threat vote start failed.");
                     }
-                }
-                else
+
+                    break;
+                case false:
                 {
-                    Log.Debug("StartThirdPartySpawning debug — no threat selected, skipping third-party spawn.");
+                    selectedThreat = _auRoundSystem.SelectedThreat;
+                    if (selectedThreat != null)
+                    {
+                        if (_sawmill.Level <= LogLevel.Debug)
+                        {
+                            int roundstartThirdParties = _auRoundSystem.SelectedThirdParties.Count(party => party.RoundStart);
+
+                            _sawmill.Debug(
+                                $"[RoundStart] Starting third-party spawning for threat '{selectedThreat.ID
+                                }'; selectedThirdParties={_auRoundSystem.SelectedThirdParties.Count
+                                }, roundstartThirdParties={
+                                    roundstartThirdParties}.");
+                        }
+
+                        try
+                        {
+                            _thirdParty.StartThirdPartySpawning(selectedThreat, assignedJobs);
+                            _sawmill.Debug($"[RoundStart] StartThirdPartySpawning returned for threat '{selectedThreat.ID
+                            }'.");
+                        }
+                        catch (Exception thirdPartyEx)
+                        {
+                            Log.Error($"StartThirdPartySpawning threw — round will continue without third-party spawn. {thirdPartyEx}");
+                        }
+                    }
+                    else
+                        Log.Debug("StartThirdPartySpawning debug — no threat selected, skipping third-party spawn.");
+
+                    break;
                 }
             }
 
             // Allow rules to add roles to players who have been spawned in. (For example, on-station traitors)
             var jobsAssignedList = new List<ICommonSession>(assignedJobs.Count);
-            foreach (var (netUserId, (job, _)) in assignedJobs)
+            foreach ((NetUserId netUserId, (ProtoId<JobPrototype>? job, EntityUid _)) in assignedJobs)
             {
                 if (threatVotePrepared && ThreatSystem.IsThreatJob(job))
                     continue;
 
-                if (readySessions.TryGetValue(netUserId, out var session))
+                if (readySessions.TryGetValue(netUserId, out ICommonSession? session))
                     jobsAssignedList.Add(session);
             }
-            var jobsAssignedPlayers = jobsAssignedList.ToArray();
+
+            ICommonSession[] jobsAssignedPlayers = jobsAssignedList.ToArray();
             RaiseLocalEvent(new RulePlayerJobsAssignedEvent(
                 jobsAssignedPlayers,
                 profiles,
@@ -551,22 +552,22 @@ namespace Content.Server.GameTicking
             if (IsThreatVoteRoundJoinBlocked(player))
                 return;
 
-            var character = GetPlayerProfile(player);
+            HumanoidCharacterProfile character = GetPlayerProfile(player);
 
-            var jobBans = _banManager.GetJobBans(player.UserId);
-            if (jobBans == null || jobId != null && jobBans.Contains(jobId))
+            HashSet<ProtoId<JobPrototype>>? jobBans = _banManager.GetJobBans(player.UserId);
+            if (jobBans == null || (jobId != null && jobBans.Contains(jobId)))
                 return;
 
             if (jobId != null)
             {
-                var ev = new IsJobAllowedEvent(player, new ProtoId<JobPrototype>(jobId));
+                var ev = new IsJobAllowedEvent(player, new(jobId));
                 RaiseLocalEvent(ref ev);
                 if (ev.Cancelled)
                     return;
             }
 
             // Allegiance check: resolve the correct character profile for this job/platoon
-            var resolvedProfile = ResolveProfileForAllegiance(player.UserId, character, jobId);
+            HumanoidCharacterProfile? resolvedProfile = ResolveProfileForAllegiance(player.UserId, character, jobId);
 
             if (resolvedProfile == null)
             {
@@ -581,10 +582,11 @@ namespace Content.Server.GameTicking
 
         private bool IsThreatVoteRoundJoinBlocked(ICommonSession player)
         {
-            if (!this._threatVoteSystem.IsRoundJoinBlocked(player.UserId))
+            if (!_threatVoteSystem.IsRoundJoinBlocked(player.UserId))
                 return false;
 
             _chatManager.DispatchServerMessage(player, Loc.GetString("au14-threat-vote-round-join-blocked"));
+
             return true;
         }
 
@@ -604,12 +606,9 @@ namespace Content.Server.GameTicking
 
             if (station == EntityUid.Invalid)
             {
-                var stations = GetSpawnableStations();
+                List<EntityUid> stations = GetSpawnableStations();
                 _robustRandom.Shuffle(stations);
-                if (stations.Count == 0)
-                    station = EntityUid.Invalid;
-                else
-                    station = stations[0];
+                station = stations.Count == 0 ? EntityUid.Invalid : stations[0];
             }
 
             if (lateJoin && DisallowLateJoin)
@@ -618,22 +617,18 @@ namespace Content.Server.GameTicking
                 return;
             }
 
-            string speciesId;
             if (_randomizeCharacters)
             {
-                var weightId = _cfg.GetCVar(CCVars.ICRandomSpeciesWeights);
+                string speciesId;
+                string weightId = _cfg.GetCVar(CCVars.ICRandomSpeciesWeights);
 
                 // If blank, choose a round start species.
                 if (string.IsNullOrEmpty(weightId))
                 {
-                    var roundStart = new List<ProtoId<SpeciesPrototype>>();
+                    IEnumerable<SpeciesPrototype> speciesPrototypes = _prototypeManager
+                        .EnumeratePrototypes<SpeciesPrototype>();
 
-                    var speciesPrototypes = _prototypeManager.EnumeratePrototypes<SpeciesPrototype>();
-                    foreach (var proto in speciesPrototypes)
-                    {
-                        if (proto.RoundStart)
-                            roundStart.Add(proto.ID);
-                    }
+                    List<ProtoId<SpeciesPrototype>> roundStart = (from proto in speciesPrototypes where proto.RoundStart select proto.ID).Select(dummy => (ProtoId<SpeciesPrototype>)dummy).ToList();
 
                     speciesId = roundStart.Count == 0
                         ? SharedHumanoidAppearanceSystem.DefaultSpecies
@@ -648,7 +643,8 @@ namespace Content.Server.GameTicking
                 character = HumanoidCharacterProfile.RandomWithSpecies(speciesId);
             }
 
-            // We raise this event to allow other systems to handle spawning this player themselves. (e.g. late-join wizard, etc)
+            // We raise this event to allow other systems to handle spawning this player themselves. (e.g. late-join wizard,
+            // etc.)
             var bev = new PlayerBeforeSpawnEvent(player, character, jobId, lateJoin, station);
             RaiseLocalEvent(bev);
 
@@ -664,25 +660,24 @@ namespace Content.Server.GameTicking
             var ev = new GetDisallowedJobsEvent(player, restrictedRoles);
             RaiseLocalEvent(ref ev);
 
-            var jobBans = _banManager.GetJobBans(player.UserId);
+            HashSet<ProtoId<JobPrototype>>? jobBans = _banManager.GetJobBans(player.UserId);
             if (jobBans != null)
                 restrictedRoles.UnionWith(jobBans);
 
             // Pick best job best on prefs.
-            var presetId = CurrentPreset?.ID ?? Preset?.ID;
+            string? presetId = CurrentPreset?.ID ?? Preset?.ID;
             jobId ??= _stationJobs.PickBestAvailableJobWithPriority(station,
                 character.GetJobPrioritiesForGamemode(presetId),
                 true,
                 restrictedRoles);
+
             // If no job available, stay in lobby, or if no lobby spawn as observer
             if (jobId is null)
             {
-                if (!LobbyEnabled)
-                {
-                    JoinAsObserver(player);
-                }
+                if (!LobbyEnabled) JoinAsObserver(player);
 
-                var evNoJobs = new NoJobsAvailableSpawningEvent(player); // Used by gamerules to wipe their antag slot, if they got one
+                var evNoJobs = new NoJobsAvailableSpawningEvent(
+                    player); // Used by gamerules to wipe their antag slot, if they got one
                 RaiseLocalEvent(evNoJobs);
 
                 _chatManager.DispatchServerMessage(player,
@@ -692,20 +687,20 @@ namespace Content.Server.GameTicking
 
             PlayerJoinGame(player, silent);
 
-            var data = player.ContentData();
+            ContentPlayerData? data = player.ContentData();
 
             DebugTools.AssertNotNull(data);
 
-            var newMind = _mind.CreateMind(data!.UserId, character.Name);
+            Entity<MindComponent> newMind = _mind.CreateMind(data.UserId, character.Name);
             _mind.SetUserId(newMind, data.UserId);
 
             var jobPrototype = _prototypeManager.Index<JobPrototype>(jobId);
 
             _playTimeTrackings.PlayerRolesChanged(player);
 
-            var mobMaybe = _stationSpawning.SpawnPlayerCharacterOnStation(station, jobId, character);
+            EntityUid? mobMaybe = _stationSpawning.SpawnPlayerCharacterOnStation(station, jobId, character);
             DebugTools.AssertNotNull(mobMaybe);
-            var mob = mobMaybe!.Value;
+            EntityUid mob = mobMaybe.Value;
 
             // Apply origin effects (components, accents, items)
             _originSystem.ApplyOrigin(mob, character);
@@ -713,9 +708,11 @@ namespace Content.Server.GameTicking
             _mind.TransferTo(newMind, mob);
 
             _roles.MindAddJobRole(newMind, silent: silent, jobPrototype: jobId);
-            var jobName = _jobs.MindTryGetJobName(newMind);
+            string jobName = _jobs.MindTryGetJobName(newMind);
             _admin.UpdatePlayerList(player);
 
+/*
+            // Deadcode
             if (lateJoin && !silent && false) // RMC14
             {
                 if (jobPrototype.JoinNotifyCrew)
@@ -726,7 +723,7 @@ namespace Content.Server.GameTicking
                             ("entity", mob),
                             ("job", CultureInfo.CurrentCulture.TextInfo.ToTitleCase(jobName))),
                         Loc.GetString("latejoin-arrival-sender"),
-                        playDefaultSound: false,
+                        false,
                         colorOverride: Color.Gold);
                 }
                 else
@@ -737,14 +734,13 @@ namespace Content.Server.GameTicking
                             ("entity", mob),
                             ("job", CultureInfo.CurrentCulture.TextInfo.ToTitleCase(jobName))),
                         Loc.GetString("latejoin-arrival-sender"),
-                        playDefaultSound: false);
+                        false);
                 }
             }
+*/
 
-            if (player.UserId == new Guid("{e887eb93-f503-4b65-95b6-2f282c014192}"))
-            {
-                AddComp<OwOAccentComponent>(mob);
-            }
+            // wtf?
+            // if (player.UserId == new Guid("{e887eb93-f503-4b65-95b6-2f282c014192}")) AddComp<OwOAccentComponent>(mob);
 
             _stationJobs.TryAssignJob(station, jobPrototype, player.UserId);
 
@@ -752,21 +748,21 @@ namespace Content.Server.GameTicking
             {
                 _adminLogger.Add(LogType.LateJoin,
                     LogImpact.Medium,
-                    $"Player {player.Name} late joined as {character.Name:characterName} on station {Name(station):stationName} with {ToPrettyString(mob):entity} as a {jobName:jobName}.");
+                    $"Player {player.Name} late joined as {character.Name:characterName} on station {Name(station)
+                        :stationName} with {ToPrettyString(mob):entity} as a {jobName:jobName}.");
             }
             else
             {
                 _adminLogger.Add(LogType.RoundStartJoin,
                     LogImpact.Medium,
-                    $"Player {player.Name} joined as {character.Name:characterName} on station {Name(station):stationName} with {ToPrettyString(mob):entity} as a {jobName:jobName}.");
+                    $"Player {player.Name} joined as {character.Name:characterName} on station {Name(station)
+                        :stationName} with {ToPrettyString(mob):entity} as a {jobName:jobName}.");
             }
 
             // Make sure they're aware of extended access.
             if (Comp<StationJobsComponent>(station).ExtendedAccess
                 && (jobPrototype.ExtendedAccess.Count > 0 || jobPrototype.ExtendedAccessGroups.Count > 0))
-            {
                 _chatManager.DispatchServerMessage(player, Loc.GetString("job-greet-crew-shortages"));
-            }
 
             if (!silent && TryComp(station, out MetaDataComponent? metaData))
             {
@@ -774,10 +770,10 @@ namespace Content.Server.GameTicking
                     Loc.GetString("job-greet-station-name", ("stationName", metaData.EntityName)));
             }
 
-            if (_distressSignal?.SelectedPlanetMapName != null)
+            if (_distressSignal.SelectedPlanetMapName != null)
             {
                 _chatManager.DispatchServerMessage(player,
-                    Loc.GetString("job-greet-planet-name", ("planetName",_distressSignal.SelectedPlanetMapName)));
+                    Loc.GetString("job-greet-planet-name", ("planetName", _distressSignal.SelectedPlanetMapName)));
             }
 
             // We raise this event directed to the mob, but also broadcast it so game rules can do something now.
@@ -807,12 +803,12 @@ namespace Content.Server.GameTicking
         }
 
         /// <summary>
-        /// Makes a player join into the game and spawn on a station.
+        ///     Makes a player join into the game and spawn on a station.
         /// </summary>
-        /// <param name="player">The player joining</param>
-        /// <param name="station">The station they're spawning on</param>
-        /// <param name="jobId">An optional job for them to spawn as</param>
-        /// <param name="silent">Whether or not the player should be greeted upon joining</param>
+        /// <param name="player" >The player joining</param>
+        /// <param name="station" >The station they're spawning on</param>
+        /// <param name="jobId" >An optional job for them to spawn as</param>
+        /// <param name="silent" >Whether the player should be greeted upon joining</param>
         public void MakeJoinGame(ICommonSession player, EntityUid station, string? jobId = null, bool silent = false)
         {
             if (!_playerGameStatuses.ContainsKey(player.UserId))
@@ -825,7 +821,7 @@ namespace Content.Server.GameTicking
         }
 
         /// <summary>
-        /// Causes the given player to join the current game as observer ghost. See also <see cref="SpawnObserver"/>
+        ///     Causes the given player to join the current game as observer ghost. See also <see cref="SpawnObserver" />
         /// </summary>
         public void JoinAsObserver(ICommonSession player)
         {
@@ -838,8 +834,8 @@ namespace Content.Server.GameTicking
         }
 
         /// <summary>
-        /// Spawns an observer ghost and attaches the given player to it. If the player does not yet have a mind, the
-        /// player is given a new mind with the observer role. Otherwise, the current mind is transferred to the ghost.
+        ///     Spawns an observer ghost and attaches the given player to it. If the player does not yet have a mind, the
+        ///     player is given a new mind with the observer role. Otherwise, the current mind is transferred to the ghost.
         /// </summary>
         public void SpawnObserver(ICommonSession player)
         {
@@ -850,14 +846,14 @@ namespace Content.Server.GameTicking
             Entity<MindComponent?>? mind = player.GetMind();
             if (mind == null)
             {
-                var name = GetPlayerProfile(player).Name;
-                var (mindId, mindComp) = _mind.CreateMind(player.UserId, name);
+                string name = GetPlayerProfile(player).Name;
+                (EntityUid mindId, MindComponent mindComp) = _mind.CreateMind(player.UserId, name);
                 mind = (mindId, mindComp);
                 _mind.SetUserId(mind.Value, player.UserId);
                 makeObserver = true;
             }
 
-            var ghost = _ghost.SpawnGhost(mind.Value);
+            EntityUid? ghost = _ghost.SpawnGhost(mind.Value);
             if (makeObserver)
                 _roles.MindAddRole(mind.Value, "MindRoleObserver");
 
@@ -866,80 +862,73 @@ namespace Content.Server.GameTicking
                 $"{player.Name} late joined the round as an Observer with {ToPrettyString(ghost):entity}.");
         }
 
-        #region Spawn Points
-
+#region Spawn Points
         public EntityCoordinates GetObserverSpawnPoint()
         {
             _possiblePositions.Clear();
-            var spawnPointQuery = EntityQueryEnumerator<SpawnPointComponent, TransformComponent>();
-            while (spawnPointQuery.MoveNext(out var uid, out var point, out var transform))
+            EntityQueryEnumerator<SpawnPointComponent, TransformComponent> spawnPointQuery
+                = EntityQueryEnumerator<SpawnPointComponent, TransformComponent>();
+            while (spawnPointQuery.MoveNext(out EntityUid uid, out SpawnPointComponent? point,
+                out TransformComponent? transform))
             {
                 if (point.SpawnType != SpawnPointType.Observer
-                   || TerminatingOrDeleted(uid)
-                   || transform.MapUid == null
-                   || TerminatingOrDeleted(transform.MapUid.Value))
-                {
+                    || TerminatingOrDeleted(uid)
+                    || transform.MapUid == null
+                    || TerminatingOrDeleted(transform.MapUid.Value))
                     continue;
-                }
 
                 _possiblePositions.Add(transform.Coordinates);
             }
 
-            var metaQuery = GetEntityQuery<MetaDataComponent>();
+            EntityQuery<MetaDataComponent> metaQuery = GetEntityQuery<MetaDataComponent>();
 
             // Fallback to a random grid.
             if (_possiblePositions.Count == 0)
             {
-                var query = AllEntityQuery<MapGridComponent>();
-                while (query.MoveNext(out var uid, out var grid))
+                AllEntityQueryEnumerator<MapGridComponent> query = AllEntityQuery<MapGridComponent>();
+                while (query.MoveNext(out EntityUid uid, out MapGridComponent? _))
                 {
-                    if (!metaQuery.TryGetComponent(uid, out var meta) || meta.EntityPaused || TerminatingOrDeleted(uid))
-                    {
-                        continue;
-                    }
+                    if (!metaQuery.TryGetComponent(uid, out MetaDataComponent? meta) || meta.EntityPaused
+                        || TerminatingOrDeleted(uid)) continue;
 
-                    _possiblePositions.Add(new EntityCoordinates(uid, Vector2.Zero));
+                    _possiblePositions.Add(new(uid, Vector2.Zero));
                 }
             }
 
             if (_possiblePositions.Count != 0)
             {
                 // TODO: This is just here for the eye lerping.
-                // Ideally engine would just spawn them on grid directly I guess? Right now grid traversal is handling it during
+                // Ideally engine would just spawn them on grid directly I guess? Right now grid traversal is handling it
+                // during
                 // update which means we need to add a hack somewhere around it.
-                var spawn = _robustRandom.Pick(_possiblePositions);
+                EntityCoordinates spawn = _robustRandom.Pick(_possiblePositions);
                 var toMap = _transform.ToMapCoordinates(spawn);
 
-                if (_mapManager.TryFindGridAt(toMap, out var gridUid, out _))
-                {
-                    var gridXform = Transform(gridUid);
+                if (!_mapManager.TryFindGridAt(toMap, out EntityUid gridUid, out _))
+                    return spawn;
 
-                    return new EntityCoordinates(gridUid, Vector2.Transform(toMap.Position, _transform.GetInvWorldMatrix(gridXform)));
-                }
-
-                return spawn;
+                TransformComponent gridXform = Transform(gridUid);
+                return new(gridUid, Vector2.Transform(toMap.Position, _transform.GetInvWorldMatrix(gridXform)));
             }
 
             if (_map.MapExists(DefaultMap))
             {
-                var mapUid = _map.GetMapOrInvalid(DefaultMap);
+                EntityUid mapUid = _map.GetMapOrInvalid(DefaultMap);
                 if (!TerminatingOrDeleted(mapUid))
-                    return new EntityCoordinates(mapUid, Vector2.Zero);
+                    return new(mapUid, Vector2.Zero);
             }
 
             // Just pick a point at this point I guess.
-            foreach (var map in _map.GetAllMapIds())
+            foreach (MapId map in _map.GetAllMapIds())
             {
-                var mapUid = _map.GetMapOrInvalid(map);
+                EntityUid mapUid = _map.GetMapOrInvalid(map);
 
-                if (!metaQuery.TryGetComponent(mapUid, out var meta)
+                if (!metaQuery.TryGetComponent(mapUid, out MetaDataComponent? meta)
                     || meta.EntityPaused
                     || TerminatingOrDeleted(mapUid))
-                {
                     continue;
-                }
 
-                return new EntityCoordinates(mapUid, Vector2.Zero);
+                return new(mapUid, Vector2.Zero);
             }
 
             // AAAAAAAAAAAAA
@@ -947,7 +936,14 @@ namespace Content.Server.GameTicking
             _sawmill.Warning("Found no observer spawn points!");
             return EntityCoordinates.Invalid;
         }
+#endregion
 
-        #endregion
+        private readonly record struct AuAssignmentCounts(
+            int NoJob,
+            int ThreatLeaders,
+            int ThreatMembers,
+            int ThirdPartyLeaders,
+            int ThirdPartyMembers
+        );
     }
 }

--- a/Content.Server/_CMU14/Threats/ThreatVoteSystem.cs
+++ b/Content.Server/_CMU14/Threats/ThreatVoteSystem.cs
@@ -410,6 +410,31 @@ public sealed partial class ThreatVoteSystem : EntitySystem
 
         try
         {
+            // Return held players who failed the threat roll back to the lobby
+            var unusedPlayers = new List<NetUserId>();
+            foreach (NetUserId playerId in prepared.HeldPlayers)
+            {
+                if (assignedJobs.TryGetValue(playerId, out (ProtoId<JobPrototype>?, EntityUid) job)
+                    && ThreatSystem.IsThreatJob(job.Item1))
+                    unusedPlayers.Add(playerId);
+            }
+
+            _sawmill?.Debug($"[RoundStart] Returning {unusedPlayers.Count} unselected threat player(s) to lobby.");
+            if (unusedPlayers.Count > 0)
+            {
+                foreach (NetUserId uid in unusedPlayers)
+                    assignedJobs.Remove(uid);
+
+                ReleaseHeldPlayersToLobby(unusedPlayers, selected.ID, "not selected as threat");
+            }
+        }
+        catch (Exception ex)
+        {
+            Sawmill.Error($"[ThreatVoteSystem] Could not return unselected threat-roll players back to lobby. {ex}");
+        }
+
+        try
+        {
             Sawmill.Debug($"[ThreatVoteSystem] Starting third-party spawning after threat vote; selectedThirdParties={
                 _auRound.SelectedThirdParties.Count}.");
             _thirdParty.StartThirdPartySpawning(selected, assignedJobs);

--- a/Content.Server/_CMU14/Threats/ThreatVoteSystem.cs
+++ b/Content.Server/_CMU14/Threats/ThreatVoteSystem.cs
@@ -50,11 +50,10 @@ public sealed partial class ThreatVoteSystem : EntitySystem
 
     private void OnRunLevelChanged(GameRunLevelChangedEvent ev)
     {
-        if (ev.New != GameRunLevel.InRound)
-        {
-            _prepared = null;
-            ClearRoundJoinBlocks();
-        }
+        if (ev.New == GameRunLevel.InRound) return;
+
+        _prepared = null;
+        ClearRoundJoinBlocks();
     }
 
     public bool IsRoundJoinBlocked(NetUserId playerId) => _roundJoinBlockedPlayers.Contains(playerId);
@@ -98,10 +97,9 @@ public sealed partial class ThreatVoteSystem : EntitySystem
         int playerCount = Math.Max(_player.PlayerCount, profiles.Count);
         Sawmill.Debug($"[ThreatVoteSystem] Preparing threat vote: preset={presetId}, planet={planet.MapId}, profiles={
             profiles.Count}, playerCount={playerCount}, selectedThreat={_auRound.SelectedThreat?.ID ?? "null"}.");
-        var candidates = new List<ThreatVoteCandidate>();
-        ThreatVoteBodyCount heldBodyCount;
-        if (!TryBuildCandidatesFromScenarioPlan(planet, presetId, playerCount, out candidates, out heldBodyCount,
-            out string diagnostic))
+
+        if (!TryBuildCandidatesFromScenarioPlan(planet, presetId, playerCount, out List<ThreatVoteCandidate> candidates,
+            out ThreatVoteBodyCount heldBodyCount, out string diagnostic))
         {
             if (HasCoveredScenarioThreatCandidate(planet, presetId))
             {
@@ -270,7 +268,7 @@ public sealed partial class ThreatVoteSystem : EntitySystem
         out ThreatVoteBodyCount heldBodyCount,
         out string diagnostic)
     {
-        candidates = new();
+        candidates = [];
         heldBodyCount = default(ThreatVoteBodyCount);
 
         var request = new ScenarioPlanValidationRequest(presetId,
@@ -320,15 +318,7 @@ public sealed partial class ThreatVoteSystem : EntitySystem
     }
 
     private bool HasCoveredScenarioThreatCandidate(RMCPlanetMapPrototypeComponent planet, string presetId)
-    {
-        foreach (ProtoId<ThreatPrototype> threatId in planet.AllowedThreats)
-        {
-            if (_scenarioPlan.HasMappedHostileRoundGroup(presetId, threatId.Id))
-                return true;
-        }
-
-        return false;
-    }
+        => planet.AllowedThreats.Any(threatId => _scenarioPlan.HasMappedHostileRoundGroup(presetId, threatId.Id));
 
     private List<ThreatVoteCandidate> BuildLegacyCandidates(RMCPlanetMapPrototypeComponent planet,
         string presetId,

--- a/Content.Shared/Movement/Systems/SpeedModifierContactsSystem.cs
+++ b/Content.Shared/Movement/Systems/SpeedModifierContactsSystem.cs
@@ -1,5 +1,6 @@
-using Content.Shared.Movement.Components;
+using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Water;
+using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Gravity;
 using Content.Shared.Slippery;
@@ -97,6 +98,10 @@ public sealed partial class SpeedModifierContactsSystem : EntitySystem
 
             if (TryComp<SpeedModifierContactsComponent>(ent, out var slowContactsComponent))
             {
+                if (HasComp<RMCFireSlowImmunityComponent>(uid) &&
+                        (HasComp<TileFireComponent>(ent) || HasComp<RMCIgniteOnCollideComponent>(ent)))
+                    continue;
+
                 if (_whitelistSystem.IsWhitelistPass(slowContactsComponent.IgnoreWhitelist, uid))
                     continue;
 

--- a/Content.Shared/_CMU14/Threats/ThreatPrototype.cs
+++ b/Content.Shared/_CMU14/Threats/ThreatPrototype.cs
@@ -86,13 +86,13 @@ public sealed partial class ThreatPrototype : IPrototype
     ///     Minimum seconds after round start before threat entities spawn and win conditions activate.
     /// </summary>
     [DataField("spawnDelayMin")]
-    public int SpawnDelayMin { get; private set; } = 1200;
+    public int SpawnDelayMin { get; private set; } = 900;
 
     /// <summary>
     ///     Maximum seconds after round start before threat entities spawn and win conditions activate.
     /// </summary>
     [DataField("spawnDelayMax")]
-    public int SpawnDelayMax { get; private set; } = 2400;
+    public int SpawnDelayMax { get; private set; } = 1800;
 
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/_RMC14/Atmos/RMCFireSlowImmunityComponent.cs
+++ b/Content.Shared/_RMC14/Atmos/RMCFireSlowImmunityComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Atmos;
+
+/// <summary>
+/// When present on an entity, all contact based speed modifiers from fire are completely ignored.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class RMCFireSlowImmunityComponent : Component { }

--- a/Resources/Locale/en-US/_AU14/threat-vote.ftl
+++ b/Resources/Locale/en-US/_AU14/threat-vote.ftl
@@ -12,3 +12,4 @@ au14-threat-vote-option-wendigo = Wendigo Threat
 au14-threat-vote-option-generic = {$threat}
 au14-threat-vote-round-join-blocked = You were selected for the threat roll. You cannot join as another role while your threat assignment is pending.
 au14-threat-vote-colony-fall-observer-warning = The threat will spawn in roughly {$min} to {$max} minutes. You may look around as an observer, but do not reconnect or join a ghost role, or you will lose your threat roll.
+au14-threat-not-selected-return-to-lobby = "You were not chosen as this round's threat. You have been returned to the lobby and are free to Join-In-Progress (JIP)."

--- a/Resources/Prototypes/_CMU14/Entities/Mobs/NPCs/SpaceApe.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Mobs/NPCs/SpaceApe.yml
@@ -19,6 +19,7 @@
         - MobMask
         layer:
         - MobLayer
+  - type: GhostTakeoverAvailable
   - type: GhostRole
     name: Ape
     description: OO OO AH AH

--- a/Resources/Prototypes/_CMU14/Roles/Threats/Base/jobs.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Threats/Base/jobs.yml
@@ -9,7 +9,6 @@
   accessGroups:
   - CMAccessXeno
   hasIcon: false
-  hidden: true
 
 - type: job
   parent: AUThreatJobBase
@@ -18,11 +17,10 @@
   description: au-job-description-threat-leader
   setPreference: true
   playTimeTracker: AUJobThreatLeader
-  requirements:
-  - !type:RoleTimeRequirement
-     role: AUJobThreatMember
-     time: 10800 # 3 hours
-  hidden: false
+  # requirements:
+  # - !type:RoleTimeRequirement
+  #    role: AUJobThreatMember
+  #    time: 10800 # 3 hours
   supervisors: nobody
   icon: "AU14JobIconThreatLeader"
   jobPreviewEntity: RMCPlayerXenoQueenPreview
@@ -40,7 +38,6 @@
   description: au-job-description-threat-member
   setPreference: true
   playTimeTracker: AUJobThreatMember
-  hidden: false
   supervisors: nobody
   icon: "AU14JobIconThreatMember"
   jobPreviewEntity: RMCPlayerXenoQueenPreview

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -826,6 +826,7 @@
       bypassWhitelist:
         components:
         - RMCFireImmunityBypass
+    - type: RMCFireSlowImmunity
     auraColor: "#03FCC6"
 
 # m45


### PR DESCRIPTION
- **📋 need to accumulate more playtime for ThreatMember before we lock ThreatLeader (or just migrate playtimes)**
- **📋 adjusted the Reaper test (XenoRepearRedGas) to new Warlock/Reaper PR 1468**
- **🔧 GameTicker.Spawning.cs code cleanup**
- **🔧 ThreatVoteSystem.cs code cleanup**
- **📋 send Threat Roll failed players back to lobby so they can play the round instead of ghost**

## About the PR
- The perfect method was already there, just had to implement it on threat roll fails.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: If you fail the threat roll you are sent back to the lobby so you can Join-In-Progress (JIP)
- tweak: Lowered the Threat Spawn time to 15-30 minutes (from 20-40)
- tweak: Threat Leader playtime requirement is gone (again (again)) - go get 3 hours of Threat Member it will be back
- fix: Ape ghost role not working for the third-party spawns
- add: Firewalk grants slowdown immunity when walking on fire tiles
