### PR TITLE
Additional Warlock fixes

### DIFF
--- a/Resources/Prototypes/_CMU14/Effects/warlock.yml
+++ b/Resources/Prototypes/_CMU14/Effects/warlock.yml
@@ -213,7 +213,7 @@
       radius: 1.25
       damage:
         types:
-          Blunt: 55
+          Blunt: 65
       slow: 1.5
       impactSound:
         path: /Audio/_CMU14/Xeno/Warlock/EMPulse.ogg

--- a/Resources/Prototypes/_CMU14/Entities/Mobs/Xeno/warlock.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Mobs/Xeno/warlock.yml
@@ -23,7 +23,7 @@
     thresholds:
       0: Alive
       550: Critical
-      625: Dead
+      650: Dead
   - type: Xeno
     role: CMXenoWarlock
     actionIds:

--- a/Resources/Prototypes/_CMU14/Entities/Mobs/Xeno/warlock.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Mobs/Xeno/warlock.yml
@@ -22,8 +22,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      325: Critical
-      425: Dead
+      550: Critical
+      625: Dead
   - type: Xeno
     role: CMXenoWarlock
     actionIds:
@@ -55,7 +55,7 @@
   - type: XenoPsychicCommunication
     whisperRange: 7
   - type: CMArmor
-    xenoArmor: 10
+    xenoArmor: 25
     explosionArmor: 30
   - type: XenoClaws
     clawType: Sharp


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Warlock's health and armor have been increased to make it more survivable, and psychic blast does more damage.
I would've modified this in my first PR, but I needed to see how it fared first. After some testing in-game, I'm confident this change is necessary. This will hopefully be the last change needed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Warlock had no survivability whatsoever to get most of its attacks off. It had a staggering 325 hp initially. For reference, a drone has 500. As a combat oriented T3, it had less health than a _support T1_. Similarly, a ranged caste like spitter, has 550. Its shield collapses too quickly for it to really help to get its attacks off, so it needed tweaks here.
As for its psychic blast, it just wasn't doing as much as it needed to for a wind-up attack.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Warlock's health and armor has been increased to help with its survivability. 
