### PR TITLE
Abomination fixes

### DIFF
--- a/Content.Server/_CMU14/Threats/Mobs/Abomination/AbominationFleshKudzuSystem.cs
+++ b/Content.Server/_CMU14/Threats/Mobs/Abomination/AbominationFleshKudzuSystem.cs
@@ -1,6 +1,5 @@
 using Content.Server.Chat.Systems;
 using Content.Shared.Damage;
-using Content.Shared.Interaction.Events;
 using Content.Shared.Mobs.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -31,11 +30,6 @@ public sealed partial class AbominationFleshKudzuSystem : EntitySystem
     [Dependency] private SharedPhysicsSystem _physics = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IGameTiming _timing = default!;
-
-    public override void Initialize()
-    {
-        SubscribeLocalEvent<AbominationComponent, AttackAttemptEvent>(OnAbominationAttackAttempt);
-    }
 
     public override void Update(float frameTime)
     {
@@ -97,16 +91,6 @@ public sealed partial class AbominationFleshKudzuSystem : EntitySystem
                 }
             }
         }
-    }
-
-    /// <summary>
-    ///     Block abominations from melee-attacking flesh kudzu — they kept
-    ///     destroying their own coverage in playtest.
-    /// </summary>
-    private void OnAbominationAttackAttempt(Entity<AbominationComponent> ent, ref AttackAttemptEvent args)
-    {
-        if (args.Target is { } target && HasComp<AbominationFleshKudzuComponent>(target))
-            args.Cancel();
     }
 
     private void HealContacts(Entity<AbominationFleshKudzuComponent, PhysicsComponent> ent)

--- a/Content.Server/_CMU14/Threats/Mobs/Abomination/AbominationMimicSystem.cs
+++ b/Content.Server/_CMU14/Threats/Mobs/Abomination/AbominationMimicSystem.cs
@@ -79,7 +79,7 @@ public sealed partial class AbominationMimicSystem : EntitySystem
     public static readonly EntProtoId RevertAction = "ActionAbominationMimicRevert";
     public static readonly ProtoId<EmotePrototype> ScreamEmote = "Scream";
     public static readonly ProtoId<LanguagePrototype> AbominationLanguage = "Primitive";
-    public const string AbominationRadioChannel = "FactionAbomination";
+    public const string AbominationRadioChannel = "Abomination";
 
     public override void Initialize()
     {

--- a/Content.Server/_CMU14/Threats/Mobs/Abomination/AbominationMimicSystem.cs
+++ b/Content.Server/_CMU14/Threats/Mobs/Abomination/AbominationMimicSystem.cs
@@ -1,9 +1,11 @@
 using System.Linq;
+using Content.Server._RMC14.Language.Systems;
 using Content.Server.Chat.Systems;
 using Content.Server.Polymorph.Components;
 using Content.Server.Polymorph.Systems;
 using Content.Server.Radio.Components;
 using Content.Shared._CMU14.Threats.Mobs.Abomination;
+using Content.Shared._RMC14.Language.Prototypes;
 using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Weapons.Ranged.IFF;
 using Content.Shared._RMC14.Xenonids.Parasite;
@@ -21,6 +23,7 @@ using Content.Shared.NPC.Systems;
 using Content.Shared.Polymorph;
 using Content.Shared.Popups;
 using Content.Shared.Stunnable;
+using Robust.Shared.GameObjects.Components.Localization;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using AbominationAppearanceSnapshot = Content.Shared._CMU14.Threats.Mobs.Abomination.AbominationAppearanceSnapshot;
@@ -70,10 +73,13 @@ public sealed partial class AbominationMimicSystem : EntitySystem
     [Dependency] private SharedStunSystem _stun = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private SharedUserInterfaceSystem _ui = default!;
+    [Dependency] private GrammarSystem _grammarSystem = default!;
+    [Dependency] private LanguageSystem _language = default!;
     public static readonly ProtoId<PolymorphPrototype> DisguisePolymorph = "AbominationMimicDisguise";
     public static readonly EntProtoId RevertAction = "ActionAbominationMimicRevert";
     public static readonly ProtoId<EmotePrototype> ScreamEmote = "Scream";
-    public const string AbominationRadioChannel = "Abomination";
+    public static readonly ProtoId<LanguagePrototype> AbominationLanguage = "Primitive";
+    public const string AbominationRadioChannel = "FactionAbomination";
 
     public override void Initialize()
     {
@@ -265,6 +271,9 @@ public sealed partial class AbominationMimicSystem : EntitySystem
         var activeRadio = EnsureComp<ActiveRadioComponent>(disguisedUid);
         transmitter.Channels.Add(AbominationRadioChannel);
         activeRadio.Channels.Add(AbominationRadioChannel);
+
+        // Abominations all speak primitive
+        _language.AddLanguage(disguisedUid, AbominationLanguage, true, true);
 
         // Every transform resets damage on the new body — mimics spawn
         // fresh into the disguise no matter how chewed-up they were.
@@ -461,6 +470,10 @@ public sealed partial class AbominationMimicSystem : EntitySystem
         humanoid.Gender = snapshot.Gender;
         humanoid.MarkingSet = new(snapshot.MarkingSet);
         humanoid.CustomBaseLayers = new(snapshot.CustomBaseLayers);
+
+        if (TryComp(disguised, out GrammarComponent? grammar))
+            _grammarSystem.SetGender((disguised, grammar), snapshot.Gender);
+
         Dirty(disguised, humanoid);
     }
 }

