### PR TITLE
Upgrade RobustToolbox v278 

### DIFF
--- a/Content.Client/Audio/AmbientSoundOverlay.cs
+++ b/Content.Client/Audio/AmbientSoundOverlay.cs
@@ -12,6 +12,7 @@ public sealed class AmbientSoundOverlay : Overlay
     private readonly IEntityManager _entManager;
     private readonly AmbientSoundSystem _ambient;
     private readonly EntityLookupSystem _lookup;
+    private readonly HashSet<EntityUid> _intersecting = new();
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
 
@@ -32,25 +33,31 @@ public sealed class AmbientSoundOverlay : Overlay
         const float Size = 0.25f;
         const float Alpha = 0.25f;
 
-        foreach (var ent in _lookup.GetEntitiesIntersecting(args.MapId, args.WorldBounds))
+        _intersecting.Clear();
+        _lookup.GetEntitiesIntersecting(args.MapId, args.WorldAABB, _intersecting);
+        foreach (var ent in _intersecting)
         {
             if (!ambientQuery.TryGetComponent(ent, out var ambientSound) ||
                 !xformQuery.TryGetComponent(ent, out var xform)) continue;
+
+            var worldPosition = xformSystem.GetWorldPosition(xform);
+            if (!args.WorldBounds.Contains(worldPosition))
+                continue;
 
             if (ambientSound.Enabled)
             {
                 if (_ambient.IsActive((ent, ambientSound)))
                 {
-                    worldHandle.DrawCircle(xformSystem.GetWorldPosition(xform), Size, Color.LightGreen.WithAlpha(Alpha * 2f));
+                    worldHandle.DrawCircle(worldPosition, Size, Color.LightGreen.WithAlpha(Alpha * 2f));
                 }
                 else
                 {
-                    worldHandle.DrawCircle(xformSystem.GetWorldPosition(xform), Size, Color.Orange.WithAlpha(Alpha));
+                    worldHandle.DrawCircle(worldPosition, Size, Color.Orange.WithAlpha(Alpha));
                 }
             }
             else
             {
-                worldHandle.DrawCircle(xformSystem.GetWorldPosition(xform), Size, Color.Red.WithAlpha(Alpha));
+                worldHandle.DrawCircle(worldPosition, Size, Color.Red.WithAlpha(Alpha));
             }
         }
     }

--- a/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
@@ -66,6 +66,7 @@ namespace Content.Client.ContextMenu.UI
         {
             _updating = true;
             _cfg.OnValueChanged(CCVars.EntityMenuGroupingType, OnGroupingChanged, true);
+            _context.OnContextClosed += OnContextClosed;
             _context.OnContextKeyEvent += OnKeyBindDown;
 
             CommandBinds.Builder
@@ -78,8 +79,14 @@ namespace Content.Client.ContextMenu.UI
             _updating = false;
             Elements.Clear();
             _cfg.UnsubValueChanged(CCVars.EntityMenuGroupingType, OnGroupingChanged);
+            _context.OnContextClosed -= OnContextClosed;
             _context.OnContextKeyEvent -= OnKeyBindDown;
             CommandBinds.Unregister<EntityMenuUIController>();
+        }
+
+        private void OnContextClosed()
+        {
+            Elements.Clear();
         }
 
         /// <summary>
@@ -312,11 +319,11 @@ namespace Content.Client.ContextMenu.UI
 
             // remove the element
             var parent = element.ParentMenu?.ParentElement;
-            element.Orphan();
             Elements.Remove(entity);
+            OrphanIfAlive(element);
 
             // update any parent elements
-            if (parent is EntityMenuElement e)
+            if (parent is EntityMenuElement { Disposed: false } e)
                 UpdateElement(e);
 
             // If this was the last entity, close the entity menu
@@ -332,15 +339,16 @@ namespace Content.Client.ContextMenu.UI
         /// </remarks>
         private void UpdateElement(EntityMenuElement element)
         {
-            if (element.SubMenu == null)
+            if (element is { Disposed: true } ||
+                element.SubMenu is not { Disposed: false } subMenu)
                 return;
 
             // Get the first entity in the sub-menus
-            var entity = GetFirstEntityOrNull(element.SubMenu);
+            var entity = GetFirstEntityOrNull(subMenu);
             if (entity == null)
             {
                 // This whole element has no associated entities. We should remove it
-                element.Orphan();
+                OrphanIfAlive(element);
                 return;
             }
 
@@ -352,14 +360,14 @@ namespace Content.Client.ContextMenu.UI
                 // There was only one entity in the sub-menu. So we will just remove the sub-menu and point directly to
                 // that entity.
                 element.Entity = entity;
-                element.SubMenu.Orphan();
+                OrphanIfAlive(subMenu);
                 element.SubMenu = null;
                 Elements[entity.Value] = element;
             }
 
             // update the parent element, so that it's count and entity icon gets updated.
             var parent = element.ParentMenu?.ParentElement;
-            if (parent is EntityMenuElement e)
+            if (parent is EntityMenuElement { Disposed: false } e)
                 UpdateElement(e);
         }
 
@@ -368,7 +376,7 @@ namespace Content.Client.ContextMenu.UI
         /// </summary>
         private EntityUid? GetFirstEntityOrNull(ContextMenuPopup? menu)
         {
-            if (menu == null)
+            if (menu is not { Disposed: false })
                 return null;
 
             foreach (var element in menu.MenuBody.Children)
@@ -390,6 +398,12 @@ namespace Content.Client.ContextMenu.UI
             }
 
             return null;
+        }
+
+        private static void OrphanIfAlive(Control? control)
+        {
+            if (control is { Disposed: false })
+                control.Orphan();
         }
     }
 }

--- a/Content.Client/Damage/DamageVisualsSystem.cs
+++ b/Content.Client/Damage/DamageVisualsSystem.cs
@@ -514,38 +514,42 @@ public sealed partial class DamageVisualsSystem : VisualizerSystem<DamageVisuals
     /// </summary>
     private void UpdateDamageVisuals(List<string> delta, Entity<DamageableComponent, SpriteComponent, DamageVisualsComponent> entity)
     {
+        foreach (var damageGroup in delta)
+        {
+            UpdateDamageVisual(damageGroup, entity);
+        }
+    }
+
+    private void UpdateDamageVisual(string damageGroup, Entity<DamageableComponent, SpriteComponent, DamageVisualsComponent> entity)
+    {
         var damageComponent = entity.Comp1;
         var spriteComponent = entity.Comp2;
         var damageVisComp = entity.Comp3;
 
-        foreach (var damageGroup in delta)
+        if (!damageVisComp.Overlay && damageGroup != damageVisComp.DamageGroup)
+            return;
+
+        if (!_prototypeManager.TryIndex<DamageGroupPrototype>(damageGroup, out var damageGroupPrototype)
+            || !damageComponent.Damage.TryGetDamageInGroup(damageGroupPrototype, out var damageTotal))
+            return;
+
+        if (!damageVisComp.LastThresholdPerGroup.TryGetValue(damageGroup, out var lastThreshold)
+            || !CheckThresholdBoundary(damageTotal, lastThreshold, damageVisComp, out var threshold))
+            return;
+
+        damageVisComp.LastThresholdPerGroup[damageGroup] = threshold;
+
+        if (damageVisComp.TargetLayers != null)
         {
-            if (!damageVisComp.Overlay && damageGroup != damageVisComp.DamageGroup)
-                continue;
-
-            if (!_prototypeManager.TryIndex<DamageGroupPrototype>(damageGroup, out var damageGroupPrototype)
-                || !damageComponent.Damage.TryGetDamageInGroup(damageGroupPrototype, out var damageTotal))
-                continue;
-
-            if (!damageVisComp.LastThresholdPerGroup.TryGetValue(damageGroup, out var lastThreshold)
-                || !CheckThresholdBoundary(damageTotal, lastThreshold, damageVisComp, out var threshold))
-                continue;
-
-            damageVisComp.LastThresholdPerGroup[damageGroup] = threshold;
-
-            if (damageVisComp.TargetLayers != null)
+            foreach (var layerMapKey in damageVisComp.TargetLayerMapKeys)
             {
-                foreach (var layerMapKey in damageVisComp.TargetLayerMapKeys)
-                {
-                    UpdateTargetLayer((entity, spriteComponent, damageVisComp), layerMapKey, damageGroup, threshold);
-                }
-            }
-            else
-            {
-                UpdateOverlay((entity, spriteComponent, damageVisComp), damageGroup, threshold);
+                UpdateTargetLayer((entity, spriteComponent, damageVisComp), layerMapKey, damageGroup, threshold);
             }
         }
-
+        else
+        {
+            UpdateOverlay((entity, spriteComponent, damageVisComp), damageGroup, threshold);
+        }
     }
 
     /// <summary>
@@ -585,11 +589,14 @@ public sealed partial class DamageVisualsSystem : VisualizerSystem<DamageVisuals
 
         if (damageVisComp.DamageOverlayGroups != null)
         {
-            UpdateDamageVisuals(damageVisComp.DamageOverlayGroups.Keys.ToList(), entity);
+            foreach (var damageGroup in damageVisComp.DamageOverlayGroups.Keys)
+            {
+                UpdateDamageVisual(damageGroup, entity);
+            }
         }
         else if (damageVisComp.DamageGroup != null)
         {
-            UpdateDamageVisuals(new List<string>() { damageVisComp.DamageGroup }, entity);
+            UpdateDamageVisual(damageVisComp.DamageGroup, entity);
         }
         else if (damageVisComp.DamageOverlay != null)
         {

--- a/Content.Client/Interactable/Components/InteractionOutlineComponent.cs
+++ b/Content.Client/Interactable/Components/InteractionOutlineComponent.cs
@@ -16,7 +16,8 @@ namespace Content.Client.Interactable.Components
         private const float DefaultWidth = 1;
 
         private bool _inRange;
-        private ShaderInstance? _shader;
+        private ShaderInstance? _inRangeShader;
+        private ShaderInstance? _outOfRangeShader;
         private int _lastRenderScale;
 
         public void OnMouseEnter(EntityUid uid, bool inInteractionRange, int renderScale)
@@ -25,9 +26,7 @@ namespace Content.Client.Interactable.Components
             _inRange = inInteractionRange;
             if (_entMan.TryGetComponent(uid, out SpriteComponent? sprite) && sprite.PostShader == null)
             {
-                // TODO why is this creating a new instance of the outline shader every time the mouse enters???
-                _shader = MakeNewShader(inInteractionRange, renderScale);
-                sprite.PostShader = _shader;
+                sprite.PostShader = GetShader(inInteractionRange, renderScale);
             }
         }
 
@@ -35,35 +34,54 @@ namespace Content.Client.Interactable.Components
         {
             if (_entMan.TryGetComponent(uid, out SpriteComponent? sprite))
             {
-                if (sprite.PostShader == _shader)
+                if (IsOutlineShader(sprite.PostShader))
                     sprite.PostShader = null;
                 sprite.RenderOrder = 0;
             }
-
-            _shader?.Dispose();
-            _shader = null;
         }
 
         public void UpdateInRange(EntityUid uid, bool inInteractionRange, int renderScale)
         {
             if (_entMan.TryGetComponent(uid, out SpriteComponent? sprite)
-                && sprite.PostShader == _shader
+                && IsOutlineShader(sprite.PostShader)
                 && (inInteractionRange != _inRange || _lastRenderScale != renderScale))
             {
                 _inRange = inInteractionRange;
                 _lastRenderScale = renderScale;
 
-                _shader = MakeNewShader(_inRange, _lastRenderScale);
-                sprite.PostShader = _shader;
+                sprite.PostShader = GetShader(_inRange, _lastRenderScale);
             }
         }
 
-        private ShaderInstance MakeNewShader(bool inRange, int renderScale)
+        public void OnShutdown(EntityUid uid)
         {
-            var shaderName = inRange ? ShaderInRange : ShaderOutOfRange;
+            OnMouseLeave(uid);
+            _inRangeShader?.Dispose();
+            _outOfRangeShader?.Dispose();
+            _inRangeShader = null;
+            _outOfRangeShader = null;
+        }
 
-            var instance = _prototypeManager.Index(shaderName).InstanceUnique();
+        private bool IsOutlineShader(ShaderInstance? shader)
+        {
+            return shader != null &&
+                   (ReferenceEquals(shader, _inRangeShader) ||
+                    ReferenceEquals(shader, _outOfRangeShader));
+        }
+
+        private ShaderInstance GetShader(bool inRange, int renderScale)
+        {
+            var instance = inRange
+                ? _inRangeShader ??= MakeNewShader(ShaderInRange)
+                : _outOfRangeShader ??= MakeNewShader(ShaderOutOfRange);
+
             instance.SetParameter("outline_width", DefaultWidth * renderScale);
+            return instance;
+        }
+
+        private ShaderInstance MakeNewShader(ProtoId<ShaderPrototype> shaderName)
+        {
+            var instance = _prototypeManager.Index(shaderName).InstanceUnique();
             return instance;
         }
     }

--- a/Content.Client/Interaction/DragDropSystem.cs
+++ b/Content.Client/Interaction/DragDropSystem.cs
@@ -102,6 +102,7 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
     private ShaderInstance? _dropTargetOutOfRangeShader;
 
     private readonly List<SpriteComponent> _highlightedSprites = new();
