### PR TITLE
Hydroponics job loop price update

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -879,6 +879,7 @@
         Quantity: 2
   - type: Tag
     tags:
+      - Cocoa
       - Ingredient
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -84,6 +84,7 @@
     seedId: meatwheat
   - type: Tag
     tags:
+    - MeatWheat
     - CMUGrain
 
 - type: entity
@@ -109,6 +110,7 @@
         Quantity: 5
   - type: Tag
     tags:
+    - Oat
     - CMUGrain
 
 - type: entity
@@ -125,13 +127,14 @@
     solutions:
       food:
         reagents:
-        - ReagentId: Sugar
+        - ReagentId: RMCSugar
           Quantity: 10
   - type: Produce
     seedId: sugarcane
     #literally not a grain but it's a grass so wtv
   - type: Tag
     tags:
+    - Sugarcane
     - CMUGrain
 
 - type: entity
@@ -152,6 +155,7 @@
     spawnCount: 2
   - type: Tag
     tags:
+    - Papercane
     - CMUGrain
 
 - type: entity
@@ -596,6 +600,7 @@
     seedId: cabbage
   - type: Tag
     tags:
+    - Cabbage
     - Vegetable
   - type: FoodSequenceElement
     entries:
@@ -628,6 +633,7 @@
     seedId: garlic
   - type: Tag
     tags:
+    - Garlic
     - Vegetable
   - type: FoodSequenceElement
     entries:
@@ -760,6 +766,7 @@
         Quantity: 10
   - type: Tag
     tags:
+    - Orange
     - Fruit
   - type: FoodSequenceElement
     entries:
@@ -845,6 +852,7 @@
     slice: FoodPineappleSlice
   - type: Tag
     tags:
+    - Pineapple
     - Fruit
 
 - type: entity
@@ -884,7 +892,6 @@
     entries:
       Burger: Potato
       Taco: Potato
-
 
 - type: entity
   name: tomato
@@ -940,6 +947,7 @@
         acts: [ "Destruction" ]
   - type: Tag
     tags:
+    - Tomato
     - Fruit
     - Vegetable
   - type: FoodSequenceElement
@@ -1075,6 +1083,7 @@
     seedId: eggplant
   - type: Tag
     tags:
+    - Eggplant
     - Fruit
     - Vegetable
 
@@ -1107,6 +1116,7 @@
         Quantity: 10
   - type: Tag
     tags:
+    - Apple
     - Fruit
   - type: FoodSequenceElement
     entries:
@@ -1186,6 +1196,7 @@
       path: /Audio/Effects/packetrip.ogg
   - type: Tag
     tags:
+    - Cocoa
     - Fruit
 
 - type: entity
@@ -1284,6 +1295,7 @@
     slice: FoodOnionSlice
   - type: Tag
     tags:
+    - Onion
     - Vegetable
 
 - type: entity
@@ -1317,6 +1329,7 @@
     slice: FoodOnionRedSlice
   - type: Tag
     tags:
+    - Onion
     - Vegetable
 
 - type: entity
@@ -1984,6 +1997,7 @@
   - type: Tag
     tags:
     - CMUGrain
+    - Rice
 
 - type: entity
   name: soybeans
@@ -2009,6 +2023,7 @@
         Quantity: 5
   - type: Tag
     tags:
+    - Soybeans
     - Vegetable
   - type: FoodSequenceElement
     entries:
@@ -2142,6 +2157,7 @@
     - id: ClothingHeadHatWatermelon
   - type: Tag
     tags:
+    - Watermelon
     - Fruit
 
 - type: entity
@@ -2318,6 +2334,7 @@
         Quantity: 10
   - type: Tag
     tags:
+    - Grape
     - Fruit
 
 - type: entity
@@ -2351,6 +2368,7 @@
         Quantity: 10
   - type: Tag
     tags:
+    - Berries
     - Fruit
   - type: FoodSequenceElement
     entries:
@@ -2449,6 +2467,7 @@
     seedId: pea
   - type: Tag
     tags:
+    - Pea
     - Vegetable
   - type: FoodSequenceElement
     entries:
@@ -2536,6 +2555,7 @@
     - id: PumpkinSeeds
   - type: Tag
     tags:
+    - Pumpkin
     - Fruit
     - Vegetable
 
@@ -2690,6 +2710,7 @@
         Quantity: 5
   - type: Tag
     tags:
+    - Cherry
     - Fruit
   - type: FoodSequenceElement
     entries:

--- a/Resources/Prototypes/_AU14/JobStuff/JobMachines.yml
+++ b/Resources/Prototypes/_AU14/JobStuff/JobMachines.yml
@@ -149,13 +149,71 @@
   components:
   - type: SubmissionStorage
     rewards:
