### PR TITLE
Medical/Engineering Pouches Have Supplies + LifeSaver Bag

### DIFF
--- a/Resources/Prototypes/_AU14/Entities/Clothing/Universal/belts.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Universal/belts.yml
@@ -27,6 +27,35 @@
     - id: CMHandsLatex
 
 - type: entity
+  parent: CMBeltMedicBag
+  id: AU14BeltMedicBagFilled
+  suffix: AU14, Filled, Colonist
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMPillCanisterBicaridine
+    - id: CMPillCanisterKelotane
+    - id: CMPillCanisterTricordrazine
+    - id: CMPillCanisterInaprovaline
+    - id: CMPillCanisterDylovene
+    - id: CMPillCanisterDexalin
+    - id: RMCPillCanisterIron
+    - id: AU14PillCanisterTramadol
+    - id: AU14PillCanisterOxycodone
+    - id: AU14PillCanisterOsteoCalc
+    - id: CMEpinephrineAutoInjector
+    - id: AU14NaloxoneAutoInjector
+    - id: CMUSplintItem
+    - id: CMUCastItem
+    - id: CMSurgicalLine
+    - id: CMSynthGraft
+    - id: CMHealthAnalyzer
+    - id: CMRollerBedSpawnFolded
+    - id: CMPortableSurgicalBedSpawnFolded
+    - id: CMBloodPackFull
+      amount: 2
+
+- type: entity
   parent: AU14BeltMedicBagSupportSynth
   id: AU14BeltMedicBagSupportSynthRMC
   suffix: Filled, Support Synth, RMC

--- a/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
@@ -15,6 +15,58 @@
     - id: CMSheetGlassReinforced30
 
 - type: entity
+  parent: RMCPouchElectronics
+  id: AU14PouchElectronicsFilled
+  suffix: AU14, Filled, Colonist
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMAPCElectronics
+      amount: 2
+    - id: RMCPowerCellHigh
+      amount: 2
+    - id: DoorElectronics
+      amount: 2
+
+- type: entity
+  parent: RMCPouchAutoinjector
+  id: AU14PouchAutoinjectorFilled
+  suffix: AU14, Filled, Colonist
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMEpinephrineAutoinjector
+      amount: 3
+    - id: CMDexalinPlusAutoinjector
+      amount: 3
+
+- type: entity
+  parent: RMCPouchMedical
+  id: AU14PouchMedicalFilled
+  suffix: AU14, Filled, Colonist
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMUCoagulantPowder
+      amount: 2
+    - id: CMUBurnGel
+      amount: 2
+    - id: CMUSplintItem
+      amount: 1
+
+- type: entity
+  parent: RMCPouchFirstResponder
+  id: AU14PouchFirstResponderFilled
+  suffix: AU14, Filled, Colonist
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMRollerBedSpawnFolded
+    - id: CMFireExtinguisherPortable
+    - id: AU14NaloxoneAutoInjector
+    - id: CMBodyBagFolded #intended since giving Stasis Body Bag to Colony wouldn't make sense since all Stasis bag's is slow down larva growth and since First Contact and all
+
+- type: entity
   parent: RMCPouchPistol
   id: AU14PouchPistolAlt
   suffix: AU14, Black

--- a/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
@@ -51,8 +51,8 @@
       amount: 2
     - id: CMUBurnGel
       amount: 2
-    - id: CMUSplintItem
-      amount: 1
+    - id: CMUPlainTraumaDressing10
+      amount: 2
 
 - type: entity
   parent: RMCPouchFirstResponder

--- a/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
@@ -35,8 +35,8 @@
   components:
   - type: StorageFill
     contents:
-    - id: CMEpinephrineAutoinjector
-    - id: CMDexalinPlusAutoinjector
+    - id: CMEpinephrineAutoInjector
+    - id: CMDexalinPlusAutoInjector
 
 - type: entity
   parent: RMCPouchMedical

