### PR TITLE
Make Armor system target based on Slots.

### DIFF
--- a/Content.Shared/_RMC14/Armor/CMArmorComponent.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Inventory;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Armor;
@@ -6,6 +7,10 @@ namespace Content.Shared._RMC14.Armor;
 [Access(typeof(CMArmorSystem))]
 public sealed partial class CMArmorComponent : Component
 {
+    [DataField]
+    [Access(typeof(CMArmorSystem), typeof(InventorySystem), Other = AccessPermissions.ReadExecute)]
+    public SlotFlags TargetSlots = SlotFlags.NONE;
+
     // TODO RMC14 other types of armor
     [DataField, AutoNetworkedField]
     public int XenoArmor;

--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -119,7 +119,7 @@ public sealed partial class CMArmorSystem : EntitySystem
         if (!TryComp<XenoComponent>(armored, out var xeno))
             return;
 
-        var ev = new CMGetArmorEvent(SlotFlags.OUTERCLOTHING | SlotFlags.INNERCLOTHING);
+        var ev = new CMGetArmorEvent(armored.Comp.TargetSlots);
         RaiseLocalEvent(armored, ref ev);
         var armorMessage = ev.FrontalArmor == 0 &&
                            ev.SideArmor == 0 &&
@@ -325,8 +325,10 @@ public sealed partial class CMArmorSystem : EntitySystem
 
     private void ModifyDamage(EntityUid ent, ref DamageModifyEvent args)
     {
-        // TODO RMC14 the slot should depend on the part that is receiving the damage once part damage is in
-        var ev = new CMGetArmorEvent(SlotFlags.OUTERCLOTHING | SlotFlags.INNERCLOTHING);
+        if (!TryComp(ent, out CMArmorComponent? armored))
+            return;
+
+        var ev = new CMGetArmorEvent(armored.TargetSlots);
         RaiseLocalEvent(ent, ref ev);
 
         var armorPiercing = args.ArmorPiercing;

--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -325,10 +325,8 @@ public sealed partial class CMArmorSystem : EntitySystem
 
     private void ModifyDamage(EntityUid ent, ref DamageModifyEvent args)
     {
-        if (!TryComp(ent, out CMArmorComponent? armor))
-            return;
-        var armored = armor.TargetSlots;
-        var ev = new CMGetArmorEvent(armored);
+        var slot = TryComp<CMArmorComponent>(ent, out var slot) && slot.TargetSlots;
+        var ev = new CMGetArmorEvent(slot);
         RaiseLocalEvent(ent, ref ev);
 
         var armorPiercing = args.ArmorPiercing;

--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -325,7 +325,10 @@ public sealed partial class CMArmorSystem : EntitySystem
 
     private void ModifyDamage(EntityUid ent, ref DamageModifyEvent args)
     {
-        var ev = new CMGetArmorEvent(armored.TargetSlots);
+        if (!TryComp(ent, out CMArmorComponent? armor))
+            return;
+        var armored = armor.TargetSlots;
+        var ev = new CMGetArmorEvent(armored);
         RaiseLocalEvent(ent, ref ev);
 
         var armorPiercing = args.ArmorPiercing;

--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -325,9 +325,6 @@ public sealed partial class CMArmorSystem : EntitySystem
 
     private void ModifyDamage(EntityUid ent, ref DamageModifyEvent args)
     {
-        if (!TryComp(ent, out CMArmorComponent? armored))
-            return;
-
         var ev = new CMGetArmorEvent(armored.TargetSlots);
         RaiseLocalEvent(ent, ref ev);
 

--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -325,8 +325,7 @@ public sealed partial class CMArmorSystem : EntitySystem
 
     private void ModifyDamage(EntityUid ent, ref DamageModifyEvent args)
     {
-        var slot = TryComp<CMArmorComponent>(ent, out var slot) && slot.TargetSlots;
-        var ev = new CMGetArmorEvent(slot);
+        var ev = new CMGetArmorEvent(args.TargetSlots);
         RaiseLocalEvent(ent, ref ev);
 
         var armorPiercing = args.ArmorPiercing;

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Hands/marine.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Hands/marine.yml
@@ -65,6 +65,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Hands/Gloves/grenadier.rsi
   - type: CMArmor
+    targetSlots: [gloves]
     melee: 40
     bullet: 40
     explosionArmor: 50

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Hands/veteran.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Hands/veteran.yml
@@ -10,6 +10,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Hands/Gloves/veteran.rsi
   - type: CMArmor
+    targetSlots: [gloves]
     melee: 40
     bullet: 40
     explosionArmor: 20

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/basic_helmets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/basic_helmets.yml
@@ -103,6 +103,8 @@
   - type: Tag
     tags:
     - RMCHelmet
+  - type: CMArmor
+    targetSlots: [head]
 
 - type: entity
   parent: RMCHelmetBase

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
@@ -36,7 +36,7 @@
   - type: MoveOrderArmor
   - type: StoreAfterFailedInteract
   - type: CMArmor
-    slot: [outerclothing]
+    targetSlots: [outerclothing]
 
 - type: entity
   parent: [ RMCBaseArmorNoAccessory, RMCBaseUniformAccessoryItemOuterClothing ]

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
@@ -35,6 +35,8 @@
       path: /Audio/_RMC14/Machines/armor_equip.ogg
   - type: MoveOrderArmor
   - type: StoreAfterFailedInteract
+  - type: CMArmor
+    slot: [outerclothing]
 
 - type: entity
   parent: [ RMCBaseArmorNoAccessory, RMCBaseUniformAccessoryItemOuterClothing ]

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/base.yml
@@ -80,6 +80,7 @@
   id: RMCArmoredUniformBase
   components:
   - type: CMArmor
+    targetSlots: [innerclothing]
     bullet: 10
     melee: 10
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Because limb targetting defaults to chest armor.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
More delimb, more fun!
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Armor no longer protects your legs and arms.