-      Fruit: 2
-      Vegetable: 2
+      Wheat: 5
+      #MeatWheat: TODO
+      Oat: 5
+      Sugarcane: 2.5
+      #Papercane: TODO
+      Banana: 7.5
+      Carrot: 14
+      Cabbage: 11
+      Garlic: 12
+      Lemon: 6
+      Lime: 5
+      Orange: 5
+      Pineapple: 5
+      Potato: 14
+      Tomato: 8.5
+      Eggplant: 8.5
+      Apple: 5
+      Cocoa: 1.25
+      Corn: 17
+      Onion: 17
+      Chili: 7.5
+      Flower: 14
+      Rice: 5
+      Soybeans: 5
+      Watermelon: 36
+      Grape: 10
+      Berries: 3.75
+      Pea: 6
+      Pumpkin: 19
+      #CottonBoll: TODO
+      Cherry: 3
   - type: DisposalUnit
     whitelist:
       tags:
-      - Fruit
-      - Vegetable
+      - Wheat
+      #- MeatWheat
+      - Oat
+      - Sugarcane
+      #- Papercane
+      - Banana
+      - Carrot
+      - Cabbage
+      - Garlic
+      - Lemon
+      - Lime
+      - Orange
+      - Pineapple
+      - Potato
+      - Tomato
+      - Eggplant
+      - Apple
+      - Cocoa
+      - Corn
+      - Onion
+      - Chili
+      - Flower
+      - Rice
+      - Soybeans
+      - Watermelon
+      - Grape
+      - Berries
+      - Pea
+      - Pumpkin
+      #- CottonBoll
+      - Cherry
 
 - type: entity
   parent: RMCCommunicationsConsoleBase

--- a/Resources/Prototypes/_CMU14/cmu_tags.yml
+++ b/Resources/Prototypes/_CMU14/cmu_tags.yml
@@ -6,3 +6,66 @@
 
 - type: Tag
   id: CMUYautjaToolbelt
+
+- type: Tag
+  id: MeatWheat
+
+- type: Tag
+  id: Oat
+
+- type: Tag
+  id: Sugarcane
+
+- type: Tag
+  id: Papercane
+
+- type: Tag
+  id: Cabbage
+
+- type: Tag
+  id: Garlic
+
+- type: Tag
+  id: Orange
+
+- type: Tag
+  id: Pineapple
+
+- type: Tag
+  id: Tomato
+
+- type: Tag
+  id: Eggplant
+
+- type: Tag
+  id: Apple
+
+- type: Tag
+  id: Cocoa
+
+- type: Tag
+  id: Onion
+
+- type: Tag
+  id: Rice
+
+- type: Tag
+  id: Soybeans
+
+- type: Tag
+  id: Watermelon
+
+- type: Tag
+  id: Grape
+
+- type: Tag
+  id: Berries
+
+- type: Tag
+  id: Pea
+
+- type: Tag
+  id: Pumpkin
+
+- type: Tag
+  id: Cherry


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
All of the currently used crops and a few more for future proofing now have different flat prices. Sugarcane now provides RMCSugar. Added a tag to each plant that didn't have one to differentiate them for AUSubmissionPointCrop. The reagent grinder at Sheperds' farm no longer requires power.

## Why / Balance
Increase economy for colonies that have the hydroponics job loop. Make hydroponics better on its own without relying on towercaps.

TODO: Separate or updated hydroponics crate with random seeds to create variance round-to-round.
TODO: Create a submission point that gives bonus money for certain random crop(s). (Possible with .yml, Better with .cs)
TODO: Guidebook?

## Technical details
The price for each crop was based on:
`(30 / Yield) + m - 6`
m = minutes to grow
Multi-harvest plants receive 50% penalty.
Wheat, Oat, Sugarcane, Cocoa, Rice, and Soybeans receive 50% penalty.

**Rewards:**

      Wheat: 5
      #MeatWheat: TODO
      Oat: 5
      Sugarcane: 2.5
      #Papercane: TODO
      Banana: 7.5
      Carrot: 14
      Cabbage: 11
      Garlic: 12
      Lemon: 6
      Lime: 5
      Orange: 5
      Pineapple: 5
      Potato: 14
      Tomato: 8.5
      Eggplant: 8.5
      Apple: 5
      Cocoa: 1.25
      Corn: 17
      Onion: 17
      Chili: 7.5
      Flower: 14
      Rice: 5
      Soybeans: 5
      Watermelon: 36
      Grape: 10
      Berries: 3.75
      Pea: 6
      Pumpkin: 19
      #CottonBoll: TODO
      Cherry: 3

**Changelog**
:cl:
- add: Hydroponics crop price differences
- add: Tags for various crops
- fix: Sugarcane provides RMCSugar