--- a/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
@@ -53,7 +53,7 @@
     - id: CMUBurnGel
       amount: 2
     - id: CMUPlainTraumaDressing10
-      amount: 2
+      amount: 3
 
 - type: entity
   parent: RMCPouchFirstResponder

--- a/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
@@ -4,6 +4,17 @@
   suffix: AU14
 
 - type: entity
+  parent: RMCPouchConstruction
+  id: AU14PouchConstructionFilled
+  suffix: AU14, Filled, Colonist
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMSheetMetal50
+    - id: CMSheetPlasteel50
+    - id: CMSheetGlassReinforced30
+
+- type: entity
   parent: RMCPouchPistol
   id: AU14PouchPistolAlt
   suffix: AU14, Black
@@ -41,14 +52,3 @@
     - state: icon
     - state: closed
       map: [ "holstered" ]
-
-- type: entity
-  parent: RMCPouchConstruction
-  id: AU14PouchConstructionFilled
-  suffix: AU14, Filled, Colonist
-  components:
-  - type: StorageFill
-    contents:
-    - id: CMSheetMetal50
-    - id: CMSheetPlasteel50
-    - id: CMSheetGlassReinforced30

--- a/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
@@ -36,9 +36,7 @@
   - type: StorageFill
     contents:
     - id: CMEpinephrineAutoinjector
-      amount: 3
     - id: CMDexalinPlusAutoinjector
-      amount: 3
 
 - type: entity
   parent: RMCPouchMedical

--- a/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
@@ -36,7 +36,10 @@
   - type: StorageFill
     contents:
     - id: CMEpinephrineAutoInjector
+      amount: 3
     - id: CMDexalinPlusAutoInjector
+      amount: 3
+    - id: AU14NaloxoneAutoInjector
 
 - type: entity
   parent: RMCPouchMedical
@@ -62,6 +65,7 @@
     - id: CMRollerBedSpawnFolded
     - id: CMFireExtinguisherPortable
     - id: AU14NaloxoneAutoInjector
+      amount: 2
     - id: CMBodyBagFolded #intended since giving Stasis Body Bag to Colony wouldn't make sense since all Stasis bag's is slow down larva growth and since First Contact and all
 
 - type: entity

--- a/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
+++ b/Resources/Prototypes/_AU14/Entities/Clothing/Universal/pouches.yml
@@ -41,3 +41,14 @@
     - state: icon
     - state: closed
       map: [ "holstered" ]
+
+- type: entity
+  parent: RMCPouchConstruction
+  id: AU14PouchConstructionFilled
+  suffix: AU14, Filled, Colonist
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMSheetMetal50
+    - id: CMSheetPlasteel50
+    - id: CMSheetGlassReinforced30

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/EROBeltAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/EROBeltAU14.yml
@@ -4,6 +4,6 @@
   minLimit: 1
   maxLimit: 1
   loadouts:
-  - BeltMedicalAU14
+  #- BeltMedicalAU14 Commenented out due to the fact the LifeSaver Bag is flatout better and taking the standard medical belt is a trap
   - BeltMedicBagAU14
   - EngiBeltUtilityFilledAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/MedBeltAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/MedBeltAU14.yml
@@ -4,7 +4,7 @@
   minLimit: 1
   maxLimit: 1
   loadouts:
-  - BeltMedicalAU14
+  #- BeltMedicalAU14
   - BeltMedicBagAU14
 
 # COS

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/belt.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/belt.yml
@@ -21,7 +21,7 @@
 - type: loadout
   id: EngiBeltUtilityFilledAU14
   equipment:
-    belt: CMBeltUtilityFilled
+    belt: AU14BeltUtilityFilled #Replaced CMUtilityBeltFilled with AU14BeltUtilityFilled since the CM lacks both an E-tool and the modified blowtorch, which is importance since Engineer's to not start with welding goggles
 
 - type: loadout
   id: BeltUtilityGeneralAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/belt.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/belt.yml