--- a/Content.Shared/_AU14/Weapons/MeleeIFFComponent.cs
+++ b/Content.Shared/_AU14/Weapons/MeleeIFFComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.Prototypes;
+using Content.Shared._RMC14.Weapons.Ranged.IFF;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._AU14.Weapons;
+
+/// <summary>
+///     Component put on entities to block them from hitting matching IFFs
+/// </summary>
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class MeleeIFFComponent : Component
+{
+    /// <summary>
+    ///     Factions that are ignored by this entity's melee attacks
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public HashSet<EntProtoId<IFFFactionComponent>> Factions;
+}

--- a/Content.Shared/_AU14/Weapons/MeleeIFFSystem.cs
+++ b/Content.Shared/_AU14/Weapons/MeleeIFFSystem.cs
@@ -1,0 +1,28 @@
+using Content.Shared._RMC14.Weapons.Ranged.IFF;
+using Content.Shared.Interaction.Events;
+
+namespace Content.Shared._AU14.Weapons;
+
+/// <summary>
+///     System that prevents IFF weapons from attacking IFF protected entities
+/// </summary>
+public sealed partial class MeleeIFFSystem : EntitySystem
+{
+    [Dependency] private GunIFFSystem _gunIFF = default!;
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<MeleeIFFComponent, AttackAttemptEvent>(OnAttackAttempt);
+    }
+
+    /// <summary>
+    ///     Cancel attacks on IFF protected objects
+    /// </summary>
+    private void OnAttackAttempt(Entity<MeleeIFFComponent> ent, ref AttackAttemptEvent args)
+    {
+        if (args.Target is not { } target)
+            return;
+        // Ideally IFF should be generalized out of GunIFFSystem
+        if (_gunIFF.TryGetUserFaction(target, out var faction) && ent.Comp.Factions.Contains(faction))
+            args.Cancel();
+    }
+}

--- a/Content.Shared/_CMU14/Threats/Mobs/Abomination/Abilities/AbominationAcidSpraySystem.cs
+++ b/Content.Shared/_CMU14/Threats/Mobs/Abomination/Abilities/AbominationAcidSpraySystem.cs
@@ -1,8 +1,10 @@
 using System.Numerics;
+using Content.Shared._RMC14.Weapons.Ranged.IFF;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Spawners;
 
@@ -19,6 +21,8 @@ public sealed partial class AbominationAcidSpraySystem : EntitySystem
     [Dependency] private INetManager _net = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private GunIFFSystem _gunIFF = default!;