+    private readonly HashSet<EntityUid> _dropTargetCandidates = new();
 
     public override void Initialize()
     {
@@ -434,11 +435,12 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
         var expansion = new Vector2(1.5f, 1.5f);
 
         var bounds = new Box2(mousePos.Position - expansion, mousePos.Position + expansion);
-        var pvsEntities = _lookup.GetEntitiesIntersecting(mousePos.MapId, bounds);
+        _dropTargetCandidates.Clear();
+        _lookup.GetEntitiesIntersecting(mousePos.MapId, bounds, _dropTargetCandidates);
 
         var spriteQuery = GetEntityQuery<SpriteComponent>();
 
-        foreach (var entity in pvsEntities)
+        foreach (var entity in _dropTargetCandidates)
         {
             if (!spriteQuery.TryGetComponent(entity, out var inRangeSprite) ||
                 !inRangeSprite.Visible ||

--- a/Content.Client/Outline/InteractionOutlineSystem.cs
+++ b/Content.Client/Outline/InteractionOutlineSystem.cs
@@ -41,7 +41,13 @@ public sealed partial class InteractionOutlineSystem : EntitySystem
         base.Initialize();
 
         Subs.CVar(_configManager, CCVars.OutlineEnabled, SetCvarEnabled);
+        SubscribeLocalEvent<InteractionOutlineComponent, ComponentShutdown>(OnOutlineShutdown);
         UpdatesAfter.Add(typeof(SharedEyeSystem));
+    }
+
+    private void OnOutlineShutdown(Entity<InteractionOutlineComponent> ent, ref ComponentShutdown args)
+    {
+        ent.Comp.OnShutdown(ent.Owner);
     }
 
     public void SetCvarEnabled(bool cvarEnabled)

--- a/Content.Client/Outline/TargetOutlineSystem.cs
+++ b/Content.Client/Outline/TargetOutlineSystem.cs
@@ -77,6 +77,7 @@ public sealed partial class TargetOutlineSystem : EntitySystem
     private ShaderInstance? _shaderTargetInvalid;
 
     private readonly HashSet<SpriteComponent> _highlightedSprites = new();
+    private readonly HashSet<EntityUid> _targetCandidates = new();
 
     public override void Initialize()
     {
@@ -129,10 +130,11 @@ public sealed partial class TargetOutlineSystem : EntitySystem
         // TODO: Duplicated in SpriteSystem and DragDropSystem. Should probably be cached somewhere for a frame?
         var mousePos = _eyeManager.PixelToMap(_inputManager.MouseScreenPosition).Position;
         var bounds = new Box2(mousePos - LookupVector, mousePos + LookupVector);
-        var pvsEntities = _lookup.GetEntitiesIntersecting(_eyeManager.CurrentEye.Position.MapId, bounds, LookupFlags.Approximate | LookupFlags.Static);
+        _targetCandidates.Clear();
+        _lookup.GetEntitiesIntersecting(_eyeManager.CurrentEye.Position.MapId, bounds, _targetCandidates, LookupFlags.Approximate | LookupFlags.Static);
         var spriteQuery = GetEntityQuery<SpriteComponent>();
 
-        foreach (var entity in pvsEntities)
+        foreach (var entity in _targetCandidates)
         {
             if (!spriteQuery.TryGetComponent(entity, out var sprite) || !sprite.Visible)
                 continue;

--- a/Content.Client/Verbs/VerbSystem.cs
+++ b/Content.Client/Verbs/VerbSystem.cs
@@ -36,6 +36,7 @@ namespace Content.Client.Verbs
         [Dependency] private EntityLookupSystem _lookup = default!;
 
         private float _lookupSize;
+        private readonly HashSet<EntityUid> _containedLookup = new();
 
         private static readonly ProtoId<TagPrototype> HideContextMenuTag = "HideContextMenu";
 
@@ -127,7 +128,9 @@ namespace Content.Client.Verbs
                 // with a large sprite aabb, but small broadphase might appear in the menu, but have its children added
                 // by this.
                 var flags = LookupFlags.All & ~LookupFlags.Sensors;
-                foreach (var e in _lookup.GetEntitiesInRange(targetPos, _lookupSize, flags: flags))
+                _containedLookup.Clear();
+                _lookup.GetEntitiesInRange(targetPos.MapId, targetPos.Position, _lookupSize, _containedLookup, flags);
+                foreach (var e in _containedLookup)
                 {
                     if (!entities.Contains(e))
                         entities.Add(e);

--- a/Content.Client/_CMU14/Fishing/Overlays/FishingOverlay.cs
+++ b/Content.Client/_CMU14/Fishing/Overlays/FishingOverlay.cs
@@ -54,6 +54,16 @@ public sealed class FishingOverlay : Overlay
         var handle = args.WorldHandle;
         var rotation = args.Viewport.Eye?.Rotation ?? Angle.Zero;
         var xformQuery = _entManager.GetEntityQuery<TransformComponent>();
+        var localEnt = _player.LocalSession?.AttachedEntity;
+        if (localEnt == null)
+            return;
+
+        if (!_entManager.TryGetComponent(localEnt.Value, out ActiveFisherComponent? comp) ||
+            !_entManager.TryGetComponent(localEnt.Value, out SpriteComponent? sprite) ||
+            !_entManager.TryGetComponent(localEnt.Value, out TransformComponent? xform))
+        {
+            return;
+        }
 
         const float scale = 1f;
         var scaleMatrix = Matrix3Helpers.CreateScale(new Vector2(scale, scale));
@@ -61,7 +71,6 @@ public sealed class FishingOverlay : Overlay
 
         // Define bounds for culling entities outside the viewport
         var bounds = args.WorldAABB.Enlarged(5f);
-        var localEnt = _player.LocalSession?.AttachedEntity;
 
         // Calculate the size of the texture in world units
         var textureSize = new Vector2(_barTexture.Width, _barTexture.Height) / EyeManager.PixelsPerMeter;
@@ -71,59 +80,52 @@ public sealed class FishingOverlay : Overlay
         // Define the progress bar's width as a fraction of the texture width
         var barWidth = scaledTextureSize.X * BarWidthFraction;
 
-        // Iterate through all entities with ActiveFisherComponent
-        var enumerator = _entManager.AllEntityQueryEnumerator<ActiveFisherComponent, SpriteComponent, TransformComponent>();
-        while (enumerator.MoveNext(out var uid, out var comp, out var sprite, out var xform))
-        {
-            // Skip if the entity is not on the current map, has invalid progress, or is not the local player
-            if (xform.MapID != args.MapId ||
-                comp.TotalProgress == null ||
-                comp.TotalProgress < 0 ||
-                uid != localEnt)
-                continue;
+        if (xform.MapID != args.MapId ||
+            comp.TotalProgress == null ||
+            comp.TotalProgress < 0)
+            return;
 
-            // Get the world position of the entity
-            var worldPosition = _transform.GetWorldPosition(xform, xformQuery);
-            if (!bounds.Contains(worldPosition))
-                continue;
+        // Get the world position of the entity
+        var worldPosition = _transform.GetWorldPosition(xform, xformQuery);
+        if (!bounds.Contains(worldPosition))
+            return;
 
-            // Set up the transformation matrix for rendering
-            var worldMatrix = Matrix3Helpers.CreateTranslation(worldPosition);
-            var scaledWorld = Matrix3x2.Multiply(scaleMatrix, worldMatrix);
-            var matty = Matrix3x2.Multiply(rotationMatrix, scaledWorld);
-            handle.SetTransform(matty);
+        // Set up the transformation matrix for rendering
+        var worldMatrix = Matrix3Helpers.CreateTranslation(worldPosition);
+        var scaledWorld = Matrix3x2.Multiply(scaleMatrix, worldMatrix);
+        var matty = Matrix3x2.Multiply(rotationMatrix, scaledWorld);
+        handle.SetTransform(matty);
 
-            // Calculate the position of the progress bar relative to the entity
-            var localBounds = _sprite.GetLocalBounds((uid, sprite));
-            var position = new Vector2(
-                localBounds.Width / 2f,
-                -scaledTextureSize.Y / 2f // Center vertically
-            );
+        // Calculate the position of the progress bar relative to the entity
+        var localBounds = _sprite.GetLocalBounds((localEnt.Value, sprite));
+        var position = new Vector2(
+            localBounds.Width / 2f,
+            -scaledTextureSize.Y / 2f // Center vertically
+        );
 
-            // Draw the background texture at the scaled size
-            handle.DrawTextureRect(_barTexture, new Box2(position, position + scaledTextureSize));
+        // Draw the background texture at the scaled size
+        handle.DrawTextureRect(_barTexture, new Box2(position, position + scaledTextureSize));
 
-            // Calculate progress and clamp it to [0, 1]
-            var progress = Math.Clamp(comp.TotalProgress.Value, 0f, 1f);
+        // Calculate progress and clamp it to [0, 1]
+        var progress = Math.Clamp(comp.TotalProgress.Value, 0f, 1f);
 
-            // Calculate the fill height based on progress
-            var startYPixel = scaledTextureSize.Y * StartYFraction;
-            var endYPixel = scaledTextureSize.Y * EndYFraction;
-            var yProgress = (endYPixel - startYPixel) * progress + startYPixel;
+        // Calculate the fill height based on progress
+        var startYPixel = scaledTextureSize.Y * StartYFraction;
+        var endYPixel = scaledTextureSize.Y * EndYFraction;
+        var yProgress = (endYPixel - startYPixel) * progress + startYPixel;
 
-            // Define the fill box with the correct width and height
-            var box = new Box2(
-                new Vector2((scaledTextureSize.X - barWidth) / 2f, startYPixel),
-                new Vector2((scaledTextureSize.X + barWidth) / 2f, yProgress)
-            );
+        // Define the fill box with the correct width and height
+        var box = new Box2(
+            new Vector2((scaledTextureSize.X - barWidth) / 2f, startYPixel),
+            new Vector2((scaledTextureSize.X + barWidth) / 2f, yProgress)
+        );
 
-            // Translate the box to the correct position
-            box = box.Translated(position);
+        // Translate the box to the correct position
+        box = box.Translated(position);
 
-            // Draw the progress fill
-            var color = GetProgressColor(progress);
-            handle.DrawRect(box, color);
-        }
+        // Draw the progress fill
+        var color = GetProgressColor(progress);
+        handle.DrawRect(box, color);
 
         // Reset the shader and transform
         handle.UseShader(null);

--- a/Content.Client/_CMU14/Language/FactionLanguageBUI.cs
+++ b/Content.Client/_CMU14/Language/FactionLanguageBUI.cs
@@ -13,7 +13,6 @@ public sealed class FactionLanguageBoundUserInterface : BoundUserInterface
     {
         base.Open();
 
-        Logger.Debug("[FactionLanguage] BUI Open() called");
         CreateWindow();
     }
 

--- a/Content.Client/_RMC14/Deafness/DeafnessSystem.cs
+++ b/Content.Client/_RMC14/Deafness/DeafnessSystem.cs
@@ -17,7 +17,9 @@ public sealed partial class DeafnessSystem : SharedDeafnessSystem
     [Dependency] private StatusEffectQuerySystem _statusEffects = default!;
     [Dependency] private IGameTiming _timing = default!;
 
-    private float _originalVolume = 0.5f;
+    private float _configuredMasterVolume = 0.5f;
+    private bool _overridingMasterGain;
+    private EntityUid? _overriddenEntity;
 
     public override void Initialize()
     {
@@ -26,18 +28,18 @@ public sealed partial class DeafnessSystem : SharedDeafnessSystem
         SubscribeLocalEvent<DeafComponent, ComponentShutdown>(OnDeafShutdown);
         SubscribeLocalEvent<DeafComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
 
-        Subs.CVar(_cfg, CCVars.AudioMasterVolume, value => _originalVolume = value, true);
+        Subs.CVar(_cfg, CCVars.AudioMasterVolume, value => _configuredMasterVolume = value, true);
     }
 
     private void OnDeafShutdown(EntityUid uid, DeafComponent component, ComponentShutdown args)
     {
-        if (_player.LocalEntity == uid)
-            _audio.SetMasterGain(_originalVolume);
+        if (_player.LocalEntity == uid || _overriddenEntity == uid)
+            RestoreMasterGain();
     }
 
     private void OnPlayerDetached(EntityUid uid, DeafComponent component, LocalPlayerDetachedEvent args)
     {
-        _audio.SetMasterGain(_originalVolume);
+        RestoreMasterGain();
     }
 
     public override void Update(float frameTime)
@@ -45,61 +47,89 @@ public sealed partial class DeafnessSystem : SharedDeafnessSystem
         base.Update(frameTime);
 
         if (_player.LocalEntity is not { } player)
+        {
+            RestoreMasterGain();
             return;
+        }
 
         var curTime = _timing.CurTime;
 
-        var query = EntityQueryEnumerator<DeafComponent>();
-        while (query.MoveNext(out var uid, out var comp))
+        if (!TryComp(player, out DeafComponent? comp) ||
+            !TryComp<StatusEffectsComponent>(player, out var status))
         {
-            if (player != uid)
-                continue;
-
-            if (!TryComp<StatusEffectsComponent>(player, out var status))
-                continue;
-
-            (TimeSpan, TimeSpan)? time = null;
-            (TimeSpan, TimeSpan)? time2 = null;
-
-            if (!_statusEffects.TryGetTime(player, DeafKey, out time, status) && !_statusEffects.TryGetTime(player, "Unconscious", out time2, status))
-                continue;
-
-            if (time2 != null && (time == null || time.Value.Item2 < time2.Value.Item2))
-                time = time2.Value;
-
-            if (time == null)
-                continue;
-
-            var statusTime = time.Value;
-
-            var lastsFor = (float)(statusTime.Item2 - statusTime.Item1).TotalSeconds;
-            var timeLeft = (float)(statusTime.Item2 - curTime).TotalSeconds;
-            var timeDone = (float)(curTime - statusTime.Item1).TotalSeconds;
-
-            var volume = 0f;
-
-            var fadeOutDuration = Math.Clamp(lastsFor * 0.35f, 0.2f, 2f);
-            var fadeInDuration = Math.Clamp(lastsFor * 0.15f, 0.1f, 1f);
-
-            if (timeDone <= 2f && !comp.DidFadeOut) // Fade out during two seconds of deafness
-            {
-                var fadeOut = 1f - timeDone / fadeOutDuration;
-                volume = fadeOut * _originalVolume;
-
-                if (volume <= 0.1f) // this is so audio doesn't clip out if a status effect refreshes
-                {
-                    volume = 0f;
-                    comp.DidFadeOut = true;
-                }
-            }
-            else if (timeLeft <= 1f) // Fade in during last second of deafness
-            {
-                var fadeIn = 1f - timeLeft / fadeInDuration;
-                volume = fadeIn * _originalVolume;
-            }
-
-            volume = Math.Max(0f, volume); // prevents negative volume
-            _audio.SetMasterGain(volume);
+            RestoreMasterGain();
+            return;
         }
+
+        (TimeSpan, TimeSpan)? time = null;
+        (TimeSpan, TimeSpan)? time2 = null;
+
+        if (!_statusEffects.TryGetTime(player, DeafKey, out time, status) &&
+            !_statusEffects.TryGetTime(player, "Unconscious", out time2, status))
+        {
+            comp.DidFadeOut = false;
+            RestoreMasterGain();
+            return;
+        }
+
+        if (time2 != null && (time == null || time.Value.Item2 < time2.Value.Item2))
+            time = time2.Value;
+
+        if (time == null)
+        {
+            comp.DidFadeOut = false;
+            RestoreMasterGain();
+            return;
+        }
+
+        var statusTime = time.Value;
+
+        var lastsFor = (float)(statusTime.Item2 - statusTime.Item1).TotalSeconds;
+        var timeLeft = (float)(statusTime.Item2 - curTime).TotalSeconds;
+        var timeDone = (float)(curTime - statusTime.Item1).TotalSeconds;
+
+        if (lastsFor <= 0f || timeLeft <= 0f)
+        {
+            comp.DidFadeOut = false;
+            RestoreMasterGain();
+            return;
+        }
+
+        var volume = 0f;
+
+        var fadeOutDuration = Math.Clamp(lastsFor * 0.35f, 0.2f, 2f);
+        var fadeInDuration = Math.Clamp(lastsFor * 0.15f, 0.1f, 1f);
+
+        if (timeDone <= 2f && !comp.DidFadeOut) // Fade out during two seconds of deafness
+        {
+            var fadeOut = 1f - timeDone / fadeOutDuration;
+            volume = fadeOut * _configuredMasterVolume;
+
+            if (volume <= 0.1f) // this is so audio doesn't clip out if a status effect refreshes
+            {
+                volume = 0f;
+                comp.DidFadeOut = true;
+            }
+        }
+        else if (timeLeft <= 1f) // Fade in during last second of deafness
+        {
+            var fadeIn = 1f - timeLeft / fadeInDuration;
+            volume = fadeIn * _configuredMasterVolume;
+        }
+
+        volume = Math.Max(0f, volume); // prevents negative volume
+        _overridingMasterGain = true;
+        _overriddenEntity = player;
+        _audio.SetMasterGain(volume);
+    }
+
+    private void RestoreMasterGain()
+    {
+        if (!_overridingMasterGain)
+            return;
+
+        _overridingMasterGain = false;
+        _overriddenEntity = null;
+        _audio.SetMasterGain(_configuredMasterVolume);
     }
 }

--- a/Content.Client/_RMC14/Sentry/Laptop/SentryLaptopBui.cs
+++ b/Content.Client/_RMC14/Sentry/Laptop/SentryLaptopBui.cs
@@ -248,7 +248,7 @@ public sealed partial class SentryLaptopBui : BoundUserInterface
 
     private void OnSearchTextChanged(string text)
     {
-        _searchText = text.ToLower();
+        _searchText = text;
         FilterSentryCards();
     }
 
@@ -265,9 +265,10 @@ public sealed partial class SentryLaptopBui : BoundUserInterface
 
         foreach (var (netEntity, card) in _sentryCards)
         {
-            var name = card.SentryName.GetMessage()?.ToLower() ?? string.Empty;
-            var location = card.LocationLabel.Text?.ToLower() ?? string.Empty;
-            card.Visible = name.Contains(_searchText) || location.Contains(_searchText);
+            var name = card.SentryName.GetMessage() ?? string.Empty;
+            var location = card.LocationLabel.Text ?? string.Empty;
+            card.Visible = name.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+                           location.Contains(_searchText, StringComparison.OrdinalIgnoreCase);
         }
     }
 

--- a/Content.Client/_RMC14/Teleporter/RMCTeleporterViewerOverlay.cs
+++ b/Content.Client/_RMC14/Teleporter/RMCTeleporterViewerOverlay.cs
@@ -35,6 +35,7 @@ public sealed partial class RMCTeleporterViewerOverlay : Overlay
     private readonly EntityQuery<XenoComponent> _xenoQuery;
 
     private readonly List<(Entity<SpriteComponent> Ent, Vector2 Position, Angle Rotation)> _toDraw = new();
+    private readonly HashSet<EntityUid> _viewerContacts = new();
 
     public override OverlaySpace Space => _overlay.HasOverlay<NightVisionOverlay>()
         ? OverlaySpace.WorldSpace
@@ -79,7 +80,9 @@ public sealed partial class RMCTeleporterViewerOverlay : Overlay
                 var otherViewerAABB = _physics.GetWorldAABB(otherViewer);
 
                 _toDraw.Clear();
-                foreach (var viewerContact in _entityLookup.GetEntitiesIntersecting(otherViewerPosition.MapId, otherViewerAABB, Uncontained))
+                _viewerContacts.Clear();
+                _entityLookup.GetEntitiesIntersecting(otherViewerPosition.MapId, otherViewerAABB, _viewerContacts, Uncontained);
+                foreach (var viewerContact in _viewerContacts)
                 {
                     if (!_spriteQuery.TryComp(viewerContact, out var viewerContactSprite) ||
                         !viewerContactSprite.Visible ||

--- a/Content.Client/_RMC14/Xenonids/Despoiler/XenoDespoilerBarrageInputSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/Despoiler/XenoDespoilerBarrageInputSystem.cs
@@ -15,7 +15,6 @@ public sealed partial class XenoDespoilerBarrageInputSystem : EntitySystem
     [Dependency] private ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private IEyeManager _eye = default!;
     [Dependency] private IInputManager _input = default!;
-    [Dependency] private IMapManager _mapManager = default!;
     [Dependency] private MapSystem _map = default!;
     [Dependency] private IPlayerManager _player = default!;
     [Dependency] private TransformSystem _transform = default!;
@@ -79,7 +78,7 @@ public sealed partial class XenoDespoilerBarrageInputSystem : EntitySystem
         var mousePos = _eye.PixelToMap(_input.MouseScreenPosition);
 
         EntityUid grid;
-        if (_mapManager.TryFindGridAt(mousePos, out var gridUid, out _))
+        if (_map.TryFindGridAt(mousePos, out var gridUid, out _))
             grid = gridUid;
         else if (_map.TryGetMap(mousePos.MapId, out var map))
             grid = map.Value;

--- a/Content.Client/_RMC14/Xenonids/Hud/XenoHudOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Hud/XenoHudOverlay.cs
@@ -40,6 +40,38 @@ namespace Content.Client._RMC14.Xenonids.Hud;
 public sealed partial class XenoHudOverlay : Overlay
 {
     private static readonly ProtoId<ShaderPrototype> UnshadedShader = "unshaded";
+    private static readonly ResPath RsiPath = new("/Textures/_RMC14/Interface/xeno_hud.rsi");
+    private static readonly ResPath DancerMarksRsiPath = new("/Textures/_CM13/Interface/Hud/dancer_marks.rsi");
+    private static readonly ResPath RsiPathSlow = new("/Textures/_RMC14/Effects/xeno_stomp.rsi");
+    private static readonly ResPath RsiPathFreeze = new("/Textures/_RMC14/Effects/xeno_freeze.rsi");
+    private static readonly ResPath RsiPathHypertension = new("/Textures/_RMC14/Interface/Alerts/hypertension.rsi");
+
+    private static readonly Rsi[] AcidStackIcons =
+    [
+        new(RsiPath, "acid_stacks0"),
+        new(RsiPath, "acid_stacks1"),
+        new(RsiPath, "acid_stacks2"),
+        new(RsiPath, "acid_stacks3"),
+        new(RsiPath, "acid_stacks4"),
+    ];
+
+    private static readonly Rsi[] RankIcons =
+    [
+        new(RsiPath, "hudxenoupgrade0"),
+        new(RsiPath, "hudxenoupgrade1"),
+        new(RsiPath, "hudxenoupgrade2"),
+        new(RsiPath, "hudxenoupgrade3"),
+        new(RsiPath, "hudxenoupgrade4"),
+        new(RsiPath, "hudxenoupgrade5"),
+        new(RsiPath, "hudxenoupgrade7"),
+        new(RsiPath, "hudxenoupgrade8"),
+    ];
+
+    private static readonly Rsi DancerMarkedIcon = new(DancerMarksRsiPath, "prae_tag");
+    private static readonly Rsi DancerYellowMarkedIcon = new(DancerMarksRsiPath, "prae_tag_yellow");
+    private static readonly Rsi SlowIcon = new(RsiPathSlow, "stomp");
+    private static readonly Rsi StunIcon = new(RsiPathFreeze, "freeze");
+    private static readonly Rsi SynthIcon = new(RsiPath, "fake_tall");
 
     [Dependency] private IEntityManager _entity = default!;
     [Dependency] private IOverlayManager _overlay = default!;
@@ -73,12 +105,6 @@ public sealed partial class XenoHudOverlay : Overlay
     public override OverlaySpace Space => _overlay.HasOverlay<NightVisionOverlay>()
         ? OverlaySpace.WorldSpace
         : OverlaySpace.WorldSpaceBelowFOV;
-
-    private readonly ResPath _rsiPath = new("/Textures/_RMC14/Interface/xeno_hud.rsi");
-    private readonly ResPath _dancerMarksRsiPath = new("/Textures/_CM13/Interface/Hud/dancer_marks.rsi");
-    private readonly ResPath _rsiPathSlow = new("/Textures/_RMC14/Effects/xeno_stomp.rsi");
-    private readonly ResPath _rsiPathFreeze = new("/Textures/_RMC14/Effects/xeno_freeze.rsi");
-    private readonly ResPath _rsiPathHypertension = new("/Textures/_RMC14/Interface/Alerts/hypertension.rsi");
 
     public XenoHudOverlay()
     {
@@ -269,7 +295,7 @@ public sealed partial class XenoHudOverlay : Overlay
             handle.SetTransform(matrix);
 
             var level = Math.Clamp(comp.Current, 0, 4);
-            var icon = new Rsi(_rsiPath, $"acid_stacks{level}");
+            var icon = AcidStackIcons[level];
             var texture = _sprite.GetFrame(icon, _timing.CurTime);
 
             var yOffset = (bounds.Height + sprite.Offset.Y) / 2f - (float) texture.Height / EyeManager.PixelsPerMeter * bounds.Height;
@@ -309,13 +335,8 @@ public sealed partial class XenoHudOverlay : Overlay
             var matrix = Matrix3x2.Multiply(rotationMatrix, scaledWorld);
             handle.SetTransform(matrix);
 
-            var rankState = comp.Rank switch
-            {
-                >= 7 => "hudxenoupgrade8",
-                6 => "hudxenoupgrade7",
-                _ => $"hudxenoupgrade{comp.Rank}"
-            };
-            var icon = new Rsi(_rsiPath, rankState);
+            var rankIndex = Math.Clamp(comp.Rank, 0, 7);
+            var icon = RankIcons[rankIndex];
             var texture = _sprite.GetFrame(icon, _timing.CurTime);
 
             var yOffset = (bounds.Height + sprite.Offset.Y) / 2f - (float) texture.Height / EyeManager.PixelsPerMeter * bounds.Height;
@@ -354,8 +375,7 @@ public sealed partial class XenoHudOverlay : Overlay
             var matrix = Matrix3x2.Multiply(rotationMatrix, scaledWorld);
             handle.SetTransform(matrix);
 
-            var icon = new Rsi(_dancerMarksRsiPath, "prae_tag");
-            var texture = _sprite.GetFrame(icon, _timing.CurTime - comp.TimeAdded, false);
+            var texture = _sprite.GetFrame(DancerMarkedIcon, _timing.CurTime - comp.TimeAdded, false);
 
             var yOffset = (bounds.Height + sprite.Offset.Y) / 2f - (float)texture.Height / EyeManager.PixelsPerMeter * bounds.Height;
             var xOffset = (bounds.Width + sprite.Offset.X) / 2f - (float)texture.Width / EyeManager.PixelsPerMeter * bounds.Width;
@@ -393,8 +413,7 @@ public sealed partial class XenoHudOverlay : Overlay
             var matrix = Matrix3x2.Multiply(rotationMatrix, scaledWorld);
             handle.SetTransform(matrix);
 
-            var icon = new Rsi(_dancerMarksRsiPath, "prae_tag_yellow");
-            var texture = _sprite.GetFrame(icon, _timing.CurTime, false);
+            var texture = _sprite.GetFrame(DancerYellowMarkedIcon, _timing.CurTime, false);
 
             var yOffset = (bounds.Height + sprite.Offset.Y) / 2f - (float)texture.Height / EyeManager.PixelsPerMeter * bounds.Height;
             var xOffset = (bounds.Width + sprite.Offset.X) / 2f - (float)texture.Width / EyeManager.PixelsPerMeter * bounds.Width;
@@ -435,8 +454,7 @@ public sealed partial class XenoHudOverlay : Overlay
             var matrix = Matrix3x2.Multiply(rotationMatrix, scaledWorld);
             handle.SetTransform(matrix);
 
-            var icon = new Rsi(_rsiPathSlow, $"stomp");
-            var texture = _sprite.GetFrame(icon, _timing.CurTime);
+            var texture = _sprite.GetFrame(SlowIcon, _timing.CurTime);
 
             var yOffset = (bounds.Height + sprite.Offset.Y) / 2f - (float)texture.Height / EyeManager.PixelsPerMeter * bounds.Height;
             var xOffset = (bounds.Width + sprite.Offset.X) / 2f - (float)texture.Width / EyeManager.PixelsPerMeter * bounds.Width;
@@ -477,8 +495,7 @@ public sealed partial class XenoHudOverlay : Overlay
             var matrix = Matrix3x2.Multiply(rotationMatrix, scaledWorld);
             handle.SetTransform(matrix);
 
-            var icon = new Rsi(_rsiPathFreeze, $"freeze");
-            var texture = _sprite.GetFrame(icon, _timing.CurTime);
+            var texture = _sprite.GetFrame(StunIcon, _timing.CurTime);
 
             var yOffset = (bounds.Height + sprite.Offset.Y) / 2f - (float)texture.Height / EyeManager.PixelsPerMeter * bounds.Height;
             var xOffset = (bounds.Width + sprite.Offset.X) / 2f - (float)texture.Width / EyeManager.PixelsPerMeter * bounds.Width;
@@ -552,8 +569,7 @@ public sealed partial class XenoHudOverlay : Overlay
             var matrix = Matrix3x2.Multiply(rotationMatrix, scaledWorld);
             handle.SetTransform(matrix);
 
-            var icon = new Rsi(_rsiPath, $"fake_tall");
-            var texture = _sprite.GetFrame(icon, _timing.CurTime);
+            var texture = _sprite.GetFrame(SynthIcon, _timing.CurTime);
 
             var yOffset = (bounds.Height + sprite.Offset.Y) / 2f - (float) texture.Height / EyeManager.PixelsPerMeter * bounds.Height;
             var xOffset = (bounds.Width + sprite.Offset.X) / 2f - (float) texture.Width / EyeManager.PixelsPerMeter * bounds.Width;
@@ -605,7 +621,7 @@ public sealed partial class XenoHudOverlay : Overlay
             state = $"xenohealth{name}";
         }
 
-        var icon = new Rsi(_rsiPath, state);
+        var icon = new Rsi(RsiPath, state);
         var rsi = _resourceCache.GetResource<RSIResource>(icon.RsiPath).RSI;
         if (!rsi.TryGetState(icon.RsiState, out _))
             return;
@@ -634,7 +650,7 @@ public sealed partial class XenoHudOverlay : Overlay
         var level = ContentHelpers.RoundToLevels(plasma.Double(), max, 11);
         var name = level > 0 ? $"{level * 10}" : "0";
         var state = $"plasma{name}";
-        var icon = new Rsi(new ResPath("/Textures/_RMC14/Interface/xeno_hud.rsi"), state);
+        var icon = new Rsi(RsiPath, state);
         var texture = _sprite.GetFrame(icon, _timing.CurTime);
 
         var bounds = _sprite.GetLocalBounds((uid, sprite));
@@ -652,7 +668,7 @@ public sealed partial class XenoHudOverlay : Overlay
             return;
 
         var level = Math.Clamp(hyper.Stacks, 0, hyper.MaxStacks);
-        var icon = new Rsi(_rsiPathHypertension, $"level_{level}");
+        var icon = new Rsi(RsiPathHypertension, $"level_{level}");
         var texture = _sprite.GetFrame(icon, _timing.CurTime);
 
         var bounds = _sprite.GetLocalBounds((uid, sprite));
@@ -689,7 +705,7 @@ public sealed partial class XenoHudOverlay : Overlay
         var level = ContentHelpers.RoundToLevels(shield.Double(), max, 11);
         var name = level > 0 ? $"{level * 10}" : "0";
         var state = $"xenoshield{name}";
-        var icon = new Rsi(new ResPath("/Textures/_RMC14/Interface/xeno_hud.rsi"), state);
+        var icon = new Rsi(RsiPath, state);
         var texture = _sprite.GetFrame(icon, _timing.CurTime);
 
         var bounds = _sprite.GetLocalBounds((uid, sprite));
@@ -717,7 +733,7 @@ public sealed partial class XenoHudOverlay : Overlay
         var level = ContentHelpers.RoundToLevels(energy, max, 11);
         var name = level > 0 ? $"{level * 10}" : "0";
         var state = $"xenoenergy{name}";
-        var icon = new Rsi(new ResPath("/Textures/_RMC14/Interface/xeno_hud.rsi"), state);
+        var icon = new Rsi(RsiPath, state);
         var texture = _sprite.GetFrame(icon, _timing.CurTime);
 
         var bounds = _sprite.GetLocalBounds((uid, sprite));
@@ -732,7 +748,7 @@ public sealed partial class XenoHudOverlay : Overlay
             var level2 = ContentHelpers.RoundToLevels(generationCap.Value, max, 11);
             var name2 = level2 > 0 ? $"{level2 * 10}" : "0";
             var state2 = $"cap{name2}";
-            var icon2 = new Rsi(new ResPath("/Textures/_RMC14/Interface/xeno_hud.rsi"), state2);
+            var icon2 = new Rsi(RsiPath, state2);
             var texture2 = _sprite.GetFrame(icon2, _timing.CurTime);
             handle.DrawTexture(texture2, position);
         }

--- a/Content.Client/_RMC14/Xenonids/Pheromones/XenoPheromonesOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Pheromones/XenoPheromonesOverlay.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Numerics;
 using Content.Shared._RMC14.Mobs;
 using Content.Shared._RMC14.Xenonids;
@@ -18,14 +17,15 @@ namespace Content.Client._RMC14.Xenonids.Pheromones;
 public sealed partial class XenoPheromonesOverlay : Overlay
 {
     private static readonly ProtoId<ShaderPrototype> UnshadedShader = "unshaded";
+    private static readonly ResPath PheromonesRsiPath = new("/Textures/_RMC14/Interface/xeno_pheromones_hud.rsi");
+    private static readonly Rsi RecoveryIcon = new(PheromonesRsiPath, "aura_recovery");
+    private static readonly Rsi WardingIcon = new(PheromonesRsiPath, "aura_warding");
+    private static readonly Rsi FrenzyIcon = new(PheromonesRsiPath, "aura_frenzy");
 
     [Dependency] private IEntityManager _entity = default!;
     [Dependency] private IPlayerManager _players = default!;
     [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private IGameTiming _timing = default!;
-
-    private static readonly ImmutableArray<XenoPheromones> AllPheromones =
-        Enum.GetValues<XenoPheromones>().ToImmutableArray();
 
     private readonly ContainerSystem _container;
     private readonly SpriteSystem _sprite;
@@ -83,11 +83,7 @@ public sealed partial class XenoPheromonesOverlay : Overlay
         var sources = _entity.AllEntityQueryEnumerator<XenoActivePheromonesComponent, SpriteComponent, TransformComponent>();
         while (sources.MoveNext(out var uid, out var pheromones, out var sprite, out var xform))
         {
-            var emitting = pheromones.Pheromones;
-            var name = $"aura_{emitting.ToString().ToLowerInvariant()}";
-            var icon = new Rsi(new ResPath("/Textures/_RMC14/Interface/xeno_pheromones_hud.rsi"), name);
-
-            DrawIcon((uid, sprite, xform), in args, icon, scaleMatrix, rotationMatrix);
+            DrawIcon((uid, sprite, xform), in args, GetIcon(pheromones.Pheromones), scaleMatrix, rotationMatrix);
         }
 
         var leaders = _entity.AllEntityQueryEnumerator<HiveLeaderComponent, SpriteComponent, TransformComponent>();
@@ -100,14 +96,21 @@ public sealed partial class XenoPheromonesOverlay : Overlay
                 continue;
             }
 
-            var emitting = active.Pheromones;
-            var name = $"aura_{emitting.ToString().ToLowerInvariant()}";
-            var icon = new Rsi(new ResPath("/Textures/_RMC14/Interface/xeno_pheromones_hud.rsi"), name);
-
-            DrawIcon((uid, sprite, xform), in args, icon, scaleMatrix, rotationMatrix);
+            DrawIcon((uid, sprite, xform), in args, GetIcon(active.Pheromones), scaleMatrix, rotationMatrix);
         }
 
         handle.UseShader(null);
+    }
+
+    private static Rsi GetIcon(XenoPheromones pheromones)
+    {
+        return pheromones switch
+        {
+            XenoPheromones.Recovery => RecoveryIcon,
+            XenoPheromones.Warding => WardingIcon,
+            XenoPheromones.Frenzy => FrenzyIcon,
+            _ => RecoveryIcon,
+        };
     }
 
     private void DrawIcon(

--- a/Content.IntegrationTests/_CMU14/Xenonids/CMUXenoPortTest.cs
+++ b/Content.IntegrationTests/_CMU14/Xenonids/CMUXenoPortTest.cs
@@ -138,8 +138,7 @@ public sealed class CMUXenoPortTest
                 Assert.That(warlockComp.PsychicShieldSegments, Has.Count.EqualTo(1));
 
                 shield = warlockComp.PsychicShieldSegments[0];
-                var segment = entMan.GetComponent<CMUXenoPsychicShieldSegmentComponent>(shield.Value);
-                var incoming = segment.Direction.GetOpposite().ToVec() * 10;
+                var incoming = transform.GetWorldRotation(shield.Value).GetCardinalDir().GetOpposite().ToVec() * 10;
 
                 var projectileComp = entMan.GetComponent<ProjectileComponent>(projectile);
                 var projectilePhysics = entMan.GetComponent<PhysicsComponent>(projectile);

--- a/Content.Server/AU14/Objectives/AuObjectiveSystem.cs
+++ b/Content.Server/AU14/Objectives/AuObjectiveSystem.cs
@@ -143,7 +143,7 @@ public sealed partial class AuObjectiveSystem : AuSharedObjectiveSystem
         else
         {
             var factionKey = component.Faction.ToLowerInvariant();
-            if (!component.FactionStatuses.ContainsKey(factionKey) || component.FactionStatuses[factionKey] !=
+            if (!component.FactionStatuses.TryGetValue(factionKey, out var status) || status !=
                 AuObjectiveComponent.ObjectiveStatus.Completed)
             {
                 // Use the assigned faction for non-neutral objectives
@@ -448,8 +448,8 @@ public sealed partial class AuObjectiveSystem : AuSharedObjectiveSystem
 
         if (objective.FactionNeutral)
         {
-            if (!objective.FactionStatuses.ContainsKey(factionKey) ||
-                objective.FactionStatuses[factionKey] != AuObjectiveComponent.ObjectiveStatus.Incomplete)
+            if (!objective.FactionStatuses.TryGetValue(factionKey, out var status) ||
+                status != AuObjectiveComponent.ObjectiveStatus.Incomplete)
                 return;
 
             objective.FactionStatuses[factionKey] = AuObjectiveComponent.ObjectiveStatus.Completed;

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -44,8 +44,7 @@ namespace Content.Server.Administration.Systems
         [Dependency] private IServerDbManager _dbManager = default!;
         [Dependency] private PlayerRateLimitManager _rateLimit = default!;
 
-        [GeneratedRegex(@"^https://discord\.com/api/webhooks/(\d+)/((?!.*/).*)$")]
-        private static partial Regex DiscordRegex();
+        private static readonly Regex DiscordRegex = new(@"^https://discord\.com/api/webhooks/(\d+)/((?!.*/).*)$");
 
         private string _webhookUrl = string.Empty;
         private WebhookData? _webhookData;
@@ -128,7 +127,7 @@ namespace Content.Server.Administration.Systems
             if (url == string.Empty)
                 return;
 
-            var match = DiscordRegex().Match(url);
+            var match = DiscordRegex.Match(url);
 
             if (!match.Success)
             {
@@ -348,7 +347,7 @@ namespace Content.Server.Administration.Systems
                 return;
 
             // Basic sanity check and capturing webhook ID and token
-            var match = DiscordRegex().Match(url);
+            var match = DiscordRegex.Match(url);
 
             if (!match.Success)
             {

--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
@@ -319,10 +319,10 @@ namespace Content.Server.DeviceNetwork.Systems
         /// <returns>false if the broadcast was canceled</returns>
         private bool CheckRecipientsList(DeviceNetworkPacketEvent packet, ref HashSet<DeviceNetworkComponent> recipients)
         {
-            if (!_networks.ContainsKey(packet.NetId) || !_networks[packet.NetId].Devices.ContainsKey(packet.SenderAddress))
+            if (!_networks.TryGetValue(packet.NetId, out var network) ||
+                !network.Devices.TryGetValue(packet.SenderAddress, out var sender))
                 return false;
 
-            var sender = _networks[packet.NetId].Devices[packet.SenderAddress];
             if (!sender.SendBroadcastAttemptEvent)
                 return true;
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -438,6 +438,7 @@ public sealed partial class ShuttleSystem
     /// </summary>
     private bool CheckShouldLog(EntityUid uid)
     {
-        return !(_impactedAt.ContainsKey(uid) && _gameTiming.CurTime < _impactedAt[uid] + _adminLogSpacing);
+        return !(_impactedAt.TryGetValue(uid, out var impactedAt) &&
+                 _gameTiming.CurTime < impactedAt + _adminLogSpacing);
     }
 }

--- a/Content.Server/Speech/EntitySystems/MothAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MothAccentSystem.cs
@@ -16,16 +16,14 @@ public sealed partial class MothAccentSystem : EntitySystem
         var message = args.Message;
 
         // buzzz
-        message = LowerBuzzRegex().Replace(message, "zzz");
+        message = LowerBuzzRegex.Replace(message, "zzz");
         // buZZZ
-        message = UpperBuzzRegex().Replace(message, "ZZZ");
+        message = UpperBuzzRegex.Replace(message, "ZZZ");
 
         args.Message = message;
     }
 
-    [GeneratedRegex("z{1,3}")]
-    private static partial Regex LowerBuzzRegex();
+    private static readonly Regex LowerBuzzRegex = new("z{1,3}");
 
-    [GeneratedRegex("Z{1,3}")]
-    private static partial Regex UpperBuzzRegex();
+    private static readonly Regex UpperBuzzRegex = new("Z{1,3}");
 }

--- a/Content.Server/Speech/EntitySystems/MothAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MothAccentSystem.cs
@@ -3,11 +3,8 @@ using Content.Server.Speech.Components;
 
 namespace Content.Server.Speech.EntitySystems;
 
-public sealed class MothAccentSystem : EntitySystem
+public sealed partial class MothAccentSystem : EntitySystem
 {
-    private static readonly Regex RegexLowerBuzz = new Regex("z{1,3}");
-    private static readonly Regex RegexUpperBuzz = new Regex("Z{1,3}");
-
     public override void Initialize()
     {
         base.Initialize();
@@ -19,10 +16,16 @@ public sealed class MothAccentSystem : EntitySystem
         var message = args.Message;
 
         // buzzz
-        message = RegexLowerBuzz.Replace(message, "zzz");
+        message = LowerBuzzRegex().Replace(message, "zzz");
         // buZZZ
-        message = RegexUpperBuzz.Replace(message, "ZZZ");
+        message = UpperBuzzRegex().Replace(message, "ZZZ");
 
         args.Message = message;
     }
+
+    [GeneratedRegex("z{1,3}")]
+    private static partial Regex LowerBuzzRegex();
+
+    [GeneratedRegex("Z{1,3}")]
+    private static partial Regex UpperBuzzRegex();
 }

--- a/Content.Server/Speech/EntitySystems/ParrotAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/ParrotAccentSystem.cs
@@ -7,8 +7,6 @@ namespace Content.Server.Speech.EntitySystems;
 
 public sealed partial class ParrotAccentSystem : EntitySystem
 {
-    private static readonly Regex WordCleanupRegex = new Regex("[^A-Za-z0-9 -]");
-
     [Dependency] private IRobustRandom _random = default!;
 
     public override void Initialize()
@@ -29,7 +27,7 @@ public sealed partial class ParrotAccentSystem : EntitySystem
         if (_random.Prob(entity.Comp.LongestWordRepeatChance))
         {
             // Don't count non-alphanumeric characters as parts of words
-            var cleaned = WordCleanupRegex.Replace(message, string.Empty);
+            var cleaned = WordCleanupRegex().Replace(message, string.Empty);
             // Split on whitespace and favor words towards the end of the message
             var words = cleaned.Split(null).Reverse();
             // Find longest word
@@ -39,9 +37,13 @@ public sealed partial class ParrotAccentSystem : EntitySystem
                 message = EnsurePunctuation(message);
 
                 // Capitalize the first letter of the repeated word
-                longest = string.Concat(longest[0].ToString().ToUpper(), longest.AsSpan(1));
+                longest = string.Create(longest.Length, longest, static (span, value) =>
+                {
+                    span[0] = char.ToUpperInvariant(value[0]);
+                    value.AsSpan(1).CopyTo(span[1..]);
+                });
 
-                message = string.Format("{0} {1} {2}!", message, GetRandomSquawk(entity), longest);
+                message = $"{message} {GetRandomSquawk(entity)} {longest}!";
                 return message; // No more changes, or it's too much
             }
         }
@@ -49,13 +51,13 @@ public sealed partial class ParrotAccentSystem : EntitySystem
         if (_random.Prob(entity.Comp.SquawkPrefixChance))
         {
             // AWWK! Sometimes add a squawk at the begining of the message
-            message = string.Format("{0} {1}", GetRandomSquawk(entity), message);
+            message = $"{GetRandomSquawk(entity)} {message}";
         }
         else
         {
             // Otherwise add a squawk at the end of the message! RAWWK!
             message = EnsurePunctuation(message);
-            message = string.Format("{0} {1}", message, GetRandomSquawk(entity));
+            message = $"{message} {GetRandomSquawk(entity)}";
         }
 
         return message;
@@ -78,4 +80,7 @@ public sealed partial class ParrotAccentSystem : EntitySystem
     {
         return Loc.GetString(_random.Pick(entity.Comp.Squawks));
     }
+
+    [GeneratedRegex("[^A-Za-z0-9 -]")]
+    private static partial Regex WordCleanupRegex();
 }

--- a/Content.Server/Speech/EntitySystems/ParrotAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/ParrotAccentSystem.cs
@@ -27,7 +27,7 @@ public sealed partial class ParrotAccentSystem : EntitySystem
         if (_random.Prob(entity.Comp.LongestWordRepeatChance))
         {
             // Don't count non-alphanumeric characters as parts of words
-            var cleaned = WordCleanupRegex().Replace(message, string.Empty);
+            var cleaned = WordCleanupRegex.Replace(message, string.Empty);
             // Split on whitespace and favor words towards the end of the message
             var words = cleaned.Split(null).Reverse();
             // Find longest word
@@ -81,6 +81,5 @@ public sealed partial class ParrotAccentSystem : EntitySystem
         return Loc.GetString(_random.Pick(entity.Comp.Squawks));
     }
 
-    [GeneratedRegex("[^A-Za-z0-9 -]")]
-    private static partial Regex WordCleanupRegex();
+    private static readonly Regex WordCleanupRegex = new("[^A-Za-z0-9 -]");
 }

--- a/Content.Server/Speech/EntitySystems/RatvarianLanguageSystem.cs
+++ b/Content.Server/Speech/EntitySystems/RatvarianLanguageSystem.cs
@@ -27,16 +27,6 @@ public sealed partial class RatvarianLanguageSystem : SharedRatvarianLanguageSys
         * This only applies if they're being used as a proper noun: armorer/Nezbere
      */
 
-    private static Regex THPattern = new Regex(@"th\w\B", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static Regex ETPattern = new Regex(@"\Bet", RegexOptions.Compiled);
-    private static Regex TEPattern = new Regex(@"te\B",RegexOptions.Compiled);
-    private static Regex OFPattern = new Regex(@"(\s)(of)");
-    private static Regex TIPattern = new Regex(@"ti\B", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static Regex GUAPattern = new Regex(@"(gu)(a)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static Regex ANDPattern = new Regex(@"\b(\s)(and)(\s)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static Regex TOMYPattern = new Regex(@"(to|my)\s", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static Regex ProperNouns = new Regex(@"(ratvar)|(nezbere)|(sevtuq)|(nzcrentr)|(inath-neq)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
     public override void Initialize()
     {
         // Activate before other modifications so translation works properly
@@ -62,14 +52,14 @@ public sealed partial class RatvarianLanguageSystem : SharedRatvarianLanguageSys
         var finalMessage = new StringBuilder();
         var newWord = new StringBuilder();
 
-        ruleTranslation = THPattern.Replace(ruleTranslation, "$&`");
-        ruleTranslation = TEPattern.Replace(ruleTranslation, "$&-");
-        ruleTranslation = ETPattern.Replace(ruleTranslation, "-$&");
-        ruleTranslation = OFPattern.Replace(ruleTranslation, "-$2");
-        ruleTranslation = TIPattern.Replace(ruleTranslation, "$&`");
-        ruleTranslation = GUAPattern.Replace(ruleTranslation, "$1-$2");
-        ruleTranslation = ANDPattern.Replace(ruleTranslation, "-$2-");
-        ruleTranslation = TOMYPattern.Replace(ruleTranslation, "$1-");
+        ruleTranslation = ThPattern().Replace(ruleTranslation, "$&`");
+        ruleTranslation = TePattern().Replace(ruleTranslation, "$&-");
+        ruleTranslation = EtPattern().Replace(ruleTranslation, "-$&");
+        ruleTranslation = OfPattern().Replace(ruleTranslation, "-$2");
+        ruleTranslation = TiPattern().Replace(ruleTranslation, "$&`");
+        ruleTranslation = GuaPattern().Replace(ruleTranslation, "$1-$2");
+        ruleTranslation = AndPattern().Replace(ruleTranslation, "-$2-");
+        ruleTranslation = ToMyPattern().Replace(ruleTranslation, "$1-");
 
         var temp = ruleTranslation.Split(' ');
 
@@ -77,7 +67,7 @@ public sealed partial class RatvarianLanguageSystem : SharedRatvarianLanguageSys
         {
             newWord.Clear();
 
-            if (ProperNouns.IsMatch(word))
+            if (ProperNouns().IsMatch(word))
                 newWord.Append(word);
 
             else
@@ -110,8 +100,37 @@ public sealed partial class RatvarianLanguageSystem : SharedRatvarianLanguageSys
                     }
                 }
             }
-            finalMessage.Append(newWord + " ");
+
+            finalMessage.Append(newWord);
+            finalMessage.Append(' ');
         }
         return finalMessage.ToString().Trim();
     }
+
+    [GeneratedRegex(@"th\w\B", RegexOptions.IgnoreCase)]
+    private static partial Regex ThPattern();
+
+    [GeneratedRegex(@"\Bet")]
+    private static partial Regex EtPattern();
+
+    [GeneratedRegex(@"te\B")]
+    private static partial Regex TePattern();
+
+    [GeneratedRegex(@"(\s)(of)")]
+    private static partial Regex OfPattern();
+
+    [GeneratedRegex(@"ti\B", RegexOptions.IgnoreCase)]
+    private static partial Regex TiPattern();
+
+    [GeneratedRegex(@"(gu)(a)", RegexOptions.IgnoreCase)]
+    private static partial Regex GuaPattern();
+
+    [GeneratedRegex(@"\b(\s)(and)(\s)", RegexOptions.IgnoreCase)]
+    private static partial Regex AndPattern();
+
+    [GeneratedRegex(@"(to|my)\s", RegexOptions.IgnoreCase)]
+    private static partial Regex ToMyPattern();
+
+    [GeneratedRegex(@"(ratvar)|(nezbere)|(sevtuq)|(nzcrentr)|(inath-neq)", RegexOptions.IgnoreCase)]
+    private static partial Regex ProperNouns();
 }

--- a/Content.Server/Speech/EntitySystems/RatvarianLanguageSystem.cs
+++ b/Content.Server/Speech/EntitySystems/RatvarianLanguageSystem.cs
@@ -52,14 +52,14 @@ public sealed partial class RatvarianLanguageSystem : SharedRatvarianLanguageSys
         var finalMessage = new StringBuilder();
         var newWord = new StringBuilder();
 
-        ruleTranslation = ThPattern().Replace(ruleTranslation, "$&`");
-        ruleTranslation = TePattern().Replace(ruleTranslation, "$&-");
-        ruleTranslation = EtPattern().Replace(ruleTranslation, "-$&");
-        ruleTranslation = OfPattern().Replace(ruleTranslation, "-$2");
-        ruleTranslation = TiPattern().Replace(ruleTranslation, "$&`");
-        ruleTranslation = GuaPattern().Replace(ruleTranslation, "$1-$2");
-        ruleTranslation = AndPattern().Replace(ruleTranslation, "-$2-");
-        ruleTranslation = ToMyPattern().Replace(ruleTranslation, "$1-");
+        ruleTranslation = ThPattern.Replace(ruleTranslation, "$&`");
+        ruleTranslation = TePattern.Replace(ruleTranslation, "$&-");
+        ruleTranslation = EtPattern.Replace(ruleTranslation, "-$&");
+        ruleTranslation = OfPattern.Replace(ruleTranslation, "-$2");
+        ruleTranslation = TiPattern.Replace(ruleTranslation, "$&`");
+        ruleTranslation = GuaPattern.Replace(ruleTranslation, "$1-$2");
+        ruleTranslation = AndPattern.Replace(ruleTranslation, "-$2-");
+        ruleTranslation = ToMyPattern.Replace(ruleTranslation, "$1-");
 
         var temp = ruleTranslation.Split(' ');
 
@@ -67,7 +67,7 @@ public sealed partial class RatvarianLanguageSystem : SharedRatvarianLanguageSys
         {
             newWord.Clear();
 
-            if (ProperNouns().IsMatch(word))
+            if (ProperNouns.IsMatch(word))
                 newWord.Append(word);
 
             else
@@ -107,30 +107,21 @@ public sealed partial class RatvarianLanguageSystem : SharedRatvarianLanguageSys
         return finalMessage.ToString().Trim();
     }
 
-    [GeneratedRegex(@"th\w\B", RegexOptions.IgnoreCase)]
-    private static partial Regex ThPattern();
+    private static readonly Regex ThPattern = new(@"th\w\B", RegexOptions.IgnoreCase);
 
-    [GeneratedRegex(@"\Bet")]
-    private static partial Regex EtPattern();
+    private static readonly Regex EtPattern = new(@"\Bet");
 
-    [GeneratedRegex(@"te\B")]
-    private static partial Regex TePattern();
+    private static readonly Regex TePattern = new(@"te\B");
 
-    [GeneratedRegex(@"(\s)(of)")]
-    private static partial Regex OfPattern();
+    private static readonly Regex OfPattern = new(@"(\s)(of)");
 
-    [GeneratedRegex(@"ti\B", RegexOptions.IgnoreCase)]
-    private static partial Regex TiPattern();
+    private static readonly Regex TiPattern = new(@"ti\B", RegexOptions.IgnoreCase);
 
-    [GeneratedRegex(@"(gu)(a)", RegexOptions.IgnoreCase)]
-    private static partial Regex GuaPattern();
+    private static readonly Regex GuaPattern = new(@"(gu)(a)", RegexOptions.IgnoreCase);
 
-    [GeneratedRegex(@"\b(\s)(and)(\s)", RegexOptions.IgnoreCase)]
-    private static partial Regex AndPattern();
+    private static readonly Regex AndPattern = new(@"\b(\s)(and)(\s)", RegexOptions.IgnoreCase);
 
-    [GeneratedRegex(@"(to|my)\s", RegexOptions.IgnoreCase)]
-    private static partial Regex ToMyPattern();
+    private static readonly Regex ToMyPattern = new(@"(to|my)\s", RegexOptions.IgnoreCase);
 
-    [GeneratedRegex(@"(ratvar)|(nezbere)|(sevtuq)|(nzcrentr)|(inath-neq)", RegexOptions.IgnoreCase)]
-    private static partial Regex ProperNouns();
+    private static readonly Regex ProperNouns = new(@"(ratvar)|(nezbere)|(sevtuq)|(nzcrentr)|(inath-neq)", RegexOptions.IgnoreCase);
 }

--- a/Content.Server/Speech/EntitySystems/SkeletonAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/SkeletonAccentSystem.cs
@@ -9,8 +9,9 @@ public sealed partial class SkeletonAccentSystem : EntitySystem
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private ReplacementAccentSystem _replacement = default!;
 
-    [GeneratedRegex(@"(?<!\w)[^aeiou]one", RegexOptions.IgnoreCase, "en-US")]
-    private static partial Regex BoneRegex();
+    private static readonly Regex BoneRegex = new(
+        @"(?<!\w)[^aeiou]one",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
     public override void Initialize()
     {
@@ -30,7 +31,7 @@ public sealed partial class SkeletonAccentSystem : EntitySystem
 
         // Character manipulations:
         // At the start of words, any non-vowel + "one" becomes "bone", e.g. tone -> bone ; lonely -> bonely; clone -> clone (remains unchanged).
-        msg = BoneRegex().Replace(msg, "bone");
+        msg = BoneRegex.Replace(msg, "bone");
 
         // apply word replacements
         msg = _replacement.ApplyReplacements(msg, "skeleton");

--- a/Content.Server/Speech/EntitySystems/StutteringSystem.cs
+++ b/Content.Server/Speech/EntitySystems/StutteringSystem.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Text.RegularExpressions;
 using Content.Server.Speech.Components;
 using Content.Shared.Speech.EntitySystems;
 using Content.Shared.StatusEffect;
@@ -11,10 +10,6 @@ namespace Content.Server.Speech.EntitySystems
     {
         [Dependency] private StatusEffectQuerySystem _statusEffectsSystem = default!;
         [Dependency] private IRobustRandom _random = default!;
-
-        // Regex of characters to stutter.
-        private static readonly Regex Stutter = new(@"[b-df-hj-np-tv-wxyz]",
-            RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public override void Initialize()
         {
@@ -36,39 +31,47 @@ namespace Content.Server.Speech.EntitySystems
 
         public string Accentuate(string message, StutteringAccentComponent component)
         {
-            var length = message.Length;
-
-            var finalMessage = new StringBuilder();
-
-            string newLetter;
-
-            for (var i = 0; i < length; i++)
+            var finalMessage = new StringBuilder(message.Length);
+            foreach (var letter in message)
             {
-                newLetter = message[i].ToString();
-                if (Stutter.IsMatch(newLetter) && _random.Prob(component.MatchRandomProb))
+                if (!IsStutterCharacter(letter) || !_random.Prob(component.MatchRandomProb))
                 {
-                    if (_random.Prob(component.FourRandomProb))
-                    {
-                        newLetter = $"{newLetter}-{newLetter}-{newLetter}-{newLetter}";
-                    }
-                    else if (_random.Prob(component.ThreeRandomProb))
-                    {
-                        newLetter = $"{newLetter}-{newLetter}-{newLetter}";
-                    }
-                    else if (_random.Prob(component.CutRandomProb))
-                    {
-                        newLetter = "";
-                    }
-                    else
-                    {
-                        newLetter = $"{newLetter}-{newLetter}";
-                    }
+                    finalMessage.Append(letter);
+                    continue;
                 }
 
-                finalMessage.Append(newLetter);
+                if (_random.Prob(component.FourRandomProb))
+                    AppendStutter(finalMessage, letter, 4);
+                else if (_random.Prob(component.ThreeRandomProb))
+                    AppendStutter(finalMessage, letter, 3);
+                else if (_random.Prob(component.CutRandomProb))
+                    continue;
+                else
+                    AppendStutter(finalMessage, letter, 2);
             }
 
             return finalMessage.ToString();
+        }
+
+        private static bool IsStutterCharacter(char letter)
+        {
+            return char.ToLowerInvariant(letter) is
+                >= 'b' and <= 'd' or
+                >= 'f' and <= 'h' or
+                >= 'j' and <= 'n' or
+                >= 'p' and <= 't' or
+                >= 'v' and <= 'z';
+        }
+
+        private static void AppendStutter(StringBuilder builder, char letter, int count)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                if (i > 0)
+                    builder.Append('-');
+
+                builder.Append(letter);
+            }
         }
     }
 }

--- a/Content.Server/_CMU14/Language/FactionLanguageSystem.cs
+++ b/Content.Server/_CMU14/Language/FactionLanguageSystem.cs
@@ -9,7 +9,7 @@ using Robust.Shared.Player;
 
 namespace Content.Server._CMU14.Language;
 
-public sealed class FactionLanguageSystem : EntitySystem
+public sealed partial class FactionLanguageSystem : EntitySystem
 {
     [Dependency] private LanguageSystem _language = default!;
     [Dependency] private UserInterfaceSystem _ui = default!;

--- a/Content.Server/_CMU14/Language/TranslatorDeviceSystem.cs
+++ b/Content.Server/_CMU14/Language/TranslatorDeviceSystem.cs
@@ -4,7 +4,7 @@ using Content.Shared.Inventory.Events;
 
 namespace Content.Server._CMU14.Language;
 
-public sealed class TranslatorDeviceSystem : EntitySystem
+public sealed partial class TranslatorDeviceSystem : EntitySystem
 {
     [Dependency] private LanguageSystem _language = default!;
 

--- a/Content.Server/_CMU14/Threats/Mobs/Abomination/AbominationMimicSystem.cs
+++ b/Content.Server/_CMU14/Threats/Mobs/Abomination/AbominationMimicSystem.cs
@@ -130,9 +130,6 @@ public sealed partial class AbominationMimicSystem : EntitySystem
     private void OnTransformAction(Entity<AbominationMimicComponent> mimic,
         ref AbominationMimicTransformActionEvent args)
     {
-        Log.Info($"[mimic] OnTransformAction fired on {ToPrettyString(mimic)} performer={ToPrettyString(args.Performer)
-        } action={ToPrettyString(args.Action.Owner)} pool={mimic.Comp.AssimilatedPool.Count}");
-
         if (args.Handled)
             return;
 
@@ -140,8 +137,6 @@ public sealed partial class AbominationMimicSystem : EntitySystem
         // on the disguised form is a no-op so they don't double-pick.
         if (HasComp<AbominationMimicTransformedComponent>(mimic))
         {
-            Log.Info($"[mimic] OnTransformAction rejected: {ToPrettyString(mimic)} already transformed");
-
             return;
         }
 
@@ -166,9 +161,6 @@ public sealed partial class AbominationMimicSystem : EntitySystem
 
     private void OnSelectForm(Entity<AbominationMimicComponent> mimic, ref AbominationMimicSelectFormMessage args)
     {
-        Log.Info($"[mimic] OnSelectForm fired on {ToPrettyString(mimic)} actor={ToPrettyString(args.Actor)} idx={
-            args.Index} pool={mimic.Comp.AssimilatedPool.Count}");
-
         if (args.Index < 0 || args.Index >= mimic.Comp.AssimilatedPool.Count)
         {
             Log.Warning($"[mimic] OnSelectForm rejected: index {args.Index} out of range for pool {
@@ -180,15 +172,18 @@ public sealed partial class AbominationMimicSystem : EntitySystem
         AbominationAssimilationProfile profile = mimic.Comp.AssimilatedPool[args.Index];
         _ui.CloseUi(mimic.Owner, AbominationMimicUiKey.Key, args.Actor);
         EntityUid? result = StartDisguise(mimic, profile, mimic.Comp.TransformDuration);
-        if (result is { } r)
-            Log.Info($"[mimic] disguise spawned: {ToPrettyString(r)}");
-        else
+        if (result == null)
             Log.Warning($"[mimic] disguise FAILED (PolymorphEntity returned null) for {ToPrettyString(mimic)}");
     }
 
     private void PushBuiState(Entity<AbominationMimicComponent> mimic)
     {
-        List<string> names = mimic.Comp.AssimilatedPool.Select(p => p.Name).ToList();
+        var names = new List<string>(mimic.Comp.AssimilatedPool.Count);
+        foreach (var profile in mimic.Comp.AssimilatedPool)
+        {
+            names.Add(profile.Name);
+        }
+
         _ui.SetUiState(mimic.Owner, AbominationMimicUiKey.Key, new AbominationMimicBuiState(names, null));
     }
 
@@ -203,9 +198,6 @@ public sealed partial class AbominationMimicSystem : EntitySystem
     public EntityUid? StartDisguise(Entity<AbominationMimicComponent> mimic, AbominationAssimilationProfile profile,
         TimeSpan duration)
     {
-        Log.Info($"[mimic] StartDisguise mimic={ToPrettyString(mimic)} profile={profile.Name} sourceProto={
-            profile.SourceProtoId ?? "(humanoid)"}");
-
         EntityUid? disguised;
 
         // Animal profiles carry a SourceProtoId — polymorph straight into that

--- a/Content.Server/_RMC14/Deafness/DeafnessSystem.cs
+++ b/Content.Server/_RMC14/Deafness/DeafnessSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Server._RMC14.Chat.Chat;
 using Content.Server.Radio;
 using Content.Shared._RMC14.Deafness;
@@ -10,8 +9,6 @@ namespace Content.Server._RMC14.Deafness;
 public sealed partial class DeafnessSystem : SharedDeafnessSystem
 {
     [Dependency] private IRobustRandom _random = default!;
-
-    private readonly List<string> _punctuation = new List<string> { ",", "!", ".", ";", "?" };
 
     public override void Initialize()
     {
@@ -46,7 +43,7 @@ public sealed partial class DeafnessSystem : SharedDeafnessSystem
         {
             var words = args.Message.Split(' ');
             var heardWord = words[_random.Next(words.Length)];
-            var finalWord = RemovePunctuation(heardWord, _punctuation);
+            var finalWord = RemovePunctuation(heardWord);
 
             var isSelf = ent.Owner != args.Source ? "rmc-deaf-hear-others" : "rmc-deaf-hear-self";
             args.WrappedMessage = Loc.GetString(isSelf, ("message", finalWord));
@@ -60,14 +57,25 @@ public sealed partial class DeafnessSystem : SharedDeafnessSystem
         }
     }
 
-    public static string RemovePunctuation(string word, List<string> punctuation)
+    private static string RemovePunctuation(string word)
     {
-        if (punctuation.Contains(word.FirstOrDefault().ToString()))
-            word = word.Substring(1);
+        if (word.Length == 0)
+            return word;
 
-        if (punctuation.Contains(word.LastOrDefault().ToString()))
-            word = word.Substring(0, word.Length - 1);
+        var start = IsPunctuation(word[0]) ? 1 : 0;
+        var length = word.Length - start;
 
-        return word;
+        if (length > 0 && IsPunctuation(word[^1]))
+            length--;
+
+        if (start == 0 && length == word.Length)
+            return word;
+
+        return length <= 0 ? string.Empty : word.Substring(start, length);
+    }
+
+    private static bool IsPunctuation(char character)
+    {
+        return character is ',' or '!' or '.' or ';' or '?';
     }
 }

--- a/Content.Server/_RMC14/Language/Systems/LanguageLearningSystem.cs
+++ b/Content.Server/_RMC14/Language/Systems/LanguageLearningSystem.cs
@@ -11,7 +11,7 @@ using Robust.Shared.Timing;
 
 namespace Content.Server._RMC14.Language.Systems;
 
-public sealed class LanguageLearningSystem : SharedLanguageLearningSystem
+public sealed partial class LanguageLearningSystem : SharedLanguageLearningSystem
 {
     [Dependency] private IComponentFactory _compFactory = default!;
     [Dependency] private ExamineSystemShared _examine = default!;

--- a/Content.Server/_RMC14/Language/Systems/LanguagePamphletSystem.cs
+++ b/Content.Server/_RMC14/Language/Systems/LanguagePamphletSystem.cs
@@ -3,7 +3,7 @@ using Content.Shared._RMC14.Marines.Skills.Pamphlets;
 
 namespace Content.Server._RMC14.Language.Systems;
 
-public sealed class LanguagePamphletSystem : EntitySystem
+public sealed partial class LanguagePamphletSystem : EntitySystem
 {
     [Dependency] private LanguageSystem _language = default!;
     [Dependency] private LanguageLearningSystem _learning = default!;

--- a/Content.Server/_RMC14/Speech/EntitySystems/VulpkaninAccentSystem.cs
+++ b/Content.Server/_RMC14/Speech/EntitySystems/VulpkaninAccentSystem.cs
@@ -22,15 +22,13 @@ public sealed partial class VulpkaninAccentSystem : EntitySystem
     {
         var message = args.Message;
         
-        message = LowerRRegex().Replace(message, _random.Pick(LowerRReplacements));
-        message = UpperRRegex().Replace(message, _random.Pick(UpperRReplacements));
+        message = LowerRRegex.Replace(message, _random.Pick(LowerRReplacements));
+        message = UpperRRegex.Replace(message, _random.Pick(UpperRReplacements));
         
         args.Message = message;
     }
 
-    [GeneratedRegex("r+")]
-    private static partial Regex LowerRRegex();
+    private static readonly Regex LowerRRegex = new("r+");
 
-    [GeneratedRegex("R+")]
-    private static partial Regex UpperRRegex();
+    private static readonly Regex UpperRRegex = new("R+");
 }

--- a/Content.Server/_RMC14/Speech/EntitySystems/VulpkaninAccentSystem.cs
+++ b/Content.Server/_RMC14/Speech/EntitySystems/VulpkaninAccentSystem.cs
@@ -7,6 +7,9 @@ namespace Content.Server._RMC14.Speech.EntitySystems;
 
 public sealed partial class VulpkaninAccentSystem : EntitySystem
 {
+    private static readonly string[] LowerRReplacements = ["rr", "rrr"];
+    private static readonly string[] UpperRReplacements = ["RR", "RRR"];
+
     [Dependency] private IRobustRandom _random = default!;
     
     public override void Initialize()
@@ -19,8 +22,8 @@ public sealed partial class VulpkaninAccentSystem : EntitySystem
     {
         var message = args.Message;
         
-        message = LowerRRegex().Replace(message, _random.Pick(new List<string> { "rr", "rrr" }));
-        message = UpperRRegex().Replace(message, _random.Pick(new List<string> { "RR", "RRR" }));
+        message = LowerRRegex().Replace(message, _random.Pick(LowerRReplacements));
+        message = UpperRRegex().Replace(message, _random.Pick(UpperRReplacements));
         
         args.Message = message;
     }

--- a/Content.Server/_RMC14/Traits/RMCTraitSystem.cs
+++ b/Content.Server/_RMC14/Traits/RMCTraitSystem.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server._RMC14.Traits;
 
-public sealed class RMCTraitSystem : EntitySystem
+public sealed partial class RMCTraitSystem : EntitySystem
 {
     [Dependency] private LanguageSystem _language = default!;
     [Dependency] private IPrototypeManager _prototypeManager = default!;

--- a/Content.Server/_RMC14/Weapons/Ranged/Brute/RMCBruteLauncherSystem.cs
+++ b/Content.Server/_RMC14/Weapons/Ranged/Brute/RMCBruteLauncherSystem.cs
@@ -59,7 +59,6 @@ public sealed partial class RMCBruteLauncherSystem : EntitySystem
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private ExamineSystemShared _examine = default!;
     [Dependency] private SharedGunSystem _gun = default!;
-    [Dependency] private IMapManager _mapManager = default!;
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private IRobustRandom _random = default!;
@@ -381,8 +380,8 @@ public sealed partial class RMCBruteLauncherSystem : EntitySystem
         if (userMap.MapId != targetMap.MapId)
             return true;
 
-        if (!_mapManager.TryFindGridAt(userMap, out var userGrid, out var grid) ||
-            !_mapManager.TryFindGridAt(targetMap, out var targetGrid, out _) ||
+        if (!_map.TryFindGridAt(userMap, out var userGrid, out var grid) ||
+            !_map.TryFindGridAt(targetMap, out var targetGrid, out _) ||
             userGrid != targetGrid)
         {
             return !_examine.InRangeUnOccluded(userMap, targetMap, 0, uid => uid == user || uid == target);

--- a/Content.Server/_RMC14/Xenonids/Psychic/XenoPsychicCommunicationSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Psychic/XenoPsychicCommunicationSystem.cs
@@ -37,7 +37,6 @@ public sealed partial class XenoPsychicCommunicationSystem : EntitySystem
     [Dependency] private SharedXenoWatchSystem _watch = default!;
 
     private static readonly Color PsychicColor = Color.FromHex("#921992");
-    private static readonly Regex NewLineRegex = new("\n{3,}", RegexOptions.Compiled);
 
     private readonly HashSet<Entity<MobStateComponent>> _nearbyMobs = new();
 
@@ -297,7 +296,7 @@ public sealed partial class XenoPsychicCommunicationSystem : EntitySystem
         if (message.Length > queen.Comp.CharacterLimit)
             message = message[..queen.Comp.CharacterLimit].Trim();
 
-        message = NewLineRegex.Replace(message, "\n\n");
+        message = NewLineRegex().Replace(message, "\n\n");
         return _chat.SanitizeMessageReplaceWords(queen, message);
     }
 
@@ -395,4 +394,7 @@ public sealed partial class XenoPsychicCommunicationSystem : EntitySystem
         Radiance,
         Order,
     }
+
+    [GeneratedRegex("\n{3,}")]
+    private static partial Regex NewLineRegex();
 }

--- a/Content.Server/_RMC14/Xenonids/Psychic/XenoPsychicCommunicationSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Psychic/XenoPsychicCommunicationSystem.cs
@@ -296,7 +296,7 @@ public sealed partial class XenoPsychicCommunicationSystem : EntitySystem
         if (message.Length > queen.Comp.CharacterLimit)
             message = message[..queen.Comp.CharacterLimit].Trim();
 
-        message = NewLineRegex().Replace(message, "\n\n");
+        message = NewLineRegex.Replace(message, "\n\n");
         return _chat.SanitizeMessageReplaceWords(queen, message);
     }
 
@@ -395,6 +395,5 @@ public sealed partial class XenoPsychicCommunicationSystem : EntitySystem
         Order,
     }
 
-    [GeneratedRegex("\n{3,}")]
-    private static partial Regex NewLineRegex();
+    private static readonly Regex NewLineRegex = new("\n{3,}");
 }

--- a/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
@@ -134,15 +134,10 @@ public sealed partial class XenoRoleSystem : EntitySystem
         if (HasComp<XenoMaturingComponent>(ent) || !TryComp<XenoRankNamesComponent>(ent, out var rankNamesComp))
             return;
 
-        LocId? rank = null;
-
-        if (rankNamesComp.RankNames.ContainsKey(ent.Comp.Rank))
-            rank = rankNamesComp.RankNames[ent.Comp.Rank];
-
-        if (rank == null)
+        if (!rankNamesComp.RankNames.TryGetValue(ent.Comp.Rank, out var rank))
             return;
 
-        args.AddModifier(rank.Value);
+        args.AddModifier(rank);
     }
 
     private void UpdateRank(EntityUid xeno, ICommonSession player, string jobId, HumanoidCharacterProfile profile)

--- a/Content.Shared/Construction/SharedConstructionSystem.cs
+++ b/Content.Shared/Construction/SharedConstructionSystem.cs
@@ -8,7 +8,6 @@ namespace Content.Shared.Construction
 {
     public abstract partial class SharedConstructionSystem : EntitySystem
     {
-        [Dependency] private IMapManager _mapManager = default!;
         [Dependency] private SharedMapSystem _map = default!;
         [Dependency] protected IPrototypeManager PrototypeManager = default!;
         [Dependency] protected SharedTransformSystem TransformSystem = default!;
@@ -21,7 +20,7 @@ namespace Content.Shared.Construction
             if (!canBuildInImpassable)
                 return null;
 
-            if (!_mapManager.TryFindGridAt(coords, out var gridUid, out var grid))
+            if (!_map.TryFindGridAt(coords, out var gridUid, out var grid))
                 return null;
 
             var ignored = _map.GetAnchoredEntities((gridUid, grid), coords).ToHashSet();

--- a/Content.Shared/Disposal/Mailing/SharedDisposalRouterComponent.cs
+++ b/Content.Shared/Disposal/Mailing/SharedDisposalRouterComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Disposal.Components
 {
     public sealed partial class SharedDisposalRouterComponent : Component
     {
-        public static readonly Regex TagRegex = TagValidationRegex();
+        public static readonly Regex TagRegex = new("^[a-zA-Z0-9, ]*$");
 
         [Serializable, NetSerializable]
         public sealed class DisposalRouterUserInterfaceState : BoundUserInterfaceState
@@ -47,7 +47,5 @@ namespace Content.Shared.Disposal.Components
             Key
         }
 
-        [GeneratedRegex("^[a-zA-Z0-9, ]*$")]
-        private static partial Regex TagValidationRegex();
     }
 }

--- a/Content.Shared/Disposal/Mailing/SharedDisposalRouterComponent.cs
+++ b/Content.Shared/Disposal/Mailing/SharedDisposalRouterComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Disposal.Components
 {
     public sealed partial class SharedDisposalRouterComponent : Component
     {
-        public static readonly Regex TagRegex = new("^[a-zA-Z0-9, ]*$", RegexOptions.Compiled);
+        public static readonly Regex TagRegex = TagValidationRegex();
 
         [Serializable, NetSerializable]
         public sealed class DisposalRouterUserInterfaceState : BoundUserInterfaceState
@@ -46,5 +46,8 @@ namespace Content.Shared.Disposal.Components
         {
             Key
         }
+
+        [GeneratedRegex("^[a-zA-Z0-9, ]*$")]
+        private static partial Regex TagValidationRegex();
     }
 }

--- a/Content.Shared/Disposal/Mailing/SharedDisposalTaggerComponent.cs
+++ b/Content.Shared/Disposal/Mailing/SharedDisposalTaggerComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Disposal.Components
 {
     public sealed partial class SharedDisposalTaggerComponent : Component
     {
-        public static readonly Regex TagRegex = TagValidationRegex();
+        public static readonly Regex TagRegex = new("^[a-zA-Z0-9 ]*$");
 
         [Serializable, NetSerializable]
         public sealed class DisposalTaggerUserInterfaceState : BoundUserInterfaceState
@@ -47,7 +47,5 @@ namespace Content.Shared.Disposal.Components
             Key
         }
 
-        [GeneratedRegex("^[a-zA-Z0-9 ]*$")]
-        private static partial Regex TagValidationRegex();
     }
 }

--- a/Content.Shared/Disposal/Mailing/SharedDisposalTaggerComponent.cs
+++ b/Content.Shared/Disposal/Mailing/SharedDisposalTaggerComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Disposal.Components
 {
     public sealed partial class SharedDisposalTaggerComponent : Component
     {
-        public static readonly Regex TagRegex = new("^[a-zA-Z0-9 ]*$", RegexOptions.Compiled);
+        public static readonly Regex TagRegex = TagValidationRegex();
 
         [Serializable, NetSerializable]
         public sealed class DisposalTaggerUserInterfaceState : BoundUserInterfaceState
@@ -46,5 +46,8 @@ namespace Content.Shared.Disposal.Components
         {
             Key
         }
+
+        [GeneratedRegex("^[a-zA-Z0-9 ]*$")]
+        private static partial Regex TagValidationRegex();
     }
 }

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -58,7 +58,6 @@ namespace Content.Shared.Interaction
     public abstract partial class SharedInteractionSystem : EntitySystem
     {
         [Dependency] private IGameTiming _gameTiming = default!;
-        [Dependency] private IMapManager _mapManager = default!;
         [Dependency] private ISharedAdminLogManager _adminLogger = default!;
         [Dependency] private ISharedChatManager _chat = default!;
         [Dependency] private ActionBlockerSystem _actionBlockerSystem = default!;
@@ -89,6 +88,7 @@ namespace Content.Shared.Interaction
         private EntityQuery<WallMountComponent> _wallMountQuery;
         private EntityQuery<UseDelayComponent> _delayQuery;
         private EntityQuery<ActivatableUIComponent> _uiQuery;
+        private readonly HashSet<EntityUid> _predicateLookupResults = new();
 
         private const CollisionGroup InRangeUnobstructedMask = CollisionGroup.Impassable | CollisionGroup.InteractImpassable;
 
@@ -908,7 +908,9 @@ namespace Content.Shared.Interaction
                 // inside of walls, users can still pick them up.
                 // TODO: Bandaid, alloc spam
                 // We use 0.01 range just in case it's perfectly in between 2 walls and 1 gets missed.
-                foreach (var otherEnt in _lookup.GetEntitiesInRange(target, 0.01f, flags: LookupFlags.Static))
+                _predicateLookupResults.Clear();
+                _lookup.GetEntitiesInRange(target, 0.01f, _predicateLookupResults, LookupFlags.Static);
+                foreach (var otherEnt in _predicateLookupResults)
                 {
                     if (target == otherEnt ||
                         !_physicsQuery.TryComp(otherEnt, out var otherBody) ||
@@ -935,10 +937,12 @@ namespace Content.Shared.Interaction
                     ignoreAnchored = angleDelta < wallMount.Arc / 2 || Math.Tau - angleDelta < wallMount.Arc / 2;
                 }
 
-                if (ignoreAnchored && _mapManager.TryFindGridAt(targetCoords, out var gridUid, out var grid))
+                if (ignoreAnchored && _map.TryFindGridAt(targetCoords, out var gridUid, out var grid))
                 {
                     ignored.UnionWith(_map.GetAnchoredEntities((gridUid, grid), targetCoords));
-                    foreach (var ent in _lookup.GetEntitiesInRange(targetCoords, 0.2f))
+                    _predicateLookupResults.Clear();
+                    _lookup.GetEntitiesInRange(targetCoords.MapId, targetCoords.Position, 0.2f, _predicateLookupResults);
+                    foreach (var ent in _predicateLookupResults)
                     {
                         if (!TryComp(ent, out TransformComponent? xform) ||
                             !xform.Anchored)
@@ -1325,7 +1329,7 @@ namespace Content.Shared.Interaction
                 rotation = mover.TargetRelativeRotation;
             }
 
-            Transform(item).LocalRotation = rotation;
+            _transform.SetLocalRotation(item, rotation);
         }
         #endregion
 

--- a/Content.Shared/Maps/TurfSystem.cs
+++ b/Content.Shared/Maps/TurfSystem.cs
@@ -14,7 +14,8 @@ namespace Content.Shared.Maps;
 /// </summary>
 public sealed partial class TurfSystem : EntitySystem
 {
-    [Dependency] private IMapManager _mapManager = default!;
+    private readonly HashSet<EntityUid> _tileBlockedIntersecting = new();
+
     [Dependency] private EntityLookupSystem _entityLookup = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private SharedMapSystem _mapSystem = default!;
@@ -32,7 +33,7 @@ public sealed partial class TurfSystem : EntitySystem
             return null;
 
         var pos = _transform.ToMapCoordinates(coordinates);
-        if (!_mapManager.TryFindGridAt(pos, out var gridUid, out var gridComp))
+        if (!_mapSystem.TryFindGridAt(pos, out var gridUid, out var gridComp))
             return null;
 
         if (!_mapSystem.TryGetTileRef(gridUid, gridComp, coordinates, out var tile))
@@ -91,7 +92,9 @@ public sealed partial class TurfSystem : EntitySystem
 
         var intersectionArea = 0f;
         var fixtureQuery = GetEntityQuery<FixturesComponent>();
-        foreach (var ent in _entityLookup.GetEntitiesIntersecting(gridUid, worldBox, LookupFlags.Dynamic | LookupFlags.Static))
+        _tileBlockedIntersecting.Clear();
+        _entityLookup.GetEntitiesIntersecting(gridUid, worldBox, _tileBlockedIntersecting, LookupFlags.Dynamic | LookupFlags.Static);
+        foreach (var ent in _tileBlockedIntersecting)
         {
             if (!fixtureQuery.TryGetComponent(ent, out var fixtures))
                 continue;

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -66,6 +66,7 @@ public abstract partial class SharedMoverController : VirtualController
     private float _minDamping;
     private float _airDamping;
     private float _offGridDamping;
+    private readonly HashSet<EntityUid> _aroundColliderIntersecting = new();
 
     /// <summary>
     /// Cache the mob movement calculation to re-use elsewhere.
@@ -459,7 +460,9 @@ public abstract partial class SharedMoverController : VirtualController
         var (uid, collider, mover, transform) = entity;
         var enlargedAABB = _lookup.GetWorldAABB(entity.Owner, transform).Enlarged(mover.GrabRange);
 
-        foreach (var otherEntity in lookupSystem.GetEntitiesIntersecting(transform.MapID, enlargedAABB))
+        _aroundColliderIntersecting.Clear();
+        lookupSystem.GetEntitiesIntersecting(transform.MapID, enlargedAABB, _aroundColliderIntersecting);
+        foreach (var otherEntity in _aroundColliderIntersecting)
         {
             if (otherEntity == uid)
                 continue; // Don't try to push off of yourself!

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Tile.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Tile.cs
@@ -68,7 +68,7 @@ public abstract partial class SharedToolSystem
         var comp = ent.Comp1!;
         var tool = ent.Comp2!;
 
-        if (!_mapManager.TryFindGridAt(_transformSystem.ToMapCoordinates(clickLocation), out var gridUid, out var mapGrid))
+        if (!_maps.TryFindGridAt(_transformSystem.ToMapCoordinates(clickLocation), out var gridUid, out var mapGrid))
             return false;
 
         var tileRef = _maps.GetTileRef(gridUid, mapGrid, clickLocation);

--- a/Content.Shared/Tools/Systems/SharedToolSystem.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.cs
@@ -19,7 +19,6 @@ namespace Content.Shared.Tools.Systems;
 
 public abstract partial class SharedToolSystem : EntitySystem
 {
-    [Dependency] private   IMapManager _mapManager = default!;
     [Dependency] private   IPrototypeManager _protoMan = default!;
     [Dependency] protected ISharedAdminLogManager AdminLogger = default!;
     [Dependency] private   ITileDefinitionManager _tileDefManager = default!;

--- a/Content.Shared/_CMU14/Threats/Mobs/SubvertedSynth/SubvertedSynthSystem.cs
+++ b/Content.Shared/_CMU14/Threats/Mobs/SubvertedSynth/SubvertedSynthSystem.cs
@@ -11,7 +11,7 @@ public sealed class SubvertedSynthSystem : EntitySystem
         SubscribeLocalEvent<SubvertedSynthComponent, ComponentRemove>(OnRemove);
     }
 
-    // hacky hack just to dirty the entity
+    // Synth visuals derive from SynthComponent, so dirty both components when this marker changes.
     private void OnInit(EntityUid uid, SubvertedSynthComponent comp, ComponentInit args)
     {
         if (TryComp(uid, out SynthComponent? sc)) Dirty(uid, sc);

--- a/Content.Shared/_CMU14/ZLevels/Core/EntitySystems/CMUSharedZLevelsSystem.Movement.cs
+++ b/Content.Shared/_CMU14/ZLevels/Core/EntitySystems/CMUSharedZLevelsSystem.Movement.cs
@@ -55,6 +55,7 @@ public abstract partial class CMUSharedZLevelsSystem
     private EntityQuery<CMUZLevelHighGroundComponent> _highgroundQuery;
     private EntityQuery<CMUVehicleZTraversalComponent> _vehicleTraversalQuery;
     private readonly HashSet<EntityUid> _moveSnapSuppressed = new();
+    private readonly HashSet<EntityUid> _fallImpactVictims = new();
     private readonly HashSet<(EntityUid Puller, EntityUid Pulled)> _deferredPullJointRefreshes = new();
     private readonly List<(EntityUid Puller, EntityUid Pulled)> _deferredPullJointRefreshBuffer = new();
     private readonly List<Vector2> _vehicleSupportSamples = new();
@@ -170,9 +171,10 @@ public abstract partial class CMUSharedZLevelsSystem
         if (_vehicleTraversalQuery.HasComp(ent.Owner))
             return;
 
-        var entitiesAround = _lookup.GetEntitiesInRange(ent, 0.25f, LookupFlags.Uncontained);
+        _fallImpactVictims.Clear();
+        _lookup.GetEntitiesInRange(ent, 0.25f, _fallImpactVictims, LookupFlags.Uncontained);
 
-        foreach (var victim in entitiesAround)
+        foreach (var victim in _fallImpactVictims)
         {
             if (victim == ent.Owner)
                 continue;

--- a/Content.Shared/_CMU14/ZLevels/Ordnance/CMUTopDownOrdnanceSystem.cs
+++ b/Content.Shared/_CMU14/ZLevels/Ordnance/CMUTopDownOrdnanceSystem.cs
@@ -11,7 +11,6 @@ namespace Content.Shared._CMU14.ZLevels.Ordnance;
 public sealed partial class CMUTopDownOrdnanceSystem : EntitySystem
 {
     [Dependency] private AreaSystem _area = default!;
-    [Dependency] private IMapManager _mapManager = default!;
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private ITileDefinitionManager _tile = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
@@ -142,7 +141,7 @@ public sealed partial class CMUTopDownOrdnanceSystem : EntitySystem
 
     public bool IsOpening(MapCoordinates coordinates)
     {
-        if (!_mapManager.TryFindGridAt(coordinates, out var gridUid, out var grid))
+        if (!_map.TryFindGridAt(coordinates, out var gridUid, out var grid))
             return true;
 
         var tile = _map.WorldToTile(gridUid, grid, coordinates.Position);

--- a/Content.Shared/_RMC14/Attachable/AttachableData.cs
+++ b/Content.Shared/_RMC14/Attachable/AttachableData.cs
@@ -30,34 +30,34 @@ public partial struct AttachableSlot()
 
 [DataRecord, Serializable, NetSerializable]
 public partial record struct AttachableModifierConditions(
-    bool UnwieldedOnly,
-    bool WieldedOnly,
-    bool ActiveOnly,
-    bool InactiveOnly,
-    EntityWhitelist? Whitelist,
-    EntityWhitelist? Blacklist
+    bool UnwieldedOnly = false,
+    bool WieldedOnly = false,
+    bool ActiveOnly = false,
+    bool InactiveOnly = false,
+    EntityWhitelist? Whitelist = null,
+    EntityWhitelist? Blacklist = null
 );
 
 [DataRecord, Serializable, NetSerializable]
 public partial record struct AttachableWeaponMeleeModifierSet(
-    AttachableModifierConditions? Conditions,
-    DamageSpecifier? BonusDamage,
-    DamageImpactProfile? Impact
+    AttachableModifierConditions? Conditions = null,
+    DamageSpecifier? BonusDamage = null,
+    DamageImpactProfile? Impact = null
 );
 
 [DataRecord, Serializable, NetSerializable]
 public partial record struct AttachableWeaponRangedModifierSet(
-    AttachableModifierConditions? Conditions,
-    FixedPoint2 AccuracyAddMult, // Affects the accuracy of all shots fired by the weapon. Conversion from 13: accuracy_mod or accuracy_unwielded_mod
-    FixedPoint2 DamageFalloffAddMult, // This affects the damage falloff of all shots fired by the weapon. Conversion to RMC: damage_falloff_mod
-    double BurstScatterAddMult, // This affects scatter during burst and full-auto fire. Conversion to RMC: burst_scatter_mod
-    int ShotsPerBurstFlat, // Modifies the maximum number of shots in a burst.
-    FixedPoint2 DamageAddMult, // Additive multiplier to damage.
-    float RecoilFlat, // How much the camera shakes when you shoot.
-    double ScatterFlat, // Scatter in degrees. This is how far bullets go from where you aim. Conversion to RMC: CM_SCATTER * 2
-    float FireDelayFlat, // The delay between each shot. Conversion to RMC: CM_FIRE_DELAY / 10
-    float ProjectileSpeedFlat, // How fast the projectiles move. Conversion to RMC: CM_PROJECTILE_SPEED * 10
-    float RangeFlat // The distance in tiles at which the damage of the projectiles starts to drop off. Conversion to RMC: projectile_max_range_mod
+    AttachableModifierConditions? Conditions = null,
+    FixedPoint2 AccuracyAddMult = default, // Affects the accuracy of all shots fired by the weapon. Conversion from 13: accuracy_mod or accuracy_unwielded_mod
+    FixedPoint2 DamageFalloffAddMult = default, // This affects the damage falloff of all shots fired by the weapon. Conversion to RMC: damage_falloff_mod
+    double BurstScatterAddMult = 0, // This affects scatter during burst and full-auto fire. Conversion to RMC: burst_scatter_mod
+    int ShotsPerBurstFlat = 0, // Modifies the maximum number of shots in a burst.
+    FixedPoint2 DamageAddMult = default, // Additive multiplier to damage.
+    float RecoilFlat = 0f, // How much the camera shakes when you shoot.
+    double ScatterFlat = 0, // Scatter in degrees. This is how far bullets go from where you aim. Conversion to RMC: CM_SCATTER * 2
+    float FireDelayFlat = 0f, // The delay between each shot. Conversion to RMC: CM_FIRE_DELAY / 10
+    float ProjectileSpeedFlat = 0f, // How fast the projectiles move. Conversion to RMC: CM_PROJECTILE_SPEED * 10
+    float RangeFlat = 0f // The distance in tiles at which the damage of the projectiles starts to drop off. Conversion to RMC: projectile_max_range_mod
 );
 
 [DataRecord, Serializable, NetSerializable]
@@ -80,19 +80,19 @@ public partial record struct AttachableWeaponFireModesModifierSet
 // Then we divide it by the original speed and subtract 1 from the result to get the additive multiplier.
 [DataRecord, Serializable, NetSerializable]
 public partial record struct AttachableSpeedModifierSet(
-    AttachableModifierConditions? Conditions,
-    float Walk, // Default human walk speed: 2.5f
-    float Sprint // Default human sprint speed: 4.5f
+    AttachableModifierConditions? Conditions = null,
+    float Walk = 0f, // Default human walk speed: 2.5f
+    float Sprint = 0f // Default human sprint speed: 4.5f
 );
 
 [DataRecord, Serializable, NetSerializable]
 public partial record struct AttachableSizeModifierSet(
-    AttachableModifierConditions? Conditions,
-    int Size
+    AttachableModifierConditions? Conditions = null,
+    int Size = 0
 );
 
 [DataRecord, Serializable, NetSerializable]
 public partial record struct AttachableWieldDelayModifierSet(
-    AttachableModifierConditions? Conditions,
-    TimeSpan Delay
+    AttachableModifierConditions? Conditions = null,
+    TimeSpan Delay = default
 );

--- a/Content.Shared/_RMC14/Attachable/AttachableData.cs
+++ b/Content.Shared/_RMC14/Attachable/AttachableData.cs
@@ -61,11 +61,16 @@ public partial record struct AttachableWeaponRangedModifierSet(
 );
 
 [DataRecord, Serializable, NetSerializable]
-public partial record struct AttachableWeaponFireModesModifierSet(
-    AttachableModifierConditions? Conditions,
-    SelectiveFire ExtraFireModes,
-    SelectiveFire SetFireMode
-);
+public partial record struct AttachableWeaponFireModesModifierSet
+{
+    public AttachableWeaponFireModesModifierSet()
+    {
+    }
+
+    public AttachableModifierConditions? Conditions { get; set; }
+    public SelectiveFire ExtraFireModes { get; set; }
+    public SelectiveFire SetFireMode { get; set; }
+}
 
 // SS13 has move delay instead of speed. Move delay isn't implemented here, and approximating it through maths like fire delay is scuffed because of how the events used to change speed work.
 // So instead we take the default speed values and use them to convert it to a multiplier beforehand.

--- a/Content.Shared/_RMC14/Attachable/AttachableData.cs
+++ b/Content.Shared/_RMC14/Attachable/AttachableData.cs
@@ -29,36 +29,71 @@ public partial struct AttachableSlot()
 }
 
 [DataRecord, Serializable, NetSerializable]
-public partial record struct AttachableModifierConditions(
-    bool UnwieldedOnly = false,
-    bool WieldedOnly = false,
-    bool ActiveOnly = false,
-    bool InactiveOnly = false,
-    EntityWhitelist? Whitelist = null,
-    EntityWhitelist? Blacklist = null
-);
+public partial record struct AttachableModifierConditions
+{
+    public AttachableModifierConditions()
+    {
+    }
+
+    public bool UnwieldedOnly { get; set; }
+    public bool WieldedOnly { get; set; }
+    public bool ActiveOnly { get; set; }
+    public bool InactiveOnly { get; set; }
+    public EntityWhitelist? Whitelist { get; set; }
+    public EntityWhitelist? Blacklist { get; set; }
+}
 
 [DataRecord, Serializable, NetSerializable]
-public partial record struct AttachableWeaponMeleeModifierSet(
-    AttachableModifierConditions? Conditions = null,
-    DamageSpecifier? BonusDamage = null,
-    DamageImpactProfile? Impact = null
-);
+public partial record struct AttachableWeaponMeleeModifierSet
+{
+    public AttachableWeaponMeleeModifierSet()
+    {
+    }
+
+    public AttachableModifierConditions? Conditions { get; set; }
+    public DamageSpecifier? BonusDamage { get; set; }
+    public DamageImpactProfile? Impact { get; set; }
+}
 
 [DataRecord, Serializable, NetSerializable]
-public partial record struct AttachableWeaponRangedModifierSet(
-    AttachableModifierConditions? Conditions = null,
-    FixedPoint2 AccuracyAddMult = default, // Affects the accuracy of all shots fired by the weapon. Conversion from 13: accuracy_mod or accuracy_unwielded_mod
-    FixedPoint2 DamageFalloffAddMult = default, // This affects the damage falloff of all shots fired by the weapon. Conversion to RMC: damage_falloff_mod
-    double BurstScatterAddMult = 0, // This affects scatter during burst and full-auto fire. Conversion to RMC: burst_scatter_mod
-    int ShotsPerBurstFlat = 0, // Modifies the maximum number of shots in a burst.
-    FixedPoint2 DamageAddMult = default, // Additive multiplier to damage.
-    float RecoilFlat = 0f, // How much the camera shakes when you shoot.
-    double ScatterFlat = 0, // Scatter in degrees. This is how far bullets go from where you aim. Conversion to RMC: CM_SCATTER * 2
-    float FireDelayFlat = 0f, // The delay between each shot. Conversion to RMC: CM_FIRE_DELAY / 10
-    float ProjectileSpeedFlat = 0f, // How fast the projectiles move. Conversion to RMC: CM_PROJECTILE_SPEED * 10
-    float RangeFlat = 0f // The distance in tiles at which the damage of the projectiles starts to drop off. Conversion to RMC: projectile_max_range_mod
-);
+public partial record struct AttachableWeaponRangedModifierSet
+{
+    public AttachableWeaponRangedModifierSet()
+    {
+    }
+
+    public AttachableModifierConditions? Conditions { get; set; }
+
+    // Affects the accuracy of all shots fired by the weapon. Conversion from 13: accuracy_mod or accuracy_unwielded_mod.
+    public FixedPoint2 AccuracyAddMult { get; set; }
+
+    // This affects the damage falloff of all shots fired by the weapon. Conversion to RMC: damage_falloff_mod.
+    public FixedPoint2 DamageFalloffAddMult { get; set; }
+
+    // This affects scatter during burst and full-auto fire. Conversion to RMC: burst_scatter_mod.
+    public double BurstScatterAddMult { get; set; }
+
+    // Modifies the maximum number of shots in a burst.
+    public int ShotsPerBurstFlat { get; set; }
+
+    // Additive multiplier to damage.
+    public FixedPoint2 DamageAddMult { get; set; }
+
+    // How much the camera shakes when you shoot.
+    public float RecoilFlat { get; set; }
+
+    // Scatter in degrees. This is how far bullets go from where you aim. Conversion to RMC: CM_SCATTER * 2.
+    public double ScatterFlat { get; set; }
+
+    // The delay between each shot. Conversion to RMC: CM_FIRE_DELAY / 10.
+    public float FireDelayFlat { get; set; }
+
+    // How fast the projectiles move. Conversion to RMC: CM_PROJECTILE_SPEED * 10.
+    public float ProjectileSpeedFlat { get; set; }
+
+    // The distance in tiles at which the damage of the projectiles starts to drop off. Conversion to RMC: projectile_max_range_mod.
+    public float RangeFlat { get; set; }
+}
 
 [DataRecord, Serializable, NetSerializable]
 public partial record struct AttachableWeaponFireModesModifierSet
@@ -79,20 +114,39 @@ public partial record struct AttachableWeaponFireModesModifierSet
 // We then add the ss13 move delay, and divide 1 by the result to convert it back into speed.
 // Then we divide it by the original speed and subtract 1 from the result to get the additive multiplier.
 [DataRecord, Serializable, NetSerializable]
-public partial record struct AttachableSpeedModifierSet(
-    AttachableModifierConditions? Conditions = null,
-    float Walk = 0f, // Default human walk speed: 2.5f
-    float Sprint = 0f // Default human sprint speed: 4.5f
-);
+public partial record struct AttachableSpeedModifierSet
+{
+    public AttachableSpeedModifierSet()
+    {
+    }
+
+    public AttachableModifierConditions? Conditions { get; set; }
+
+    // Default human walk speed: 2.5f.
+    public float Walk { get; set; }
+
+    // Default human sprint speed: 4.5f.
+    public float Sprint { get; set; }
+}
 
 [DataRecord, Serializable, NetSerializable]
-public partial record struct AttachableSizeModifierSet(
-    AttachableModifierConditions? Conditions = null,
-    int Size = 0
-);
+public partial record struct AttachableSizeModifierSet
+{
+    public AttachableSizeModifierSet()
+    {
+    }
+
+    public AttachableModifierConditions? Conditions { get; set; }
+    public int Size { get; set; }
+}
 
 [DataRecord, Serializable, NetSerializable]
-public partial record struct AttachableWieldDelayModifierSet(
-    AttachableModifierConditions? Conditions = null,
-    TimeSpan Delay = default
-);
+public partial record struct AttachableWieldDelayModifierSet
+{
+    public AttachableWieldDelayModifierSet()
+    {
+    }
+
+    public AttachableModifierConditions? Conditions { get; set; }
+    public TimeSpan Delay { get; set; }
+}

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableHolderSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableHolderSystem.cs
@@ -445,7 +445,9 @@ public sealed partial class AttachableHolderSystem : EntitySystem
     //Detaching
     public void StartDetach(Entity<AttachableHolderComponent> holder, string slotId, EntityUid userUid)
     {
-        if (TryGetAttachable(holder, slotId, out var attachable) && holder.Comp.Slots.ContainsKey(slotId) && !holder.Comp.Slots[slotId].Locked)
+        if (TryGetAttachable(holder, slotId, out var attachable) &&
+            holder.Comp.Slots.TryGetValue(slotId, out var slot) &&
+            !slot.Locked)
             StartDetach(holder, attachable.Owner, userUid);
     }
 

--- a/Content.Shared/_RMC14/Deploy/RMCDeploySystem.cs
+++ b/Content.Shared/_RMC14/Deploy/RMCDeploySystem.cs
@@ -43,6 +43,7 @@ public sealed partial class RMCDeploySystem : EntitySystem
     [Dependency] private SharedAudioSystem _audio = default!;
 
     private List<EntityUid> _toDelete = [];
+    private readonly HashSet<EntityUid> _areaBlockedIntersecting = new();
 
     public override void Initialize()
     {
@@ -371,8 +372,9 @@ public sealed partial class RMCDeploySystem : EntitySystem
             return true;
 
         // Check all entities that actually intersect with the area
-        var entitiesInArea = _lookup.GetEntitiesIntersecting(mapId, area);
-        foreach (var entId in entitiesInArea)
+        _areaBlockedIntersecting.Clear();
+        _lookup.GetEntitiesIntersecting(mapId, area, _areaBlockedIntersecting);
+        foreach (var entId in _areaBlockedIntersecting)
         {
             if (entId == ignore || (user != null && entId == user))
                 continue;

--- a/Content.Shared/_RMC14/Dropship/Weapon/DropshipTerminalWeaponsComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/DropshipTerminalWeaponsComponent.cs
@@ -112,13 +112,18 @@ public sealed partial class DropshipTerminalWeaponsComponent : Component
 
     [DataRecord]
     [Serializable, NetSerializable]
-    public partial record struct Screen(
-        DropshipTerminalWeaponsScreen State,
-        NetEntity? Weapon,
-        NetEntity? System,
-        int? FireMissionId,
-        bool QuickMode
-    );
+    public partial record struct Screen
+    {
+        public Screen()
+        {
+        }
+
+        public DropshipTerminalWeaponsScreen State { get; set; }
+        public NetEntity? Weapon { get; set; }
+        public NetEntity? System { get; set; }
+        public int? FireMissionId { get; set; }
+        public bool QuickMode { get; set; }
+    }
 
     [DataRecord]
     [Serializable, NetSerializable]

--- a/Content.Shared/_RMC14/Language/Systems/SharedLanguageLearningSystem.cs
+++ b/Content.Shared/_RMC14/Language/Systems/SharedLanguageLearningSystem.cs
@@ -56,7 +56,7 @@ public abstract partial class SharedLanguageLearningSystem : EntitySystem
         var result = new StringBuilder(message.Length);
         var lastIndex = 0;
 
-        var matches = WordRegex().Matches(message);
+        var matches = WordRegex.Matches(message);
         foreach (Match match in matches)
         {
             result.Append(message, lastIndex, match.Index - lastIndex);
@@ -156,7 +156,7 @@ public abstract partial class SharedLanguageLearningSystem : EntitySystem
 
     public List<string> ExtractWords(string message)
     {
-        var matches = WordRegex().Matches(message);
+        var matches = WordRegex.Matches(message);
         var words = new List<string>(matches.Count);
 
         foreach (Match match in matches)
@@ -213,8 +213,7 @@ public abstract partial class SharedLanguageLearningSystem : EntitySystem
         return totalWeight > 0 ? totalComprehension / totalWeight : 0f;
     }
 
-    [GeneratedRegex(@"\b[a-zA-Z']+\b")]
-    private static partial Regex WordRegex();
+    private static readonly Regex WordRegex = new(@"\b[a-zA-Z']+\b");
 
     public float GetComprehensionLevel(EntityUid entity, ProtoId<LanguagePrototype> language)
     {

--- a/Content.Shared/_RMC14/Language/Systems/SharedLanguageLearningSystem.cs
+++ b/Content.Shared/_RMC14/Language/Systems/SharedLanguageLearningSystem.cs
@@ -7,13 +7,11 @@ using Robust.Shared.Random;
 
 namespace Content.Shared._RMC14.Language.Systems;
 
-public abstract class SharedLanguageLearningSystem : EntitySystem
+public abstract partial class SharedLanguageLearningSystem : EntitySystem
 {
-    [Dependency] protected readonly SharedLanguageSystem _language = default!;
-    [Dependency] protected readonly IPrototypeManager _prototypeManager = default!;
-    [Dependency] protected readonly IRobustRandom _random = default!;
-
-    protected static readonly Regex WordRegex = new(@"\b[a-zA-Z']+\b", RegexOptions.Compiled);
+    [Dependency] protected SharedLanguageSystem _language = default!;
+    [Dependency] protected IPrototypeManager _prototypeManager = default!;
+    [Dependency] protected IRobustRandom _random = default!;
 
     public string ProcessMessageForListener(EntityUid listener, string message, ProtoId<LanguagePrototype> language)
     {
@@ -23,7 +21,7 @@ public abstract class SharedLanguageLearningSystem : EntitySystem
         if (!TryComp<LanguageLearningComponent>(listener, out var comp))
             return _language.ObfuscateMessage(message, language);
 
-        if (!comp.Languages.ContainsKey(language))
+        if (!comp.Languages.TryGetValue(language, out _))
             return _language.ObfuscateMessage(message, language);
 
         return ProcessMessageWordByWord(message, language, comp);
@@ -37,7 +35,7 @@ public abstract class SharedLanguageLearningSystem : EntitySystem
         if (!TryComp<LanguageLearningComponent>(speaker, out var comp))
             return _language.ObfuscateMessage(message, language);
 
-        if (!comp.Languages.ContainsKey(language))
+        if (!comp.Languages.TryGetValue(language, out _))
             return _language.ObfuscateMessage(message, language);
 
         return ProcessMessageWordByWord(message, language, comp);
@@ -58,7 +56,7 @@ public abstract class SharedLanguageLearningSystem : EntitySystem
         var result = new StringBuilder(message.Length);
         var lastIndex = 0;
 
-        var matches = WordRegex.Matches(message);
+        var matches = WordRegex().Matches(message);
         foreach (Match match in matches)
         {
             result.Append(message, lastIndex, match.Index - lastIndex);
@@ -67,8 +65,8 @@ public abstract class SharedLanguageLearningSystem : EntitySystem
             var wordLower = word.ToLowerInvariant();
 
             var wordComprehension = 0f;
-            if (learnedWords?.ContainsKey(wordLower) == true)
-                wordComprehension = learnedWords[wordLower];
+            if (learnedWords?.TryGetValue(wordLower, out var learnedComprehension) == true)
+                wordComprehension = learnedComprehension;
             else
             {
                 if (previewBoostedWordsRemaining > 0 && previewBoostedWordComprehension > 0f)
@@ -158,7 +156,7 @@ public abstract class SharedLanguageLearningSystem : EntitySystem
 
     public List<string> ExtractWords(string message)
     {
-        var matches = WordRegex.Matches(message);
+        var matches = WordRegex().Matches(message);
         var words = new List<string>(matches.Count);
 
         foreach (Match match in matches)
@@ -214,6 +212,9 @@ public abstract class SharedLanguageLearningSystem : EntitySystem
 
         return totalWeight > 0 ? totalComprehension / totalWeight : 0f;
     }
+
+    [GeneratedRegex(@"\b[a-zA-Z']+\b")]
+    private static partial Regex WordRegex();
 
     public float GetComprehensionLevel(EntityUid entity, ProtoId<LanguagePrototype> language)
     {

--- a/Content.Shared/_RMC14/Language/Systems/SharedLanguageSystem.cs
+++ b/Content.Shared/_RMC14/Language/Systems/SharedLanguageSystem.cs
@@ -7,9 +7,9 @@ using Robust.Shared.Random;
 
 namespace Content.Shared._RMC14.Language.Systems;
 
-public abstract class SharedLanguageSystem : EntitySystem
+public abstract partial class SharedLanguageSystem : EntitySystem
 {
-    [Dependency] protected readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] protected IPrototypeManager _prototypeManager = default!;
     [Dependency] private IRobustRandom _random = default!;
 
     public static readonly ProtoId<LanguagePrototype> CommonLanguage = "English";

--- a/Content.Shared/_RMC14/Medical/Wounds/WoundedComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Wounds/WoundedComponent.cs
@@ -32,15 +32,38 @@ public sealed partial class WoundedComponent : Component
 
 [DataRecord]
 [Serializable, NetSerializable]
-public partial record struct Wound(
-    FixedPoint2 Damage,
-    FixedPoint2 Healed,
-    float Bloodloss,
-    [field: DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
-    TimeSpan? StopBleedAt,
-    WoundType Type,
-    bool Treated
-);
+public partial record struct Wound
+{
+    public Wound()
+    {
+    }
+
+    public Wound(
+        FixedPoint2 damage,
+        FixedPoint2 healed,
+        float bloodloss,
+        TimeSpan? stopBleedAt,
+        WoundType type,
+        bool treated)
+    {
+        Damage = damage;
+        Healed = healed;
+        Bloodloss = bloodloss;
+        StopBleedAt = stopBleedAt;
+        Type = type;
+        Treated = treated;
+    }
+
+    public FixedPoint2 Damage { get; set; }
+    public FixedPoint2 Healed { get; set; }
+    public float Bloodloss { get; set; }
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan? StopBleedAt { get; set; }
+
+    public WoundType Type { get; set; }
+    public bool Treated { get; set; }
+}
 
 [Serializable, NetSerializable]
 public enum WoundType

--- a/Content.Shared/_RMC14/Sentry/SharedSentryTargettingSystem.cs
+++ b/Content.Shared/_RMC14/Sentry/SharedSentryTargettingSystem.cs
@@ -68,18 +68,20 @@ public abstract partial class SharedSentryTargetingSystem : EntitySystem
         targeting.FriendlyFactions.Clear();
         targeting.HumanoidAdded.Clear();
 
-        var iffFactions = new HashSet<EntProtoId<IFFFactionComponent>>();
-        var ev = new GetIFFFactionEvent(SlotFlags.IDCARD | SlotFlags.BELT | SlotFlags.POCKET, iffFactions);
+        _targetIffBuffer.Clear();
+        var ev = new GetIFFFactionEvent(SlotFlags.IDCARD | SlotFlags.BELT | SlotFlags.POCKET, _targetIffBuffer);
         RaiseLocalEvent(deployer, ref ev);
 
-        if (iffFactions.Count > 0)
+        if (_targetIffBuffer.Count > 0)
         {
             foreach (var (sentryFaction, iffFaction) in SentryFactionToIff)
             {
-                if (iffFactions.Contains(iffFaction))
+                if (_targetIffBuffer.Contains(iffFaction))
                     targeting.FriendlyFactions.Add(sentryFaction);
             }
         }
+
+        _targetIffBuffer.Clear();
 
         // Fallback to NPC faction when IFF yielded nothing (no IFF at all, or IFF not in the standard map).
         if (targeting.FriendlyFactions.Count == 0 &&
@@ -109,20 +111,27 @@ public abstract partial class SharedSentryTargetingSystem : EntitySystem
         ent.Comp.FriendlyFactions.Clear();
         ent.Comp.HumanoidAdded.Clear();
 
-        var friendly = factions
-            .Where(f => f != SentryExcludedFaction && f != "Humanoid" && SentryAllowedFactions.Contains(f))
-            .ToHashSet();
+        var includeHumanoid = false;
+        foreach (var faction in factions)
+        {
+            if (faction == "Humanoid")
+            {
+                includeHumanoid = true;
+                continue;
+            }
 
-        if (factions.Contains("Humanoid"))
+            if (faction != SentryExcludedFaction && SentryAllowedFactions.Contains(faction))
+                ent.Comp.FriendlyFactions.Add(faction);
+        }
+
+        if (includeHumanoid)
         {
             foreach (var faction in GetHumanoidFactions())
             {
-                if (friendly.Add(faction))
+                if (ent.Comp.FriendlyFactions.Add(faction))
                     ent.Comp.HumanoidAdded.Add(faction);
             }
         }
-
-        ent.Comp.FriendlyFactions.UnionWith(friendly);
 
         if (_net.IsServer)
             ApplyTargeting(ent);

--- a/Content.Shared/_RMC14/TacticalMap/TacticalMapBlip.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacticalMapBlip.cs
@@ -5,4 +5,38 @@ namespace Content.Shared._RMC14.TacticalMap;
 
 [DataRecord]
 [Serializable, NetSerializable]
-public readonly partial record struct TacticalMapBlip(Vector2i Indices, SpriteSpecifier.Rsi? Image, Color Color, TacticalMapBlipStatus Status, SpriteSpecifier.Rsi? Background, bool HiveLeader, int OccupantCount = 0, int FireteamNumber = 0);
+public readonly partial record struct TacticalMapBlip
+{
+    public TacticalMapBlip()
+    {
+    }
+
+    public TacticalMapBlip(
+        Vector2i indices,
+        SpriteSpecifier.Rsi? image,
+        Color color,
+        TacticalMapBlipStatus status,
+        SpriteSpecifier.Rsi? background,
+        bool hiveLeader,
+        int occupantCount = 0,
+        int fireteamNumber = 0)
+    {
+        Indices = indices;
+        Image = image;
+        Color = color;
+        Status = status;
+        Background = background;
+        HiveLeader = hiveLeader;
+        OccupantCount = occupantCount;
+        FireteamNumber = fireteamNumber;
+    }
+
+    public Vector2i Indices { get; init; }
+    public SpriteSpecifier.Rsi? Image { get; init; }
+    public Color Color { get; init; }
+    public TacticalMapBlipStatus Status { get; init; }
+    public SpriteSpecifier.Rsi? Background { get; init; }
+    public bool HiveLeader { get; init; }
+    public int OccupantCount { get; init; }
+    public int FireteamNumber { get; init; }
+}

--- a/Content.Shared/_RMC14/Vehicle/Core/VehicleSystem.cs
+++ b/Content.Shared/_RMC14/Vehicle/Core/VehicleSystem.cs
@@ -33,6 +33,8 @@ namespace Content.Shared._RMC14.Vehicle;
 
 public sealed partial class VehicleSystem : EntitySystem
 {
+    private readonly HashSet<EntityUid> _exitDestinationIntersecting = new();
+
     [Dependency] private SharedEyeSystem _eye = default!;
     [Dependency] private VehicleViewToggleSystem _viewToggle = default!;
     [Dependency] private INetManager _net = default!;
@@ -579,7 +581,9 @@ public sealed partial class VehicleSystem : EntitySystem
         var tileAabb = Box2.UnitCentered.Scale(0.95f * size).Translated(localPos);
         var worldBox = new Box2Rotated(Box2.UnitCentered.Scale(0.95f * size).Translated(worldPos), gridRot, worldPos);
 
-        foreach (var ent in _lookup.GetEntitiesIntersecting(gridUid, worldBox, LookupFlags.Dynamic | LookupFlags.Static))
+        _exitDestinationIntersecting.Clear();
+        _lookup.GetEntitiesIntersecting(gridUid, worldBox, _exitDestinationIntersecting, LookupFlags.Dynamic | LookupFlags.Static);
+        foreach (var ent in _exitDestinationIntersecting)
         {
             if (ent == vehicle || ent == user)
                 continue;

--- a/Content.Shared/_RMC14/Vehicle/Grid/GridVehicleMoveSystem.Collision.cs
+++ b/Content.Shared/_RMC14/Vehicle/Grid/GridVehicleMoveSystem.Collision.cs
@@ -1558,7 +1558,14 @@ public sealed partial class GridVehicleMoverSystem : EntitySystem
 
         var tileArea = tileAabb.Width * tileAabb.Height;
         var minIntersectionArea = tileArea * PushTileBlockFraction;
-        foreach (var ent in lookup.GetEntitiesIntersecting(gridUid, worldBox, LookupFlags.Dynamic | LookupFlags.Static))
+        PhysicsComponent? mobBody = null;
+        FixturesComponent? mobFixtures = null;
+        var mobHasCollision = physicsQ.TryComp(mob, out mobBody) &&
+                              fixtureQ.TryComp(mob, out mobFixtures);
+
+        _pushTileIntersecting.Clear();
+        lookup.GetEntitiesIntersecting(gridUid, worldBox, _pushTileIntersecting, LookupFlags.Dynamic | LookupFlags.Static);
+        foreach (var ent in _pushTileIntersecting)
         {
             if (ent == vehicle || ent == mob)
                 continue;
@@ -1589,9 +1596,8 @@ public sealed partial class GridVehicleMoverSystem : EntitySystem
             if (!fixtureQ.TryComp(ent, out var fixtures))
                 continue;
 
-            if (physicsQ.TryComp(mob, out var mobBody) &&
-                fixtureQ.TryComp(mob, out var mobFixtures) &&
-                !physics.IsHardCollidable((mob, mobFixtures, mobBody), (ent, fixtures, otherBody)))
+            if (mobHasCollision &&
+                !physics.IsHardCollidable((mob, mobFixtures!, mobBody!), (ent, fixtures, otherBody)))
             {
                 continue;
             }
@@ -1668,8 +1674,9 @@ public sealed partial class GridVehicleMoverSystem : EntitySystem
         if (!checkAabb.IsValid())
             checkAabb = targetAabb;
 
-        var hits = lookup.GetEntitiesIntersecting(mapId, checkAabb, LookupFlags.Dynamic | LookupFlags.Static);
-        foreach (var other in hits)
+        _pushBlockedIntersecting.Clear();
+        lookup.GetEntitiesIntersecting(mapId, checkAabb, _pushBlockedIntersecting, LookupFlags.Dynamic | LookupFlags.Static);
+        foreach (var other in _pushBlockedIntersecting)
         {
             if (other == mob || other == vehicle)
                 continue;

--- a/Content.Shared/_RMC14/Vehicle/Grid/GridVehicleMoveSystem.cs
+++ b/Content.Shared/_RMC14/Vehicle/Grid/GridVehicleMoveSystem.cs
@@ -103,6 +103,8 @@ public sealed partial class GridVehicleMoverSystem : EntitySystem
     public static bool MovementDebugEnabled { get; set; }
 
     private readonly HashSet<EntityUid> _intersecting = new();
+    private readonly HashSet<EntityUid> _pushBlockedIntersecting = new();
+    private readonly HashSet<EntityUid> _pushTileIntersecting = new();
     private readonly List<EntityUid>[] _hitsBuffers = { new(), new(), new() };
     private int _hitsDepth;
     private readonly Dictionary<EntityUid, TimeSpan> _lastMobCollision = new();

--- a/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
@@ -194,12 +194,15 @@ public sealed partial class CMGunSystem : EntitySystem
         if (direction == Vector2.Zero)
             return;
 
+        var directionLength = direction.Length();
+        var normalized = direction / directionLength;
+
         // Check for a max range from the ShootAtFixedPointComponent. If defined, take the minimum between that and the calculated distance.
-        var baseDistance = ent.Comp.MaxFixedRange != null ? Math.Min(ent.Comp.MaxFixedRange.Value, direction.Length()) : direction.Length();
+        var baseDistance = ent.Comp.MaxFixedRange != null ? Math.Min(ent.Comp.MaxFixedRange.Value, directionLength) : directionLength;
 
         if (ent.Comp.AutoAimClosestObstacle)
         {
-            var ray = new CollisionRay(from.Position, direction.Normalized(), ((int)Physics.CollisionGroup.Impassable));
+            var ray = new CollisionRay(from.Position, normalized, ((int)Physics.CollisionGroup.Impassable));
             var hitResults = _physics.IntersectRay(from.MapId, ray, baseDistance, returnOnFirstHit: true);
             if (hitResults.TryFirstOrNull(out var hitResult) && hitResult is RayCastResults trueHit)
             {
@@ -208,7 +211,6 @@ public sealed partial class CMGunSystem : EntitySystem
         }
         // Get current time and normalize the vector for physics math.
         var time = _timing.CurTime;
-        var normalized = direction.Normalized();
 
         // Send each FiredProjectile with a PhysicsComponent off with the same Vector. Max
         foreach (var projectile in args.FiredProjectiles)

--- a/Content.Shared/_RMC14/Weapons/Ranged/Homing/HomingProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Homing/HomingProjectileSystem.cs
@@ -14,9 +14,16 @@ public sealed partial class HomingProjectileSystem : EntitySystem
     [Dependency] private SharedPhysicsSystem _physics = default!;
 
     private readonly List<EntityUid> _toRemove = new();
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+    private EntityQuery<ProjectileComponent> _projectileQuery;
+    private EntityQuery<TransformComponent> _xformQuery;
 
     public override void Initialize()
     {
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
+        _projectileQuery = GetEntityQuery<ProjectileComponent>();
+        _xformQuery = GetEntityQuery<TransformComponent>();
+
         SubscribeLocalEvent<HomingShotsComponent, AmmoShotEvent>(OnAmmoShot);
 
         SubscribeLocalEvent<HomingProjectileComponent, StartCollideEvent>(OnStartCollide);
@@ -73,13 +80,18 @@ public sealed partial class HomingProjectileSystem : EntitySystem
         var query = EntityQueryEnumerator<HomingProjectileComponent>();
         while (query.MoveNext(out var projectile, out var component))
         {
-            if(!TryComp(projectile, out PhysicsComponent? physics))
+            if (!_physicsQuery.TryComp(projectile, out var physics) ||
+                !_xformQuery.TryComp(projectile, out var projectileXform) ||
+                !_xformQuery.TryComp(component.Target, out var targetXform))
+            {
+                _toRemove.Add(projectile);
                 continue;
+            }
 
             // Get the map coordinates and the direction
             var target = component.Target;
-            var targetCoords = _transform.GetMapCoordinates(target, Transform(target));
-            var projectileCoords = _transform.GetMapCoordinates(projectile, Transform(projectile));
+            var targetCoords = _transform.GetMapCoordinates(target, targetXform);
+            var projectileCoords = _transform.GetMapCoordinates(projectile, projectileXform);
             if (targetCoords.MapId != projectileCoords.MapId)
             {
                 _toRemove.Add(projectile);
@@ -87,16 +99,17 @@ public sealed partial class HomingProjectileSystem : EntitySystem
             }
 
             var direction = targetCoords.Position - projectileCoords.Position;
+            var distanceSquared = direction.LengthSquared();
 
             // Remove the homing component once the projectile gets close to it's target.
-            if (_transform.InRange(Transform(projectile).Coordinates, Transform(target).Coordinates, 1f))
+            if (distanceSquared <= 1f)
             {
                 _toRemove.Add(projectile);
                 continue;
             }
 
             // Get the velocity of the target and the projectile
-            var targetMapVelocity = Vector2.Zero + direction.Normalized() * component.ProjectileSpeed;
+            var targetMapVelocity = direction / MathF.Sqrt(distanceSquared) * component.ProjectileSpeed;
             var currentMapVelocity = _physics.GetMapLinearVelocity(projectile, physics);
 
             // Adjust the velocity
@@ -104,7 +117,7 @@ public sealed partial class HomingProjectileSystem : EntitySystem
 
             _physics.SetLinearVelocity(projectile, newLinear, body: physics);
 
-            if (!TryComp(projectile, out ProjectileComponent? projectileComponent))
+            if (!_projectileQuery.TryComp(projectile, out var projectileComponent))
                 continue;
 
             _transform.SetWorldRotationNoLerp(projectile, direction.ToWorldAngle() + projectileComponent.Angle);

--- a/Content.Shared/_RMC14/Weapons/Ranged/IFF/GunIFFSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/IFF/GunIFFSystem.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using Content.Shared._RMC14.Attachable.Systems;
 using Content.Shared.Examine;
 using Content.Shared.Hands.Components;
@@ -108,8 +107,13 @@ public sealed partial class GunIFFSystem : EntitySystem
             user.Comp.Factions.Count == 0)
             return false;
 
-        faction = user.Comp.Factions.First();
-        return true;
+        foreach (var userFaction in user.Comp.Factions)
+        {
+            faction = userFaction;
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -118,12 +122,16 @@ public sealed partial class GunIFFSystem : EntitySystem
     public bool TryGetFaction(Entity<UserIFFComponent?> user, out EntProtoId<IFFFactionComponent> faction, SlotFlags slots = SlotFlags.IDCARD)
     {
         faction = default;
-        var buffer = new HashSet<EntProtoId<IFFFactionComponent>>();
-        if (!TryGetFactions(user, buffer, slots))
+        if (!TryGetFactions(user, _factionBuffer, slots))
             return false;
 
-        faction = buffer.First();
-        return true;
+        foreach (var userFaction in _factionBuffer)
+        {
+            faction = userFaction;
+            return true;
+        }
+
+        return false;
     }
 
     public bool TryGetFactions(Entity<UserIFFComponent?> user, HashSet<EntProtoId<IFFFactionComponent>> factions, SlotFlags slots = SlotFlags.IDCARD)
@@ -134,10 +142,8 @@ public sealed partial class GunIFFSystem : EntitySystem
 
         factions.UnionWith(user.Comp.Factions);
 
-        var ev = new GetIFFFactionEvent(slots, new HashSet<EntProtoId<IFFFactionComponent>>());
+        var ev = new GetIFFFactionEvent(slots, factions);
         RaiseLocalEvent(user, ref ev);
-
-        factions.UnionWith(ev.Factions);
 
         if (factions.Count == 0)
             return false;
@@ -155,10 +161,11 @@ public sealed partial class GunIFFSystem : EntitySystem
                 return true;
         }
 
-        var ev = new GetIFFFactionEvent(SlotFlags.IDCARD, new HashSet<EntProtoId<IFFFactionComponent>>());
+        _factionBuffer.Clear();
+        var ev = new GetIFFFactionEvent(SlotFlags.IDCARD, _factionBuffer);
         RaiseLocalEvent(uid, ref ev);
 
-        if (ev.Factions.Count > 0 && ev.Factions.Contains(faction))
+        if (_factionBuffer.Count > 0 && _factionBuffer.Contains(faction))
             return true;
 
         return false;

--- a/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
@@ -90,6 +90,8 @@ public sealed partial class XenoChargeSystem : EntitySystem
     private EntityQuery<XenoToggleChargingRecentlyHitComponent> _xenoToggleChargingRecentlyHitQuery;
 
     private bool _relativeMovement;
+    private readonly HashSet<Entity<MobStateComponent>> _nearbyMobs = new();
+    private readonly List<EntityUid> _colorFlashTargets = new(1);
     private readonly HashSet<(Entity<ActiveXenoToggleChargingComponent> Crusher, EntityUid Target)> _hit = new();
 
     public override void Initialize()
@@ -364,7 +366,8 @@ public sealed partial class XenoChargeSystem : EntitySystem
             _xenoAnimations.PlayLungeAnimationEvent(xeno, charge);
         }
 
-        foreach (var slower in _lookup.GetEntitiesInRange<MobStateComponent>(_transform.GetMapCoordinates(xeno), xeno.Comp.SlowRange))
+        _lookup.GetEntitiesInRange(_transform.GetMapCoordinates(xeno), xeno.Comp.SlowRange, _nearbyMobs);
+        foreach (var slower in _nearbyMobs)
         {
             if (!_xeno.CanAbilityAttackTarget(xeno, slower))
                 continue;
@@ -427,7 +430,7 @@ public sealed partial class XenoChargeSystem : EntitySystem
         if (damage?.GetTotal() > FixedPoint2.Zero && !TerminatingOrDeleted(targetId))
         {
             var filter = Filter.Pvs(targetId, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);
-            _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { targetId }, filter);
+            RaiseColorFlash(targetId, filter);
         }
 
         if (crush != null && crush.DestroyDamage != null)
@@ -493,7 +496,7 @@ public sealed partial class XenoChargeSystem : EntitySystem
         _damageable.TryChangeDamage(target, ent.Comp.CollisionDamage, origin: ent);
 
         var filter = Filter.Pvs(target, entityManager: EntityManager);
-        _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { target }, filter);
+        RaiseColorFlash(target, filter);
 
         _stun.TryParalyze(target, ent.Comp.KnockdownTime, true);
         _slow.TrySlowdown(target, TimeSpan.FromSeconds(1.5));
@@ -549,8 +552,9 @@ public sealed partial class XenoChargeSystem : EntitySystem
 
         // Find the closest valid mob target near the click position.
         xeno.Comp.PrimaryTarget = null;
-        float closestDist = float.MaxValue;
-        foreach (var mob in _lookup.GetEntitiesInRange<MobStateComponent>(targetMap, 2f))
+        var closestDist = float.MaxValue;
+        _lookup.GetEntitiesInRange(targetMap, 2f, _nearbyMobs);
+        foreach (var mob in _nearbyMobs)
         {
             if (!_xeno.CanAbilityAttackTarget(xeno, mob))
                 continue;
@@ -559,7 +563,7 @@ public sealed partial class XenoChargeSystem : EntitySystem
                 continue;
 
             var mobMap = _transform.GetMapCoordinates(mob);
-            var dist = (mobMap.Position - targetMap.Position).Length();
+            var dist = (mobMap.Position - targetMap.Position).LengthSquared();
             if (dist < closestDist)
             {
                 closestDist = dist;
@@ -906,5 +910,12 @@ public sealed partial class XenoChargeSystem : EntitySystem
             else if (time >= active.LastMovedAt + charging.LastMovedGrace)
                 ResetCharging((uid, active), false);
         }
+    }
+
+    private void RaiseColorFlash(EntityUid target, Filter filter)
+    {
+        _colorFlashTargets.Clear();
+        _colorFlashTargets.Add(target);
+        _colorFlash.RaiseEffect(Color.Red, _colorFlashTargets, filter);
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -530,13 +530,15 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
                 if (existingComp.Tier < newXenoComp.Tier)
                     continue;
 
-                if (slotCount.ContainsKey(existingComp.Role.Id) && slotCount[existingComp.Role.Id] > 0)
-                    slotCount[existingComp.Role.Id] -= 1;
+                if (slotCount.TryGetValue(existingComp.Role.Id, out var freeSlots) && freeSlots > 0)
+                    slotCount[existingComp.Role.Id] = freeSlots - 1;
                 else
                     existing++;
             }
 
-            if (total != 0 && existing / (float) total >= limit && (!slotCount.ContainsKey(newXeno) || slotCount[newXeno] <= 0))
+            if (total != 0 &&
+                existing / (float) total >= limit &&
+                (!slotCount.TryGetValue(newXeno, out var newXenoSlots) || newXenoSlots <= 0))
             {
                 if (doPopup)
                 {

--- a/Content.Shared/_RMC14/Xenonids/Flurry/XenoFlurrySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Flurry/XenoFlurrySystem.cs
@@ -36,6 +36,10 @@ public sealed partial class XenoFlurrySystem : EntitySystem
     [Dependency] private SharedXenoHealSystem _xenoHeal = default!;
     [Dependency] private SharedHitLocationSystem _hitLocation = default!;
 
+    private readonly HashSet<EntityUid> _areaHits = new();
+    private readonly List<EntityUid> _mobs = new();
+    private readonly List<EntityUid> _colorFlashTargets = new(1);
+
     public override void Initialize()
     {
         SubscribeLocalEvent<XenoFlurryComponent, XenoFlurryActionEvent>(OnXenoFlurryAction);
@@ -60,17 +64,19 @@ public sealed partial class XenoFlurrySystem : EntitySystem
         var area = Box2.CenteredAround(xenoCoord.Position, new(1, xeno.Comp.Range)).Translated(new(0, (xeno.Comp.Range / 2) + 0.5f));
         var rot = new Box2Rotated(area, direction, xenoCoord.Position); // Correct the angle
 
-        List<EntityUid> mobs = new();
+        _mobs.Clear();
 
         if (_net.IsClient)
             return;
 
-        foreach (var ent in _lookup.GetEntitiesIntersecting(Transform(xeno).MapID, rot, LookupFlags.Dynamic | LookupFlags.Static))
+        _areaHits.Clear();
+        _lookup.GetEntitiesIntersecting(gridId, rot, _areaHits, LookupFlags.Dynamic | LookupFlags.Static);
+        foreach (var ent in _areaHits)
         {
             if (!_xeno.CanAbilityAttackTarget(xeno, ent))
                 continue;
 
-            mobs.Add(ent);
+            _mobs.Add(ent);
         }
 
         _emote.TryEmoteWithChat(xeno, xeno.Comp.Emote, cooldown: xeno.Comp.EmoteDelay);
@@ -85,7 +91,7 @@ public sealed partial class XenoFlurrySystem : EntitySystem
         EntityUid? hitEnt = null;
         using var targetingSuppression = _hitLocation.SuppressBodyZoneTargeting(xeno.Owner);
 
-        foreach (var victim in mobs)
+        foreach (var victim in _mobs)
         {
             if (!_interaction.InRangeUnobstructed(xeno.Owner, victim, xeno.Comp.Range + 0.5f))
                 continue;
@@ -100,7 +106,7 @@ public sealed partial class XenoFlurrySystem : EntitySystem
             if (change?.GetTotal() > FixedPoint2.Zero)
             {
                 var filter = Filter.Pvs(victim, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);
-                _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { victim }, filter);
+                RaiseColorFlash(victim, filter);
             }
 
             SpawnAttachedTo(xeno.Comp.AttackEffect, victim.ToCoordinates());
@@ -125,5 +131,12 @@ public sealed partial class XenoFlurrySystem : EntitySystem
 
             SpawnAtPosition(xeno.Comp.TelegraphEffect, _turf.GetTileCenter(tile));
         }
+    }
+
+    private void RaiseColorFlash(EntityUid target, Filter filter)
+    {
+        _colorFlashTargets.Clear();
+        _colorFlashTargets.Add(target);
+        _colorFlash.RaiseEffect(Color.Red, _colorFlashTargets, filter);
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/HighGallop/XenoHighGallopSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/HighGallop/XenoHighGallopSystem.cs
@@ -27,6 +27,9 @@ public sealed partial class XenoHighGallopSystem : EntitySystem
     [Dependency] private SharedRMCEmoteSystem _emote = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private RMCSizeStunSystem _size = default!;
+
+    private readonly HashSet<EntityUid> _areaHits = new();
+
     public override void Initialize()
     {
         SubscribeLocalEvent<XenoHighGallopComponent, XenoHighGallopActionEvent>(OnHighGallopAction);
@@ -68,7 +71,9 @@ public sealed partial class XenoHighGallopSystem : EntitySystem
             SpawnAtPosition(spawn, _turf.GetTileCenter(tile));
         }
 
-        foreach (var ent in _lookup.GetEntitiesIntersecting(Transform(xeno).MapID, rot))
+        _areaHits.Clear();
+        _lookup.GetEntitiesIntersecting(gridId, rot, _areaHits);
+        foreach (var ent in _areaHits)
         {
             if (_tags.HasTag(ent, xeno.Comp.Flingable))
             {

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
@@ -45,6 +45,9 @@ namespace Content.Shared._RMC14.Xenonids.Neurotoxin;
 
 public abstract partial class SharedNeurotoxinSystem : EntitySystem
 {
+    private static readonly string[] ModerateNeuroMessages = ["rmc-neuro-very-numb", "rmc-neuro-erratic", "rmc-neuro-panic"];
+    private static readonly string[] SevereNeuroMessages = ["rmc-neuro-pain", "rmc-neuro-agh", "rmc-neuro-so-numb", "rmc-neuro-limbs", "rmc-neuro-think"];
+
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private INetManager _net = default!;
     [Dependency] private EntityLookupSystem _entityLookup = default!;
@@ -297,25 +300,27 @@ public abstract partial class SharedNeurotoxinSystem : EntitySystem
                 continue;
             }
 
-            List<(NeuroHallucinations, int, TimeSpan, EntityCoordinates?)> toRemove = new();
-            List<(NeuroHallucinations, int, TimeSpan, EntityCoordinates?)> toAdd = new();
-
-            foreach (var entry in hallu.Hallucinations)
+            for (var i = 0; i < hallu.Hallucinations.Count;)
             {
+                var entry = hallu.Hallucinations[i];
                 if (entry.Item3 > time)
+                {
+                    i++;
                     continue;
+                }
 
                 var newEntry = ProcessHallucination(uid, hallu, entry);
 
-                toRemove.Add(entry);
-
                 if (newEntry != null)
-                    toAdd.Add(newEntry.Value);
+                {
+                    hallu.Hallucinations[i] = newEntry.Value;
+                    i++;
+                }
+                else
+                {
+                    hallu.Hallucinations.RemoveAt(i);
+                }
             }
-
-            hallu.Hallucinations.RemoveAll(a => toRemove.Contains(a));
-
-            hallu.Hallucinations.AddRange(toAdd);
         }
 
     }
@@ -346,7 +351,7 @@ public abstract partial class SharedNeurotoxinSystem : EntitySystem
             }
             else
             {
-                message = _random.Pick(new List<string> {"rmc-neuro-very-numb", "rmc-neuro-erratic", "rmc-neuro-panic"});
+                message = _random.Pick(ModerateNeuroMessages);
                 poptype = PopupType.MediumCaution;
             }
             coughChance = 0.10f;
@@ -375,7 +380,7 @@ public abstract partial class SharedNeurotoxinSystem : EntitySystem
             }
             else
             {
-                message = _random.Pick(new List<string> { "rmc-neuro-pain", "rmc-neuro-agh", "rmc-neuro-so-numb", "rmc-neuro-limbs", "rmc-neuro-think"});
+                message = _random.Pick(SevereNeuroMessages);
                 poptype = PopupType.LargeCaution;
             }
             coughChance = 0.25f;

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -62,6 +62,11 @@ namespace Content.Shared._RMC14.Xenonids.Parasite;
 
 public abstract partial class SharedXenoParasiteSystem : EntitySystem
 {
+    private static readonly string[] InsanePainSuffixes = ["one", "two", "three", "four", "five"];
+    private static readonly string[] MajorPainSuffixes = ["chest", "breathing", "heart"];
+    private static readonly string[] ThroatPainSuffixes = ["sore", "mucous"];
+    private static readonly string[] MinorPainSuffixes = ["stomach", "chest"];
+
     [Dependency] private SharedActionsSystem _action = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedAppearanceSystem _appearance = default!;
@@ -808,7 +813,7 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
             {
                 if (_random.Prob(infected.InsanePainChance * frameTime))
                 {
-                    var random = _random.Pick(new List<string> { "one", "two", "three", "four", "five" });
+                    var random = _random.Pick(InsanePainSuffixes);
                     var message = Loc.GetString("rmc-xeno-infection-insanepain-" + random);
                     _popup.PopupEntity(message, uid, uid, PopupType.LargeCaution);
 
@@ -821,7 +826,7 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
             {
                 if (_random.Prob(infected.MajorPainChance * frameTime))
                 {
-                    var message = Loc.GetString("rmc-xeno-infection-majorpain-" + _random.Pick(new List<string> { "chest", "breathing", "heart" }));
+                    var message = Loc.GetString("rmc-xeno-infection-majorpain-" + _random.Pick(MajorPainSuffixes));
                     _popup.PopupEntity(message, uid, uid, PopupType.SmallCaution);
                     if (_random.Prob(0.5f))
                     {
@@ -837,7 +842,7 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
             {
                 if (_random.Prob(infected.ThroatPainChance * frameTime))
                 {
-                    var message = Loc.GetString("rmc-xeno-infection-throat-" + _random.Pick(new List<string> { "sore", "mucous" }));
+                    var message = Loc.GetString("rmc-xeno-infection-throat-" + _random.Pick(ThroatPainSuffixes));
                     _popup.PopupEntity(message, uid, uid, PopupType.SmallCaution);
                 }
                 // TODO 20% chance to take limb damage
@@ -849,7 +854,7 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
                 }
                 else if (_random.Prob(infected.SneezeCoughChance * frameTime))
                 {
-                    var emote = _random.Pick(new List<ProtoId<EmotePrototype>> { infected.SneezeId, infected.CoughId });
+                    var emote = _random.Prob(0.5f) ? infected.SneezeId : infected.CoughId;
                     var ev = new VictimInfectedEmoteEvent(emote);
                     RaiseLocalEvent(uid, ref ev);
                 }
@@ -861,7 +866,7 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
             {
                 if (_random.Prob(infected.MinorPainChance * frameTime))
                 {
-                    var message = Loc.GetString("rmc-xeno-infection-minorpain-" + _random.Pick(new List<string> { "stomach", "chest" }));
+                    var message = Loc.GetString("rmc-xeno-infection-minorpain-" + _random.Pick(MinorPainSuffixes));
                     _popup.PopupEntity(message, uid, uid, PopupType.SmallCaution);
                 }
 

--- a/Content.Shared/_RMC14/Xenonids/ScissorCut/XenoScissorCutSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/ScissorCut/XenoScissorCutSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Numerics;
 using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Emote;
@@ -35,6 +34,12 @@ public sealed partial class XenoScissorCutSystem : EntitySystem
     [Dependency] private SharedRMCMeleeWeaponSystem _rmcMelee = default!;
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private TurfSystem _turf = default!;
+
+    private readonly HashSet<EntityUid> _areaHits = new();
+    private readonly List<EntityUid> _destructibles = new();
+    private readonly List<EntityUid> _mobs = new();
+    private readonly List<EntityUid> _colorFlashTargets = new(1);
+
     public override void Initialize()
     {
         SubscribeLocalEvent<XenoScissorCutComponent, XenoScissorCutActionEvent>(OnXenoScissorCutAction);
@@ -61,32 +66,38 @@ public sealed partial class XenoScissorCutSystem : EntitySystem
         var area = Box2.CenteredAround(xenoCoord.Position, new(1, xeno.Comp.Range)).Translated(new(0, (xeno.Comp.Range / 2) + 0.5f));
         var rot = new Box2Rotated(area, direction, xenoCoord.Position); // Correct the angle
 
-        List<EntityUid> destructibles = new();
-        List<EntityUid> mobs = new();
+        _destructibles.Clear();
+        _mobs.Clear();
 
         if (_net.IsClient)
             return;
 
-        foreach (var ent in _lookup.GetEntitiesIntersecting(Transform(xeno).MapID, rot, LookupFlags.Dynamic | LookupFlags.Static))
+        _areaHits.Clear();
+        _lookup.GetEntitiesIntersecting(gridId, rot, _areaHits, LookupFlags.Dynamic | LookupFlags.Static);
+        foreach (var ent in _areaHits)
         {
             if (HasComp<DamageOnXenoScissorsComponent>(ent) || HasComp<DestroyOnXenoPierceScissorComponent>(ent))
             {
-                destructibles.Add(ent);
+                _destructibles.Add(ent);
                 continue;
             }
 
             if (!_xeno.CanAbilityAttackTarget(xeno, ent, false, true))
                 continue;
-            mobs.Add(ent);
+            _mobs.Add(ent);
         }
 
         var selfCoords = _transform.GetMoverCoordinates(xeno);
 
         //Have to sort so multi fence destruction happens in order
-        destructibles = destructibles.OrderBy(a =>
-        (selfCoords.TryDistance(EntityManager, a.ToCoordinates(), out var distance) ? distance : 10)).ToList();
+        _destructibles.Sort((a, b) =>
+        {
+            var aDistance = selfCoords.TryDistance(EntityManager, a.ToCoordinates(), out var distanceA) ? distanceA : 10;
+            var bDistance = selfCoords.TryDistance(EntityManager, b.ToCoordinates(), out var distanceB) ? distanceB : 10;
+            return aDistance.CompareTo(bDistance);
+        });
 
-        foreach (var des in destructibles)
+        foreach (var des in _destructibles)
         {
             if (!_interaction.InRangeUnobstructed(xeno.Owner, des, xeno.Comp.Range + 0.5f))
                 continue;
@@ -98,7 +109,7 @@ public sealed partial class XenoScissorCutSystem : EntitySystem
                 if (dam?.GetTotal() > FixedPoint2.Zero)
                 {
                     var filter = Filter.Pvs(des, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);
-                    _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { des }, filter);
+                    RaiseColorFlash(des, filter);
                 }
 
                 continue;
@@ -119,7 +130,7 @@ public sealed partial class XenoScissorCutSystem : EntitySystem
 
         //Now mobs
         EntityUid? hitEnt = null;
-        foreach (var victim in mobs)
+        foreach (var victim in _mobs)
         {
             if (!_interaction.InRangeUnobstructed(xeno.Owner, victim, xeno.Comp.Range + 0.5f))
                 continue;
@@ -132,7 +143,7 @@ public sealed partial class XenoScissorCutSystem : EntitySystem
             if (change?.GetTotal() > FixedPoint2.Zero)
             {
                 var filter = Filter.Pvs(victim, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);
-                _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { victim }, filter);
+                RaiseColorFlash(victim, filter);
             }
 
             SpawnAttachedTo(xeno.Comp.AttackEffect, victim.ToCoordinates());
@@ -159,5 +170,12 @@ public sealed partial class XenoScissorCutSystem : EntitySystem
 
             SpawnAtPosition(spawn, _turf.GetTileCenter(tile));
         }
+    }
+
+    private void RaiseColorFlash(EntityUid target, Filter filter)
+    {
+        _colorFlashTargets.Clear();
+        _colorFlashTargets.Add(target);
+        _colorFlash.RaiseEffect(Color.Red, _colorFlashTargets, filter);
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/TailLash/XenoTailLashSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/TailLash/XenoTailLashSystem.cs
@@ -37,6 +37,8 @@ public sealed partial class XenoTailLashSystem : EntitySystem
     [Dependency] private SharedStunSystem _stun = default!;
     [Dependency] private RMCPullingSystem _pulling = default!;
 
+    private readonly HashSet<EntityUid> _areaHits = new();
+
     public override void Initialize()
     {
         base.Initialize();
@@ -116,8 +118,15 @@ public sealed partial class XenoTailLashSystem : EntitySystem
             return;
 
         args.Handled = true;
+        if (Transform(xeno).GridUid is not { } gridId)
+        {
+            xeno.Comp.Area = null;
+            return;
+        }
 
-        foreach (var ent in _lookup.GetEntitiesIntersecting(Transform(xeno).MapID, xeno.Comp.Area.Value, LookupFlags.Dynamic | LookupFlags.Static))
+        _areaHits.Clear();
+        _lookup.GetEntitiesIntersecting(gridId, xeno.Comp.Area.Value, _areaHits, LookupFlags.Dynamic | LookupFlags.Static);
+        foreach (var ent in _areaHits)
         {
             if (!_xeno.CanAbilityAttackTarget(xeno, ent))
                 continue;

--- a/Content.Shared/_RMC14/Xenonids/Word/XenoWordQueenSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Word/XenoWordQueenSystem.cs
@@ -88,7 +88,7 @@ public sealed partial class XenoWordQueenSystem : EntitySystem
 
         _xenoPlasma.TryRemovePlasma(queen.Owner, queen.Comp.PlasmaCost);
 
-        text = NewLineRegex().Replace(text, "\n\n");
+        text = NewLineRegex.Replace(text, "\n\n");
         text = _cmChat.SanitizeMessageReplaceWords(queen, text);
         var headerText = Loc.GetString("rmc-xeno-words-of-the-queen-header");
         var wrapped = FormattedMessage.EscapeText(text);
@@ -120,6 +120,5 @@ public sealed partial class XenoWordQueenSystem : EntitySystem
         return false;
     }
 
-    [GeneratedRegex("\n{3,}")]
-    private static partial Regex NewLineRegex();
+    private static readonly Regex NewLineRegex = new("\n{3,}");
 }

--- a/Content.Shared/_RMC14/Xenonids/Word/XenoWordQueenSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Word/XenoWordQueenSystem.cs
@@ -28,7 +28,6 @@ public sealed partial class XenoWordQueenSystem : EntitySystem
     [Dependency] private SharedXenoHiveSystem _hive = default!;
     [Dependency] private XenoPlasmaSystem _xenoPlasma = default!;
 
-    private readonly Regex _newLineRegex = new("\n{3,}", RegexOptions.Compiled);
     private int _characterLimit = 1000;
 
     public override void Initialize()
@@ -89,7 +88,7 @@ public sealed partial class XenoWordQueenSystem : EntitySystem
 
         _xenoPlasma.TryRemovePlasma(queen.Owner, queen.Comp.PlasmaCost);
 
-        text = _newLineRegex.Replace(text, "\n\n");
+        text = NewLineRegex().Replace(text, "\n\n");
         text = _cmChat.SanitizeMessageReplaceWords(queen, text);
         var headerText = Loc.GetString("rmc-xeno-words-of-the-queen-header");
         var wrapped = FormattedMessage.EscapeText(text);
@@ -120,4 +119,7 @@ public sealed partial class XenoWordQueenSystem : EntitySystem
 
         return false;
     }
+
+    [GeneratedRegex("\n{3,}")]
+    private static partial Regex NewLineRegex();
 }


### PR DESCRIPTION
:cl:
- tweak: Updated RobustToolbox to v278.0.0.
- tweak: Reduced allocations in common stuff including IFF, xeno HUD overlays, status effects, and prediction-adjacent systems.
- fix: Updated the CMU xeno port integration test for the v278 upgrade.
- fix: Avoid generated regex IL that Robust sandbox verification rejects.
- fix: Preserve RMC attachable modifier defaults across v278 prototype serialization.
- fix: Prevent disposed entity context menu controls from crashing the client.
- fix: Fixed game audio sometimes staying muted after deafness, unconsciousness, death, or returning from being unfocused.