@@ -36,4 +36,4 @@
 - type: loadout
   id: BeltMedicBagAU14
   equipment:
-    belt: CMBeltMedicBag
+    belt: AU14BeltMedicBagFilled

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/pouches.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/pouches.yml
@@ -46,7 +46,7 @@
 - type: loadout
   id: PouchFirstAidAU14
   equipment:
-    pocket1: RMCPouchFirstAid
+    pocket1: AU14PouchMedicalFilled
 
 - type: loadout
   id: PouchGeneralLargeAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/pouches.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/pouches.yml
@@ -16,7 +16,7 @@
 - type: loadout
   id: RMCPouchConstructionAU14
   equipment:
-    pocket1: RMCPouchConstruction
+    pocket1: AU14PouchConstructionFilled
 
 - type: loadout
   id: PouchAutoinjectorAU14
@@ -78,7 +78,7 @@
 - type: loadout
   id: RMCPouchConstructionRightAU14
   equipment:
-    pocket2: RMCPouchConstruction
+    pocket2: AU14PouchConstructionFilled
 
 - type: loadout
   id: PouchAutoinjectorRightAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/pouches.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/pouches.yml
@@ -21,7 +21,7 @@
 - type: loadout
   id: PouchAutoinjectorAU14
   equipment:
-    pocket1: AU14PouchAutoinjectorFilled
+    pocket1: RMCPouchAutoinjector
 
 - type: loadout
   id: PouchFirstResponderAU14
@@ -83,7 +83,7 @@
 - type: loadout
   id: PouchAutoinjectorRightAU14
   equipment:
-    pocket2: AU14PouchAutoinjectorFilled
+    pocket2: RMCPouchAutoinjector
 
 - type: loadout
   id: PouchFirstResponderRightAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/pouches.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/pouches.yml
@@ -11,7 +11,7 @@
 - type: loadout
   id: RMCPouchElectronicsAU14
   equipment:
-    pocket1: RMCPouchElectronics
+    pocket1: AU14PouchElectronicsFilled
 
 - type: loadout
   id: RMCPouchConstructionAU14
@@ -21,17 +21,17 @@
 - type: loadout
   id: PouchAutoinjectorAU14
   equipment:
-    pocket1: RMCPouchAutoinjector
+    pocket1: AU14PouchAutoinjectorFilled
 
 - type: loadout
   id: PouchFirstResponderAU14
   equipment:
-    pocket1: RMCPouchFirstResponder
+    pocket1: AU14PouchFirstResponderFilled
 
 - type: loadout
   id: PouchMedicalAU14
   equipment:
-    pocket1: RMCPouchMedical
+    pocket1: AU14PouchMedicalFilled
 
 - type: loadout
   id: PouchSyringeFillAU14
@@ -73,7 +73,7 @@
 - type: loadout
   id: RMCPouchElectronicsRightAU14
   equipment:
-    pocket2: RMCPouchElectronics
+    pocket2: AU14PouchElectronicsFilled
 
 - type: loadout
   id: RMCPouchConstructionRightAU14
@@ -83,17 +83,17 @@
 - type: loadout
   id: PouchAutoinjectorRightAU14
   equipment:
-    pocket2: RMCPouchAutoinjector
+    pocket2: AU14PouchAutoinjectorFilled
 
 - type: loadout
   id: PouchFirstResponderRightAU14
   equipment:
-    pocket2: RMCPouchFirstResponder
+    pocket2: AU14PouchFirstResponderFilled
 
 - type: loadout
   id: PouchMedicalRightAU14
   equipment:
-    pocket2: RMCPouchMedical
+    pocket2: AU14PouchMedicalFilled
 
 - type: loadout
   id: PouchSyringeFillRightAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/pouches.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/pouches.yml
@@ -21,7 +21,7 @@
 - type: loadout
   id: PouchAutoinjectorAU14
   equipment:
-    pocket1: RMCPouchAutoinjector
+    pocket1: AU14PouchAutoinjectorFilled
 
 - type: loadout
   id: PouchFirstResponderAU14
@@ -83,7 +83,7 @@
 - type: loadout
   id: PouchAutoinjectorRightAU14
   equipment:
-    pocket2: RMCPouchAutoinjector
+    pocket2: AU14PouchAutoinjectorFilled
 
 - type: loadout
   id: PouchFirstResponderRightAU14

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
@@ -458,6 +458,7 @@
       tags:
       - RMCCircuitboard
       - PowerCell
+      - DoorElectronics #CMU Change
 #      - # TODO RMC14 6 different stock parts
       components:
       - ComputerBoard


### PR DESCRIPTION

## About the PR
Added round start supplies to Medical (Autoinjector/First Responder/Medical) Pouches and Engineering (Construction/Electronics) Pouches. Added round start supplies to Lifesaver Bag. Tweaked the Electronics Pouch Whitelist to accept Door Electronics. Commented out the M276 medical storage rig `CMBeltMedical` due to the fact it is a downgrade in all aspects to the M276 lifesaver bag. Changed the Belt Engineers/ERO's get to choose from `CMBeltUtilityFilled` to `AU14BeltUtilityFilled` since the belt they start with lack an E-tool and because engineers don't start have access to welding goggles, but the AU14 Toolbelt has the modified blowtorch. 

## Why / Balance
Eventually Vendors will be pulled out of more and more maps, at least from what I see, as Barker's was the first to have the vendors removed. Putting supplies in the various Pouches and belts means that at least for the start of the round, the colony will have enough supplies to last until they generate enough money to purchase departmental essentials. 

## Technical details
Created these Filled Pouches with the Suffix `[AU14, Filled, Colonist]` in the path 'ColonialMarinesUniverse\Resources\Prototypes\_AU14\Entities\Clothing\Universal\pouches.yml'
Created the Filled LifeSaver Bag in the path 
'ColonialMarinesUniverse\Resources\Prototypes\_AU14\Entities\Clothing\Universal\belts.yml'
Commented out `BeltMedicalAU14` in `Resources\Prototypes\_CMU14\Roles\Shared\Loadouts\Groups\EROBeltAU14.yml` and in `Resources\Prototypes\_CMU14\Roles\Shared\Loadouts\Groups\MedBeltAU14.yml`
Gave RMCPouchEletronics the whitelist for `-DoorElectronics`

## Media
Life Saver Bag
<img width="500" height="197" alt="image" src="https://github.com/user-attachments/assets/2b12da71-5609-4251-ac84-d48dc14c372b" />
Auto Injector Pouch 
<img width="515" height="85" alt="image" src="https://github.com/user-attachments/assets/235c3514-6648-46a0-aae9-39c0dbda2186" />
FIrst Responder
<img width="391" height="85" alt="image" src="https://github.com/user-attachments/assets/09c82a91-8fb0-4e94-bbe2-9a9616614ac0" />
Medical Pouch
<img width="541" height="110" alt="image" src="https://github.com/user-attachments/assets/4d80d8f8-eb4b-4f53-a262-68995c3b2d68" />
Electronics Pouch 
<img width="458" height="87" alt="image" src="https://github.com/user-attachments/assets/d2992fe0-6663-4c7d-8fc3-93d5190e2ff2" />
Construction Pouch 
<img width="278" height="100" alt="image" src="https://github.com/user-attachments/assets/4d9fdf09-b055-4d3e-86a6-1954e13c1871" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Various Supplies to all Medical/Engineering pouches in loadouts. (Check PR Media For Contents).
- add: The Life Saver bag one can choose in loadouts now has starting medical supplies.
- add: Colony engineering's toolbelts in loadouts now have an E-tool and Modified Blowtorch
- remove: The M276 medical storage rig is no longer a choice to choose for Colony Medical Staff in Loadouts.
- tweak: The electronics Pouch can now fit door electronics. 


