### PR TITLE
Make the M240-T Unmeltable

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34t_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34t_flamer.yml
@@ -5,7 +5,7 @@
   description: An improved version of the M240 incinerator unit, the M240-T model is capable of dispersing a larger variety of fuel types. #cmu14
   components:
   - type: Corrodible
-    isCorrodible: true
+    isCorrodible: false
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Guns/Flamethrower/m34t.rsi
   - type: Item


### PR DESCRIPTION

## About the PR
Changed back the IsCorrodible: true back to IsCorrodible: false.

## Why / Balance
Reason being is that since the M240-T was removed from req and readded back as a spec choice, it only makes sense that it goes back to be unmeltable since it's one of a kind again. 

# Technical details
IsCorrodible: true to IsCorrodible: false.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: The M240-T Flame-thrower is now un-meltable again. 