+    private static readonly EntProtoId<IFFFactionComponent> AbominationFaction = "FactionAbomination";
 
     public override void Initialize()
     {
@@ -56,6 +60,7 @@ public sealed partial class AbominationAcidSpraySystem : EntitySystem
             Vector2 velocity = dir * ent.Comp.Speed;
 
             EntityUid projectile = Spawn(ent.Comp.Projectile, origin);
+            _gunIFF.GiveAmmoIFF(projectile, AbominationFaction, true);
             _gun.ShootProjectile(projectile, velocity, Vector2.Zero, ent.Owner, ent.Owner, ent.Comp.Speed);
 
             var despawn = EnsureComp<TimedDespawnComponent>(projectile);

--- a/Content.Shared/_CMU14/Threats/Mobs/Abomination/Abilities/AbominationSpitSystem.cs
+++ b/Content.Shared/_CMU14/Threats/Mobs/Abomination/Abilities/AbominationSpitSystem.cs
@@ -1,8 +1,10 @@
 using System.Numerics;
+using Content.Shared._RMC14.Weapons.Ranged.IFF;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Spawners;
 
 namespace Content.Shared._CMU14.Threats.Mobs.Abomination.Abilities;
@@ -13,6 +15,8 @@ public sealed partial class AbominationSpitSystem : EntitySystem
     [Dependency] private SharedGunSystem _gun = default!;
     [Dependency] private INetManager _net = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private GunIFFSystem _gunIFF = default!;
+    private static readonly EntProtoId<IFFFactionComponent> AbominationFaction = "FactionAbomination";
 
     public override void Initialize()
     {
@@ -45,6 +49,7 @@ public sealed partial class AbominationSpitSystem : EntitySystem
         // ShootProjectile sets up the ProjectileComponent.Shooter, body type and
         // initial velocity correctly. Doing this manually is what made the
         // previous version's networking go sideways.
+        _gunIFF.GiveAmmoIFF(projectile, AbominationFaction, true);
         _gun.ShootProjectile(projectile, velocity, Vector2.Zero, ent.Owner, ent.Owner, ent.Comp.Speed);
 
         // Hard despawn so missed projectiles don't litter the map.

--- a/Resources/Prototypes/_CMU14/Threats/Abominations/Structures/flesh_nest.yml
+++ b/Resources/Prototypes/_CMU14/Threats/Abominations/Structures/flesh_nest.yml
@@ -47,9 +47,6 @@
   # caste at it. Base cadence is 360s with one nest; each extra placed
   # nest speeds the global rate by 5%.
   - type: AbominationFleshNest
-  - type: UserIFF
-    factions:
-    - FactionAbomination
   - type: NpcFactionMember
     factions:
     - Abomination

--- a/Resources/Prototypes/_CMU14/Threats/Abominations/base.yml
+++ b/Resources/Prototypes/_CMU14/Threats/Abominations/base.yml
@@ -113,6 +113,9 @@
   - type: UserIFF
     factions:
     - FactionAbomination
+  - type: MeleeIFF
+    factions:
+    - FactionAbomination
   - type: GhostTakeoverAvailable
   - type: GhostRole
     name: Abomination


### PR DESCRIPTION
## About the PR
-Transformed abom mimics can speak and understand abom (primitive language)
-Transformed aboms now get the body's correct gender
-Aboms can no longer friendly fire each other, can't destroy their own weeds, but can still break nests (cause they get stuck often). This applies to both their melee and acid attacks. This purposefully doesn't apply to transformed aboms, who can still attack aboms and be attacked by aboms as to act innocent. 

## Technical details
Added a new melee IFF system because RMC's is deeply hardcoded. Everything has been tested in game. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: shibechef
- fix: Abominations can no longer friendly fire each other, but can still attack transformed mimics. 
- fix: Transformed abomination mimics inherit the correct gender of corpses
- fix: Transformed abomination mimics can speak and understand abomination