### PR TITLE
Stats

### DIFF
--- a/Content.Client/_CMU14/RoundStatistics/CMURoundStatisticsEui.cs
+++ b/Content.Client/_CMU14/RoundStatistics/CMURoundStatisticsEui.cs
@@ -1,0 +1,45 @@
+using Content.Client.Eui;
+using Content.Shared._CMU14.RoundStatistics;
+using Content.Shared.Eui;
+using JetBrains.Annotations;
+
+namespace Content.Client._CMU14.RoundStatistics;
+
+[UsedImplicitly]
+public sealed class CMURoundStatisticsEui : BaseEui
+{
+    private CMURoundStatisticsWindow? _window;
+
+    public override void Opened()
+    {
+        base.Opened();
+
+        _window = new CMURoundStatisticsWindow();
+        _window.OnRefresh += OnRefresh;
+        _window.OpenCentered();
+    }
+
+    public override void Closed()
+    {
+        base.Closed();
+
+        if (_window != null)
+            _window.OnRefresh -= OnRefresh;
+
+        _window?.Close();
+        _window = null;
+    }
+
+    public override void HandleState(EuiStateBase state)
+    {
+        base.HandleState(state);
+
+        if (state is CMURoundStatisticsEuiState s)
+            _window?.UpdateDashboard(s.Dashboard);
+    }
+
+    private void OnRefresh()
+    {
+        SendMessage(new CMURoundStatisticsRefreshMsg());
+    }
+}

--- a/Content.Client/_CMU14/RoundStatistics/CMURoundStatisticsWindow.cs
+++ b/Content.Client/_CMU14/RoundStatistics/CMURoundStatisticsWindow.cs
@@ -1,0 +1,910 @@
+using System;
+using System.Linq;
+using System.Numerics;
+using Content.Client.Lobby.UI;
+using Content.Client.Stylesheets;
+using Content.Shared._CMU14.RoundStatistics;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Maths;
+using static Robust.Client.UserInterface.Controls.BoxContainer;
+
+namespace Content.Client._CMU14.RoundStatistics;
+
+public sealed class CMURoundStatisticsWindow : DefaultWindow
+{
+    private const float BorderAlpha = 0.85f;
+    private const int BarWidth = 650;
+
+    private static readonly Color Background = Color.FromHex("#071311");
+    private static readonly Color Card = Color.FromHex("#0d1f1c");
+    private static readonly Color CardQuiet = Color.FromHex("#0a1715");
+    private static readonly Color Border = Color.FromHex("#4972A1").WithAlpha(BorderAlpha);
+    private static readonly Color Text = Color.FromHex("#d7f4dc");
+    private static readonly Color Muted = Color.FromHex("#7ea993");
+    private static readonly Color GovforBlue = Color.FromHex("#68a7d8");
+    private static readonly Color XenoRed = Color.FromHex("#d66a7b");
+    private static readonly Color ClfGold = Color.FromHex("#d1b85d");
+    private static readonly Color ColonistGreen = Color.FromHex("#77c88e");
+    private static readonly Color ThreatPurple = Color.FromHex("#c98fda");
+    private static readonly Color DrawGray = Color.FromHex("#b7b7b7");
+    private static readonly Color UnknownGray = Color.FromHex("#666f6b");
+
+    private readonly BoxContainer _modes;
+    private readonly BoxContainer _recent;
+    private readonly Label _summary;
+    private readonly Button _refresh;
+
+    public event Action? OnRefresh;
+
+    public CMURoundStatisticsWindow()
+    {
+        MinSize = new Vector2(900, 680);
+        SetSize = new Vector2(980, 760);
+        Title = "CMU Round Outcomes";
+
+        var root = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            SeparationOverride = 12,
+            Margin = new Thickness(12),
+            HorizontalExpand = true,
+            VerticalExpand = true,
+        };
+
+        var header = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Horizontal,
+            SeparationOverride = 12,
+            HorizontalExpand = true,
+        };
+
+        var headerText = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            SeparationOverride = 2,
+            HorizontalExpand = true,
+        };
+
+        headerText.AddChild(new Label
+        {
+            Text = "Operational Outcomes",
+            FontColorOverride = Text,
+            StyleClasses = { StyleBase.StyleClassLabelHeading },
+            ClipText = true,
+            HorizontalExpand = true,
+        });
+
+        _summary = new Label
+        {
+            Text = "Waiting for data",
+            FontColorOverride = Muted,
+            ClipText = true,
+            HorizontalExpand = true,
+        };
+        headerText.AddChild(_summary);
+        header.AddChild(headerText);
+
+        _refresh = new Button
+        {
+            Text = "Refresh",
+            MinSize = new Vector2(110, 34),
+            VerticalAlignment = VAlignment.Center,
+        };
+        _refresh.OnPressed += _ => OnRefresh?.Invoke();
+        header.AddChild(_refresh);
+
+        root.AddChild(header);
+
+        var tabs = new TabContainer
+        {
+            HorizontalExpand = true,
+            VerticalExpand = true,
+        };
+
+        var overviewTab = new BoxContainer
+        {
+            Name = "Overview",
+            Orientation = LayoutOrientation.Vertical,
+            HorizontalExpand = true,
+            VerticalExpand = true,
+        };
+        var overviewScroll = new ScrollContainer
+        {
+            HScrollEnabled = false,
+            VerticalExpand = true,
+        };
+        _modes = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            SeparationOverride = 12,
+            HorizontalExpand = true,
+        };
+        overviewScroll.AddChild(_modes);
+        overviewTab.AddChild(overviewScroll);
+
+        var recentTab = new BoxContainer
+        {
+            Name = "Recent Rounds",
+            Orientation = LayoutOrientation.Vertical,
+            HorizontalExpand = true,
+            VerticalExpand = true,
+        };
+        var recentScroll = new ScrollContainer
+        {
+            HScrollEnabled = false,
+            VerticalExpand = true,
+        };
+        _recent = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            SeparationOverride = 8,
+            HorizontalExpand = true,
+        };
+        recentScroll.AddChild(_recent);
+        recentTab.AddChild(recentScroll);
+
+        tabs.AddChild(overviewTab);
+        tabs.AddChild(recentTab);
+        root.AddChild(tabs);
+
+        Contents.AddChild(root);
+        CrtLobbyTheme.ApplyWindow(this, useCrtTypography: true);
+    }
+
+    public void UpdateDashboard(CMURoundStatisticsDashboard dashboard)
+    {
+        var totalRounds = dashboard.Modes.Sum(mode => mode.Total);
+        var decidedRounds = dashboard.Modes.Sum(mode => mode.DecidedTotal);
+        _summary.Text = $"{totalRounds} tracked endings, {decidedRounds} decided wins";
+
+        _modes.DisposeAllChildren();
+        foreach (var mode in dashboard.Modes)
+            _modes.AddChild(MakeModePanel(mode));
+
+        _recent.DisposeAllChildren();
+        if (dashboard.RecentRounds.Count == 0)
+        {
+            _recent.AddChild(MakeEmptyPanel("No tracked rounds yet."));
+            return;
+        }
+
+        foreach (var record in dashboard.RecentRounds)
+            _recent.AddChild(MakeRecentRoundPanel(record));
+    }
+
+    private Control MakeModePanel(CMURoundModeStatistics mode)
+    {
+        var panel = MakePanel(Card, Border);
+        var container = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            Margin = new Thickness(12),
+            SeparationOverride = 10,
+            HorizontalExpand = true,
+        };
+
+        container.AddChild(new Label
+        {
+            Text = mode.Title,
+            FontColorOverride = Text,
+            StyleClasses = { StyleBase.StyleClassLabelHeading },
+            ClipText = true,
+            HorizontalExpand = true,
+        });
+        container.AddChild(new Label
+        {
+            Text = $"{mode.Total} tracked endings / {mode.DecidedTotal} decided wins / " +
+                   $"{mode.Draws} draws / {mode.Unknown} unknown",
+            FontColorOverride = Muted,
+            ClipText = true,
+            HorizontalExpand = true,
+        });
+
+        container.AddChild(MakeRateGrid(mode));
+        container.AddChild(MakeInsightGrid(mode));
+        container.AddChild(MakeRecentFormPanel(mode));
+        container.AddChild(MakeOutcomeBar(mode));
+
+        if (mode.Preset == CMURoundStatisticsPreset.DistressSignal)
+            container.AddChild(MakeDistressSplit(mode));
+
+        container.AddChild(MakeOutcomeBreakdown(mode));
+
+        if (mode.Threats.Count > 0)
+            container.AddChild(MakeThreatBreakdown(mode));
+        if (mode.Planets.Count > 0)
+            container.AddChild(MakePlanetBreakdown(mode));
+        if (mode.PlatoonMatchups.Count > 0)
+            container.AddChild(MakePlatoonMatchupBreakdown(mode));
+        if (mode.PlayerCountBands.Count > 0)
+            container.AddChild(MakePlayerCountBreakdown(mode));
+
+        panel.AddChild(container);
+        return panel;
+    }
+
+    private Control MakeRateGrid(CMURoundModeStatistics mode)
+    {
+        var grid = new GridContainer
+        {
+            Columns = 4,
+            HSeparationOverride = 8,
+            VSeparationOverride = 8,
+            HorizontalExpand = true,
+        };
+
+        grid.AddChild(MakeMetric(
+            mode.SideA,
+            $"{FormatRate(mode.SideAWins, mode.DecidedTotal)}",
+            $"{mode.SideAWins} wins",
+            GetSideAColor(mode.Preset)));
+        grid.AddChild(MakeMetric(
+            mode.SideB,
+            $"{FormatRate(mode.SideBWins, mode.DecidedTotal)}",
+            $"{mode.SideBWins} wins",
+            GetSideBColor(mode.Preset)));
+        grid.AddChild(MakeMetric("Draws", mode.Draws.ToString(), "excluded", DrawGray));
+        grid.AddChild(MakeMetric("Unknown", mode.Unknown.ToString(), "excluded", UnknownGray));
+
+        return grid;
+    }
+
+    private Control MakeInsightGrid(CMURoundModeStatistics mode)
+    {
+        var grid = new GridContainer
+        {
+            Columns = 4,
+            HSeparationOverride = 8,
+            VSeparationOverride = 8,
+            HorizontalExpand = true,
+        };
+
+        grid.AddChild(MakeMetric(
+            "Recent 10",
+            FormatRecentForm(mode),
+            $"{mode.RecentForm.Rounds} tracked",
+            Border));
+        grid.AddChild(MakeMetric(
+            "Current Streak",
+            FormatStreak(mode.CurrentStreak),
+            "decided endings",
+            StreakColor(mode.CurrentStreak)));
+        grid.AddChild(MakeMetric(
+            "Longest Streak",
+            FormatStreak(mode.LongestStreak),
+            "decided endings",
+            StreakColor(mode.LongestStreak)));
+        grid.AddChild(MakeMetric(
+            "Avg Duration",
+            FormatDurationOrNone(mode.Durations.AverageSeconds),
+            $"{mode.SideA} {FormatDurationOrNone(mode.Durations.SideAAverageSeconds)} / " +
+            $"{mode.SideB} {FormatDurationOrNone(mode.Durations.SideBAverageSeconds)}",
+            Border));
+
+        return grid;
+    }
+
+    private Control MakeRecentFormPanel(CMURoundModeStatistics mode)
+    {
+        var panel = MakePanel(CardQuiet, Border);
+        var box = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            Margin = new Thickness(8, 6),
+            SeparationOverride = 6,
+            HorizontalExpand = true,
+        };
+
+        var header = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Horizontal,
+            SeparationOverride = 8,
+            HorizontalExpand = true,
+        };
+        header.AddChild(new Label
+        {
+            Text = "Recent Form",
+            FontColorOverride = Text,
+            ClipText = true,
+            HorizontalExpand = true,
+        });
+        header.AddChild(new Label
+        {
+            Text = $"{mode.SideA} {mode.RecentForm.SideAWins} / {mode.SideB} {mode.RecentForm.SideBWins}",
+            FontColorOverride = Muted,
+            ClipText = true,
+            MinWidth = 180,
+        });
+        box.AddChild(header);
+
+        var pips = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Horizontal,
+            SeparationOverride = 4,
+            HorizontalExpand = true,
+        };
+
+        if (mode.RecentForm.Winners.Count == 0)
+        {
+            pips.AddChild(new Label
+            {
+                Text = "No recent rounds",
+                FontColorOverride = Muted,
+                ClipText = true,
+                HorizontalExpand = true,
+            });
+        }
+        else
+        {
+            foreach (var winner in mode.RecentForm.Winners)
+                pips.AddChild(MakeFormPip(WinnerColor(winner)));
+        }
+
+        box.AddChild(pips);
+        panel.AddChild(box);
+        return panel;
+    }
+
+    private static Control MakeFormPip(Color color)
+    {
+        return new PanelContainer
+        {
+            MinSize = new Vector2(18, 18),
+            HorizontalExpand = false,
+            PanelOverride = new StyleBoxFlat
+            {
+                BackgroundColor = color.WithAlpha(0.85f),
+                BorderColor = color,
+                BorderThickness = new Thickness(1),
+            },
+        };
+    }
+
+    private Control MakeMetric(string label, string value, string detail, Color color)
+    {
+        var panel = MakePanel(CardQuiet, color.WithAlpha(BorderAlpha));
+        panel.MinSize = new Vector2(190, 76);
+
+        var box = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            Margin = new Thickness(10, 8),
+            SeparationOverride = 2,
+            HorizontalExpand = true,
+        };
+        box.AddChild(new Label
+        {
+            Text = label,
+            FontColorOverride = Muted,
+            ClipText = true,
+            HorizontalExpand = true,
+        });
+        box.AddChild(new Label
+        {
+            Text = value,
+            FontColorOverride = color,
+            StyleClasses = { StyleNano.StyleClassLabelBig },
+            ClipText = true,
+            HorizontalExpand = true,
+        });
+        box.AddChild(new Label
+        {
+            Text = detail,
+            FontColorOverride = Muted,
+            ClipText = true,
+            HorizontalExpand = true,
+        });
+
+        panel.AddChild(box);
+        return panel;
+    }
+
+    private Control MakeOutcomeBar(CMURoundModeStatistics mode)
+    {
+        var panel = MakePanel(CardQuiet, UnknownGray.WithAlpha(BorderAlpha));
+        panel.HorizontalExpand = false;
+        panel.MinSize = new Vector2(BarWidth, 18);
+
+        var bar = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Horizontal,
+            HorizontalExpand = false,
+            MinSize = new Vector2(BarWidth, 18),
+        };
+
+        if (mode.Total <= 0)
+        {
+            bar.AddChild(MakeBarSegment(BarWidth, UnknownGray));
+        }
+        else
+        {
+            AddBarSegment(bar, mode.SideAWins, mode.Total, GetSideAColor(mode.Preset));
+            AddBarSegment(bar, mode.Draws, mode.Total, DrawGray);
+            AddBarSegment(bar, mode.Unknown, mode.Total, UnknownGray);
+            AddBarSegment(bar, mode.SideBWins, mode.Total, GetSideBColor(mode.Preset));
+        }
+
+        panel.AddChild(bar);
+        return panel;
+    }
+
+    private static void AddBarSegment(BoxContainer bar, int count, int total, Color color)
+    {
+        if (count <= 0)
+            return;
+
+        var width = Math.Max(5, (int) MathF.Round(BarWidth * count / (float) total));
+        bar.AddChild(MakeBarSegment(width, color));
+    }
+
+    private static Control MakeBarSegment(int width, Color color)
+    {
+        return new PanelContainer
+        {
+            MinSize = new Vector2(width, 18),
+            HorizontalExpand = false,
+            PanelOverride = new StyleBoxFlat
+            {
+                BackgroundColor = color,
+                BorderColor = color,
+                BorderThickness = new Thickness(0),
+            },
+        };
+    }
+
+    private Control MakeOutcomeBreakdown(CMURoundModeStatistics mode)
+    {
+        var box = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            SeparationOverride = 6,
+            HorizontalExpand = true,
+        };
+
+        box.AddChild(MakeSectionLabel("Outcome Breakdown"));
+
+        if (mode.Outcomes.Count == 0)
+        {
+            box.AddChild(MakeEmptyPanel("No outcomes recorded for this mode."));
+            return box;
+        }
+
+        foreach (var outcome in mode.Outcomes)
+            box.AddChild(MakeBreakdownRow(
+                OutcomeName(outcome.Outcome),
+                $"{WinnerName(outcome.Winner)} / {FormatRate(outcome.Count, mode.Total)} of endings",
+                outcome.Count,
+                WinnerColor(outcome.Winner)));
+
+        return box;
+    }
+
+    private Control MakeDistressSplit(CMURoundModeStatistics mode)
+    {
+        var box = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            SeparationOverride = 6,
+            HorizontalExpand = true,
+        };
+
+        box.AddChild(MakeSectionLabel("Distress Signal Major / Minor Split"));
+        box.AddChild(MakeOutcomeSplitRow(
+            mode,
+            CMURoundStatisticsOutcome.XenoMajorHijackWin,
+            "Xeno major",
+            "Hijack win",
+            XenoRed));
+        box.AddChild(MakeOutcomeSplitRow(
+            mode,
+            CMURoundStatisticsOutcome.XenoMinorHijackLoss,
+            "Xeno minor",
+            "Hijack loss",
+            XenoRed));
+        box.AddChild(MakeOutcomeSplitRow(
+            mode,
+            CMURoundStatisticsOutcome.MarineMinorHiveCollapse,
+            "Marine minor",
+            "Hive collapse",
+            GovforBlue));
+        box.AddChild(MakeOutcomeSplitRow(
+            mode,
+            CMURoundStatisticsOutcome.MarineMajorXenoWipe,
+            "Marine major",
+            "Pre-hijack xeno wipe",
+            GovforBlue));
+        box.AddChild(MakeOutcomeSplitRow(
+            mode,
+            CMURoundStatisticsOutcome.DrawAlmayerAutodestruct,
+            "Draw",
+            "Almayer autodestruct",
+            DrawGray));
+
+        return box;
+    }
+
+    private Control MakeOutcomeSplitRow(
+        CMURoundModeStatistics mode,
+        CMURoundStatisticsOutcome outcome,
+        string label,
+        string detail,
+        Color color)
+    {
+        var count = mode.Outcomes
+            .Where(entry => entry.Outcome == outcome)
+            .Sum(entry => entry.Count);
+
+        return MakeBreakdownRow(label, $"{detail} / {FormatRate(count, mode.Total)}", count, color);
+    }
+
+    private Control MakeThreatBreakdown(CMURoundModeStatistics mode)
+    {
+        var box = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            SeparationOverride = 6,
+            HorizontalExpand = true,
+        };
+
+        box.AddChild(MakeSectionLabel("Threat Breakdown"));
+
+        foreach (var threat in mode.Threats)
+        {
+            var decided = threat.SideAWins + threat.SideBWins;
+            var text = $"{mode.SideA} {FormatRate(threat.SideAWins, decided)} ({threat.SideAWins}) / " +
+                       $"{mode.SideB} {FormatRate(threat.SideBWins, decided)} ({threat.SideBWins})";
+            if (threat.Draws > 0)
+                text += $" / draws {threat.Draws}";
+            if (threat.Unknown > 0)
+                text += $" / unknown {threat.Unknown}";
+
+            box.AddChild(MakeBreakdownRow(threat.ThreatId, text, threat.Total, Border));
+        }
+
+        return box;
+    }
+
+    private Control MakePlanetBreakdown(CMURoundModeStatistics mode)
+    {
+        var box = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            SeparationOverride = 6,
+            HorizontalExpand = true,
+        };
+
+        box.AddChild(MakeSectionLabel("Planet Breakdown"));
+
+        foreach (var planet in mode.Planets)
+        {
+            var decided = planet.SideAWins + planet.SideBWins;
+            var text = $"{mode.SideA} {FormatRate(planet.SideAWins, decided)} ({planet.SideAWins}) / " +
+                       $"{mode.SideB} {FormatRate(planet.SideBWins, decided)} ({planet.SideBWins}) / " +
+                       $"avg {FormatDurationOrNone(planet.AverageDurationSeconds)}";
+            if (planet.Draws > 0)
+                text += $" / draws {planet.Draws}";
+            if (planet.Unknown > 0)
+                text += $" / unknown {planet.Unknown}";
+
+            box.AddChild(MakeBreakdownRow(planet.PlanetId, text, planet.Total, Border));
+        }
+
+        return box;
+    }
+
+    private Control MakePlatoonMatchupBreakdown(CMURoundModeStatistics mode)
+    {
+        var box = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            SeparationOverride = 6,
+            HorizontalExpand = true,
+        };
+
+        box.AddChild(MakeSectionLabel("Platoon Matchups"));
+
+        foreach (var matchup in mode.PlatoonMatchups)
+        {
+            var decided = matchup.SideAWins + matchup.SideBWins;
+            var text = $"{mode.SideA} {FormatRate(matchup.SideAWins, decided)} ({matchup.SideAWins}) / " +
+                       $"{mode.SideB} {FormatRate(matchup.SideBWins, decided)} ({matchup.SideBWins})";
+            if (matchup.Draws > 0)
+                text += $" / draws {matchup.Draws}";
+            if (matchup.Unknown > 0)
+                text += $" / unknown {matchup.Unknown}";
+
+            box.AddChild(MakeBreakdownRow(
+                $"{matchup.GovforPlatoonId} vs {matchup.OpforPlatoonId}",
+                text,
+                matchup.Total,
+                Border));
+        }
+
+        return box;
+    }
+
+    private Control MakePlayerCountBreakdown(CMURoundModeStatistics mode)
+    {
+        var box = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            SeparationOverride = 6,
+            HorizontalExpand = true,
+        };
+
+        box.AddChild(MakeSectionLabel("Player Count Bands"));
+
+        foreach (var band in mode.PlayerCountBands)
+        {
+            var decided = band.SideAWins + band.SideBWins;
+            var text = $"{mode.SideA} {FormatRate(band.SideAWins, decided)} ({band.SideAWins}) / " +
+                       $"{mode.SideB} {FormatRate(band.SideBWins, decided)} ({band.SideBWins})";
+            if (band.Draws > 0)
+                text += $" / draws {band.Draws}";
+            if (band.Unknown > 0)
+                text += $" / unknown {band.Unknown}";
+
+            box.AddChild(MakeBreakdownRow(band.Band, text, band.Total, Border));
+        }
+
+        return box;
+    }
+
+    private Control MakeBreakdownRow(string left, string right, int count, Color color)
+    {
+        var panel = MakePanel(CardQuiet, color.WithAlpha(BorderAlpha));
+        var row = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Horizontal,
+            Margin = new Thickness(8, 6),
+            SeparationOverride = 10,
+            HorizontalExpand = true,
+        };
+
+        row.AddChild(MakeBadge(count.ToString(), color));
+        row.AddChild(new Label
+        {
+            Text = left,
+            FontColorOverride = Text,
+            ClipText = true,
+            HorizontalExpand = true,
+        });
+        row.AddChild(new Label
+        {
+            Text = right,
+            FontColorOverride = Muted,
+            ClipText = true,
+            MinWidth = 240,
+        });
+
+        panel.AddChild(row);
+        return panel;
+    }
+
+    private Control MakeRecentRoundPanel(CMURoundOutcomeRecord record)
+    {
+        var color = WinnerColor(record.Winner);
+        var panel = MakePanel(CardQuiet, color.WithAlpha(BorderAlpha));
+        var box = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            Margin = new Thickness(10, 8),
+            SeparationOverride = 4,
+            HorizontalExpand = true,
+        };
+
+        box.AddChild(new Label
+        {
+            Text = $"Round {record.RoundId} - {PresetName(record.Preset)} - {WinnerName(record.Winner)}",
+            FontColorOverride = color,
+            ClipText = true,
+            HorizontalExpand = true,
+        });
+        box.AddChild(new Label
+        {
+            Text = OutcomeName(record.Outcome),
+            FontColorOverride = Text,
+            ClipText = true,
+            HorizontalExpand = true,
+        });
+
+        var threat = string.IsNullOrWhiteSpace(record.SelectedThreatId)
+            ? "no threat"
+            : $"threat {record.SelectedThreatId}";
+        var planet = string.IsNullOrWhiteSpace(record.PlanetId)
+            ? "no planet"
+            : $"planet {record.PlanetId}";
+
+        box.AddChild(new Label
+        {
+            Text = $"{record.PlayerCount} players / {FormatDuration(record.DurationSeconds)} / {threat} / {planet} / {record.RecordedAt:yyyy-MM-dd HH:mm} UTC",
+            FontColorOverride = Muted,
+            ClipText = true,
+            HorizontalExpand = true,
+        });
+
+        panel.AddChild(box);
+        return panel;
+    }
+
+    private Control MakeEmptyPanel(string text)
+    {
+        var panel = MakePanel(CardQuiet, UnknownGray.WithAlpha(BorderAlpha));
+        panel.AddChild(new Label
+        {
+            Text = text,
+            FontColorOverride = Muted,
+            Margin = new Thickness(10, 8),
+            ClipText = true,
+            HorizontalExpand = true,
+        });
+        return panel;
+    }
+
+    private static Label MakeSectionLabel(string text)
+    {
+        return new Label
+        {
+            Text = text,
+            FontColorOverride = Text,
+            StyleClasses = { StyleBase.StyleClassLabelSubText },
+            ClipText = true,
+            HorizontalExpand = true,
+        };
+    }
+
+    private static Control MakeBadge(string label, Color color)
+    {
+        var panel = MakePanel(Background, color.WithAlpha(BorderAlpha));
+        panel.HorizontalExpand = false;
+        panel.MinSize = new Vector2(Math.Max(28, label.Length * 8 + 14), 20);
+        panel.AddChild(new Label
+        {
+            Text = label,
+            FontColorOverride = color,
+            Margin = new Thickness(7, 2),
+            ClipText = true,
+        });
+        return panel;
+    }
+
+    private static PanelContainer MakePanel(Color background, Color border)
+    {
+        return new PanelContainer
+        {
+            HorizontalExpand = true,
+            PanelOverride = new StyleBoxFlat
+            {
+                BackgroundColor = background,
+                BorderColor = border,
+                BorderThickness = new Thickness(1),
+            },
+        };
+    }
+
+    private static string FormatRate(int wins, int decided)
+    {
+        return decided <= 0
+            ? "0.0%"
+            : $"{wins * 100f / decided:0.0}%";
+    }
+
+    private static string FormatRecentForm(CMURoundModeStatistics mode)
+    {
+        if (mode.RecentForm.Rounds == 0)
+            return "No data";
+
+        return $"{mode.RecentForm.SideAWins}-{mode.RecentForm.SideBWins}";
+    }
+
+    private static string FormatStreak(CMURoundStreak streak)
+    {
+        return streak.Count <= 0
+            ? "None"
+            : $"{WinnerName(streak.Winner)} x{streak.Count}";
+    }
+
+    private static Color StreakColor(CMURoundStreak streak)
+    {
+        return streak.Count <= 0
+            ? UnknownGray
+            : WinnerColor(streak.Winner);
+    }
+
+    private static string FormatDuration(int seconds)
+    {
+        var duration = TimeSpan.FromSeconds(Math.Max(0, seconds));
+        return $"{(int) duration.TotalHours:00}:{duration.Minutes:00}:{duration.Seconds:00}";
+    }
+
+    private static string FormatDurationOrNone(int seconds)
+    {
+        return seconds <= 0
+            ? "No data"
+            : FormatDuration(seconds);
+    }
+
+    private static string PresetName(CMURoundStatisticsPreset preset)
+    {
+        return preset switch
+        {
+            CMURoundStatisticsPreset.DistressSignal => "Distress Signal",
+            CMURoundStatisticsPreset.Insurgency => "Insurgency",
+            CMURoundStatisticsPreset.ColonyFall => "Colony Fall",
+            _ => preset.ToString(),
+        };
+    }
+
+    private static string WinnerName(CMURoundStatisticsWinner winner)
+    {
+        return winner switch
+        {
+            CMURoundStatisticsWinner.Xeno => "Xeno",
+            CMURoundStatisticsWinner.Govfor => "Govfor",
+            CMURoundStatisticsWinner.Clf => "CLF",
+            CMURoundStatisticsWinner.Colonists => "Colonists",
+            CMURoundStatisticsWinner.Threat => "Threat",
+            CMURoundStatisticsWinner.Draw => "Draw",
+            CMURoundStatisticsWinner.Unknown => "Unknown",
+            _ => winner.ToString(),
+        };
+    }
+
+    private static string OutcomeName(CMURoundStatisticsOutcome outcome)
+    {
+        return outcome switch
+        {
+            CMURoundStatisticsOutcome.XenoMajorHijackWin => "Xeno major - hijack win",
+            CMURoundStatisticsOutcome.XenoMinorHijackLoss => "Xeno minor - hijack loss / xenowipe",
+            CMURoundStatisticsOutcome.MarineMinorHiveCollapse => "Marine minor - hive collapse",
+            CMURoundStatisticsOutcome.MarineMajorXenoWipe => "Marine major - pre-hijack xeno wipe",
+            CMURoundStatisticsOutcome.DrawAlmayerAutodestruct => "Draw - Almayer autodestruct",
+            CMURoundStatisticsOutcome.InsurgencyClfVictory => "CLF victory",
+            CMURoundStatisticsOutcome.InsurgencyGovforVictory => "Govfor victory",
+            CMURoundStatisticsOutcome.ColonyFallThreatVictory => "Threat victory",
+            CMURoundStatisticsOutcome.ColonyFallSurvivorVictory => "Colonist victory",
+            CMURoundStatisticsOutcome.Unknown => "Unknown / manual ending",
+            _ => outcome.ToString(),
+        };
+    }
+
+    private static Color WinnerColor(CMURoundStatisticsWinner winner)
+    {
+        return winner switch
+        {
+            CMURoundStatisticsWinner.Xeno => XenoRed,
+            CMURoundStatisticsWinner.Govfor => GovforBlue,
+            CMURoundStatisticsWinner.Clf => ClfGold,
+            CMURoundStatisticsWinner.Colonists => ColonistGreen,
+            CMURoundStatisticsWinner.Threat => ThreatPurple,
+            CMURoundStatisticsWinner.Draw => DrawGray,
+            CMURoundStatisticsWinner.Unknown => UnknownGray,
+            _ => Text,
+        };
+    }
+
+    private static Color GetSideAColor(CMURoundStatisticsPreset preset)
+    {
+        return preset switch
+        {
+            CMURoundStatisticsPreset.DistressSignal => XenoRed,
+            CMURoundStatisticsPreset.Insurgency => GovforBlue,
+            CMURoundStatisticsPreset.ColonyFall => ColonistGreen,
+            _ => Text,
+        };
+    }
+
+    private static Color GetSideBColor(CMURoundStatisticsPreset preset)
+    {
+        return preset switch
+        {
+            CMURoundStatisticsPreset.DistressSignal => GovforBlue,
+            CMURoundStatisticsPreset.Insurgency => ClfGold,
+            CMURoundStatisticsPreset.ColonyFall => ThreatPurple,
+            _ => Text,
+        };
+    }
+}

--- a/Content.Server.Database/CMUModel.cs
+++ b/Content.Server.Database/CMUModel.cs
@@ -1,0 +1,48 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Content.Server.Database;
+
+[Table("cmu_round_outcomes")]
+[Index(nameof(PresetId))]
+[Index(nameof(SelectedThreatId))]
+[Index(nameof(RecordedAt))]
+public sealed class CMURoundOutcome
+{
+    [Key, ForeignKey(nameof(Round))]
+    public int RoundId { get; set; }
+
+    public Round Round { get; set; } = default!;
+
+    [StringLength(64)]
+    public string PresetId { get; set; } = string.Empty;
+
+    [StringLength(64)]
+    public string Winner { get; set; } = string.Empty;
+
+    [StringLength(96)]
+    public string Outcome { get; set; } = string.Empty;
+
+    [StringLength(96)]
+    public string Source { get; set; } = string.Empty;
+
+    [StringLength(96)]
+    public string? SelectedThreatId { get; set; }
+
+    [StringLength(96)]
+    public string? PlanetId { get; set; }
+
+    [StringLength(96)]
+    public string? GovforPlatoonId { get; set; }
+
+    [StringLength(96)]
+    public string? OpforPlatoonId { get; set; }
+
+    public int PlayerCount { get; set; }
+
+    public int DurationSeconds { get; set; }
+
+    public DateTime RecordedAt { get; set; }
+}

--- a/Content.Server.Database/Migrations/Postgres/20260701000001_CMURoundOutcomes.cs
+++ b/Content.Server.Database/Migrations/Postgres/20260701000001_CMURoundOutcomes.cs
@@ -1,0 +1,66 @@
+using System;
+using Content.Server.Database;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Content.Server.Database.Migrations.Postgres
+{
+    [DbContext(typeof(PostgresServerDbContext))]
+    [Migration("20260701000001_CMURoundOutcomes")]
+    public partial class CMURoundOutcomes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "cmu_round_outcomes",
+                columns: table => new
+                {
+                    round_id = table.Column<int>(type: "integer", nullable: false),
+                    preset_id = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    winner = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    outcome = table.Column<string>(type: "character varying(96)", maxLength: 96, nullable: false),
+                    source = table.Column<string>(type: "character varying(96)", maxLength: 96, nullable: false),
+                    selected_threat_id = table.Column<string>(type: "character varying(96)", maxLength: 96, nullable: true),
+                    planet_id = table.Column<string>(type: "character varying(96)", maxLength: 96, nullable: true),
+                    govfor_platoon_id = table.Column<string>(type: "character varying(96)", maxLength: 96, nullable: true),
+                    opfor_platoon_id = table.Column<string>(type: "character varying(96)", maxLength: 96, nullable: true),
+                    player_count = table.Column<int>(type: "integer", nullable: false),
+                    duration_seconds = table.Column<int>(type: "integer", nullable: false),
+                    recorded_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cmu_round_outcomes", x => x.round_id);
+                    table.ForeignKey(
+                        name: "FK_cmu_round_outcomes_round_round_id",
+                        column: x => x.round_id,
+                        principalTable: "round",
+                        principalColumn: "round_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cmu_round_outcomes_preset_id",
+                table: "cmu_round_outcomes",
+                column: "preset_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cmu_round_outcomes_recorded_at",
+                table: "cmu_round_outcomes",
+                column: "recorded_at");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cmu_round_outcomes_selected_threat_id",
+                table: "cmu_round_outcomes",
+                column: "selected_threat_id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "cmu_round_outcomes");
+        }
+    }
+}

--- a/Content.Server.Database/Migrations/Postgres/PostgresServerDbContextModelSnapshot.cs
+++ b/Content.Server.Database/Migrations/Postgres/PostgresServerDbContextModelSnapshot.cs
@@ -1050,6 +1050,83 @@ namespace Content.Server.Database.Migrations.Postgres
                     b.ToTable("profile_role_loadout", (string)null);
                 });
 
+            modelBuilder.Entity("Content.Server.Database.CMURoundOutcome", b =>
+                {
+                    b.Property<int>("RoundId")
+                        .HasColumnType("integer")
+                        .HasColumnName("round_id");
+
+                    b.Property<int>("DurationSeconds")
+                        .HasColumnType("integer")
+                        .HasColumnName("duration_seconds");
+
+                    b.Property<string>("GovforPlatoonId")
+                        .HasMaxLength(96)
+                        .HasColumnType("character varying(96)")
+                        .HasColumnName("govfor_platoon_id");
+
+                    b.Property<string>("OpforPlatoonId")
+                        .HasMaxLength(96)
+                        .HasColumnType("character varying(96)")
+                        .HasColumnName("opfor_platoon_id");
+
+                    b.Property<string>("Outcome")
+                        .IsRequired()
+                        .HasMaxLength(96)
+                        .HasColumnType("character varying(96)")
+                        .HasColumnName("outcome");
+
+                    b.Property<string>("PlanetId")
+                        .HasMaxLength(96)
+                        .HasColumnType("character varying(96)")
+                        .HasColumnName("planet_id");
+
+                    b.Property<int>("PlayerCount")
+                        .HasColumnType("integer")
+                        .HasColumnName("player_count");
+
+                    b.Property<string>("PresetId")
+                        .IsRequired()
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)")
+                        .HasColumnName("preset_id");
+
+                    b.Property<DateTime>("RecordedAt")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("recorded_at");
+
+                    b.Property<string>("SelectedThreatId")
+                        .HasMaxLength(96)
+                        .HasColumnType("character varying(96)")
+                        .HasColumnName("selected_threat_id");
+
+                    b.Property<string>("Source")
+                        .IsRequired()
+                        .HasMaxLength(96)
+                        .HasColumnType("character varying(96)")
+                        .HasColumnName("source");
+
+                    b.Property<string>("Winner")
+                        .IsRequired()
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)")
+                        .HasColumnName("winner");
+
+                    b.HasKey("RoundId")
+                        .HasName("PK_cmu_round_outcomes");
+
+                    b.HasIndex("PresetId")
+                        .HasDatabaseName("IX_cmu_round_outcomes_preset_id");
+
+                    b.HasIndex("RecordedAt")
+                        .HasDatabaseName("IX_cmu_round_outcomes_recorded_at");
+
+                    b.HasIndex("SelectedThreatId")
+                        .HasDatabaseName("IX_cmu_round_outcomes_selected_threat_id");
+
+                    b.ToTable("cmu_round_outcomes", (string)null);
+                });
+
             modelBuilder.Entity("Content.Server.Database.RMCChatBans", b =>
                 {
                     b.Property<int>("Id")
@@ -2318,6 +2395,18 @@ namespace Content.Server.Database.Migrations.Postgres
                         .HasConstraintName("FK_profile_role_loadout_profile_profile_id");
 
                     b.Navigation("Profile");
+                });
+
+            modelBuilder.Entity("Content.Server.Database.CMURoundOutcome", b =>
+                {
+                    b.HasOne("Content.Server.Database.Round", "Round")
+                        .WithOne()
+                        .HasForeignKey("Content.Server.Database.CMURoundOutcome", "RoundId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired()
+                        .HasConstraintName("FK_cmu_round_outcomes_round_round_id");
+
+                    b.Navigation("Round");
                 });
 
             modelBuilder.Entity("Content.Server.Database.RMCChatBans", b =>

--- a/Content.Server.Database/Migrations/Sqlite/20260701000000_CMURoundOutcomes.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20260701000000_CMURoundOutcomes.cs
@@ -1,0 +1,66 @@
+using System;
+using Content.Server.Database;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Content.Server.Database.Migrations.Sqlite
+{
+    [DbContext(typeof(SqliteServerDbContext))]
+    [Migration("20260701000000_CMURoundOutcomes")]
+    public partial class CMURoundOutcomes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "cmu_round_outcomes",
+                columns: table => new
+                {
+                    round_id = table.Column<int>(type: "INTEGER", nullable: false),
+                    preset_id = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    winner = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    outcome = table.Column<string>(type: "TEXT", maxLength: 96, nullable: false),
+                    source = table.Column<string>(type: "TEXT", maxLength: 96, nullable: false),
+                    selected_threat_id = table.Column<string>(type: "TEXT", maxLength: 96, nullable: true),
+                    planet_id = table.Column<string>(type: "TEXT", maxLength: 96, nullable: true),
+                    govfor_platoon_id = table.Column<string>(type: "TEXT", maxLength: 96, nullable: true),
+                    opfor_platoon_id = table.Column<string>(type: "TEXT", maxLength: 96, nullable: true),
+                    player_count = table.Column<int>(type: "INTEGER", nullable: false),
+                    duration_seconds = table.Column<int>(type: "INTEGER", nullable: false),
+                    recorded_at = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cmu_round_outcomes", x => x.round_id);
+                    table.ForeignKey(
+                        name: "FK_cmu_round_outcomes_round_round_id",
+                        column: x => x.round_id,
+                        principalTable: "round",
+                        principalColumn: "round_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cmu_round_outcomes_preset_id",
+                table: "cmu_round_outcomes",
+                column: "preset_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cmu_round_outcomes_recorded_at",
+                table: "cmu_round_outcomes",
+                column: "recorded_at");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cmu_round_outcomes_selected_threat_id",
+                table: "cmu_round_outcomes",
+                column: "selected_threat_id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "cmu_round_outcomes");
+        }
+    }
+}

--- a/Content.Server.Database/Migrations/Sqlite/SqliteServerDbContextModelSnapshot.cs
+++ b/Content.Server.Database/Migrations/Sqlite/SqliteServerDbContextModelSnapshot.cs
@@ -995,6 +995,83 @@ namespace Content.Server.Database.Migrations.Sqlite
                     b.ToTable("profile_role_loadout", (string)null);
                 });
 
+            modelBuilder.Entity("Content.Server.Database.CMURoundOutcome", b =>
+                {
+                    b.Property<int>("RoundId")
+                        .HasColumnType("INTEGER")
+                        .HasColumnName("round_id");
+
+                    b.Property<int>("DurationSeconds")
+                        .HasColumnType("INTEGER")
+                        .HasColumnName("duration_seconds");
+
+                    b.Property<string>("GovforPlatoonId")
+                        .HasMaxLength(96)
+                        .HasColumnType("TEXT")
+                        .HasColumnName("govfor_platoon_id");
+
+                    b.Property<string>("OpforPlatoonId")
+                        .HasMaxLength(96)
+                        .HasColumnType("TEXT")
+                        .HasColumnName("opfor_platoon_id");
+
+                    b.Property<string>("Outcome")
+                        .IsRequired()
+                        .HasMaxLength(96)
+                        .HasColumnType("TEXT")
+                        .HasColumnName("outcome");
+
+                    b.Property<string>("PlanetId")
+                        .HasMaxLength(96)
+                        .HasColumnType("TEXT")
+                        .HasColumnName("planet_id");
+
+                    b.Property<int>("PlayerCount")
+                        .HasColumnType("INTEGER")
+                        .HasColumnName("player_count");
+
+                    b.Property<string>("PresetId")
+                        .IsRequired()
+                        .HasMaxLength(64)
+                        .HasColumnType("TEXT")
+                        .HasColumnName("preset_id");
+
+                    b.Property<DateTime>("RecordedAt")
+                        .HasColumnType("TEXT")
+                        .HasColumnName("recorded_at");
+
+                    b.Property<string>("SelectedThreatId")
+                        .HasMaxLength(96)
+                        .HasColumnType("TEXT")
+                        .HasColumnName("selected_threat_id");
+
+                    b.Property<string>("Source")
+                        .IsRequired()
+                        .HasMaxLength(96)
+                        .HasColumnType("TEXT")
+                        .HasColumnName("source");
+
+                    b.Property<string>("Winner")
+                        .IsRequired()
+                        .HasMaxLength(64)
+                        .HasColumnType("TEXT")
+                        .HasColumnName("winner");
+
+                    b.HasKey("RoundId")
+                        .HasName("PK_cmu_round_outcomes");
+
+                    b.HasIndex("PresetId")
+                        .HasDatabaseName("IX_cmu_round_outcomes_preset_id");
+
+                    b.HasIndex("RecordedAt")
+                        .HasDatabaseName("IX_cmu_round_outcomes_recorded_at");
+
+                    b.HasIndex("SelectedThreatId")
+                        .HasDatabaseName("IX_cmu_round_outcomes_selected_threat_id");
+
+                    b.ToTable("cmu_round_outcomes", (string)null);
+                });
+
             modelBuilder.Entity("Content.Server.Database.RMCChatBans", b =>
                 {
                     b.Property<int>("Id")
@@ -2233,6 +2310,18 @@ namespace Content.Server.Database.Migrations.Sqlite
                         .HasConstraintName("FK_profile_role_loadout_profile_profile_id");
 
                     b.Navigation("Profile");
+                });
+
+            modelBuilder.Entity("Content.Server.Database.CMURoundOutcome", b =>
+                {
+                    b.HasOne("Content.Server.Database.Round", "Round")
+                        .WithOne()
+                        .HasForeignKey("Content.Server.Database.CMURoundOutcome", "RoundId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired()
+                        .HasConstraintName("FK_cmu_round_outcomes_round_round_id");
+
+                    b.Navigation("Round");
                 });
 
             modelBuilder.Entity("Content.Server.Database.RMCChatBans", b =>

--- a/Content.Server.Database/Model.cs
+++ b/Content.Server.Database/Model.cs
@@ -64,6 +64,9 @@ namespace Content.Server.Database
         public DbSet<RMCPlayerActionOrder> RMCPlayerActionOrder { get; set; } = default!;
         public DbSet<RMCChatBans> RMCPlayerChatBans { get; set; } = default!;
 
+        // CMU14
+        public DbSet<CMURoundOutcome> CMURoundOutcomes { get; set; } = default!;
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Preference>()
@@ -170,6 +173,12 @@ namespace Content.Server.Database
 
             modelBuilder.Entity<Round>()
                 .HasIndex(round => round.StartDate);
+
+            modelBuilder.Entity<CMURoundOutcome>()
+                .HasOne(outcome => outcome.Round)
+                .WithOne()
+                .HasForeignKey<CMURoundOutcome>(outcome => outcome.RoundId)
+                .OnDelete(DeleteBehavior.Cascade);
 
             modelBuilder.Entity<AdminLogPlayer>()
                 .HasKey(logPlayer => new {logPlayer.RoundId, logPlayer.LogId, logPlayer.PlayerUserId});

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -14,6 +14,7 @@ using Content.Shared._RMC14.NamedItems;
 using Content.Shared.Administration.Logs;
 using Content.Shared.AU14.Allegiance;
 using Content.Shared.AU14.Origin;
+using Content.Shared._CMU14.RoundStatistics;
 using Content.Shared._CMU14.Threats;
 using Content.Shared.Construction.Prototypes;
 using Content.Shared.Database;
@@ -1099,6 +1100,358 @@ INSERT INTO player_round (players_id, rounds_id) VALUES ({players[player]}, {id}
             }
 
             await db.DbContext.SaveChangesAsync();
+        }
+
+        public async Task UpsertCMURoundOutcome(CMURoundOutcomeRecord record)
+        {
+            await using var db = await GetDb();
+
+            var outcome = await db.DbContext.CMURoundOutcomes
+                .FirstOrDefaultAsync(outcome => outcome.RoundId == record.RoundId);
+
+            outcome ??= db.DbContext.CMURoundOutcomes
+                .Add(new CMURoundOutcome { RoundId = record.RoundId })
+                .Entity;
+
+            outcome.PresetId = record.Preset.ToString();
+            outcome.Winner = record.Winner.ToString();
+            outcome.Outcome = record.Outcome.ToString();
+            outcome.Source = record.Source;
+            outcome.SelectedThreatId = record.SelectedThreatId;
+            outcome.PlanetId = record.PlanetId;
+            outcome.GovforPlatoonId = record.GovforPlatoonId;
+            outcome.OpforPlatoonId = record.OpforPlatoonId;
+            outcome.PlayerCount = record.PlayerCount;
+            outcome.DurationSeconds = record.DurationSeconds;
+            outcome.RecordedAt = record.RecordedAt.ToUniversalTime();
+
+            await db.DbContext.SaveChangesAsync();
+        }
+
+        public async Task<CMURoundStatisticsDashboard> GetCMURoundStatisticsDashboard(
+            int recentRounds,
+            CancellationToken cancel = default)
+        {
+            await using var db = await GetDb();
+
+            var records = (await db.DbContext.CMURoundOutcomes
+                    .AsNoTracking()
+                    .OrderByDescending(outcome => outcome.RecordedAt)
+                    .ToListAsync(cancel))
+                .Select(MakeCMURoundOutcomeRecord)
+                .ToList();
+
+            var modes = new List<CMURoundModeStatistics>
+            {
+                BuildModeStatistics(
+                    records,
+                    CMURoundStatisticsPreset.DistressSignal,
+                    "Distress Signal",
+                    "Xeno",
+                    "Govfor"),
+                BuildModeStatistics(
+                    records,
+                    CMURoundStatisticsPreset.Insurgency,
+                    "Insurgency",
+                    "Govfor",
+                    "CLF"),
+                BuildModeStatistics(
+                    records,
+                    CMURoundStatisticsPreset.ColonyFall,
+                    "Colony Fall",
+                    "Colonists",
+                    "Threat"),
+            };
+
+            return new CMURoundStatisticsDashboard(
+                modes,
+                records.Take(Math.Max(0, recentRounds)).ToList());
+        }
+
+        private CMURoundOutcomeRecord MakeCMURoundOutcomeRecord(CMURoundOutcome outcome)
+        {
+            var preset = Enum.TryParse(outcome.PresetId, out CMURoundStatisticsPreset parsedPreset)
+                ? parsedPreset
+                : CMURoundStatisticsPreset.DistressSignal;
+            var winner = Enum.TryParse(outcome.Winner, out CMURoundStatisticsWinner parsedWinner)
+                ? parsedWinner
+                : CMURoundStatisticsWinner.Unknown;
+            var result = Enum.TryParse(outcome.Outcome, out CMURoundStatisticsOutcome parsedOutcome)
+                ? parsedOutcome
+                : CMURoundStatisticsOutcome.Unknown;
+
+            return new CMURoundOutcomeRecord(
+                outcome.RoundId,
+                preset,
+                winner,
+                result,
+                outcome.Source,
+                outcome.SelectedThreatId,
+                outcome.PlanetId,
+                outcome.GovforPlatoonId,
+                outcome.OpforPlatoonId,
+                outcome.PlayerCount,
+                outcome.DurationSeconds,
+                NormalizeDatabaseTime(outcome.RecordedAt));
+        }
+
+        private static CMURoundModeStatistics BuildModeStatistics(
+            List<CMURoundOutcomeRecord> records,
+            CMURoundStatisticsPreset preset,
+            string title,
+            string sideA,
+            string sideB)
+        {
+            var modeRecords = records
+                .Where(record => record.Preset == preset)
+                .OrderByDescending(record => record.RecordedAt)
+                .ThenByDescending(record => record.RoundId)
+                .ToList();
+
+            var sideAWins = modeRecords.Count(IsSideAWin);
+            var sideBWins = modeRecords.Count(IsSideBWin);
+            var draws = modeRecords.Count(record => record.Winner == CMURoundStatisticsWinner.Draw);
+            var unknown = modeRecords.Count(record => record.Winner == CMURoundStatisticsWinner.Unknown);
+            var recentRecords = modeRecords.Take(10).ToList();
+
+            var outcomes = modeRecords
+                .GroupBy(record => new { record.Outcome, record.Winner })
+                .OrderByDescending(group => group.Count())
+                .ThenBy(group => group.Key.Outcome.ToString())
+                .Select(group => new CMURoundOutcomeBreakdown(
+                    group.Key.Outcome,
+                    group.Key.Winner,
+                    group.Count()))
+                .ToList();
+
+            var threats = modeRecords
+                .Where(record => !string.IsNullOrWhiteSpace(record.SelectedThreatId))
+                .GroupBy(record => record.SelectedThreatId!)
+                .OrderByDescending(group => group.Count())
+                .ThenBy(group => group.Key)
+                .Select(group =>
+                {
+                    var groupedRecords = group.ToList();
+                    return new CMURoundThreatBreakdown(
+                        group.Key,
+                        groupedRecords.Count(IsSideAWin),
+                        groupedRecords.Count(IsSideBWin),
+                        groupedRecords.Count(record => record.Winner == CMURoundStatisticsWinner.Draw),
+                        groupedRecords.Count(record => record.Winner == CMURoundStatisticsWinner.Unknown),
+                        groupedRecords.Count);
+                })
+                .ToList();
+
+            var planets = modeRecords
+                .Where(record => !string.IsNullOrWhiteSpace(record.PlanetId))
+                .GroupBy(record => record.PlanetId!.Trim())
+                .OrderByDescending(group => group.Count())
+                .ThenBy(group => group.Key)
+                .Select(group =>
+                {
+                    var groupedRecords = group.ToList();
+                    return new CMURoundPlanetBreakdown(
+                        group.Key,
+                        groupedRecords.Count(IsSideAWin),
+                        groupedRecords.Count(IsSideBWin),
+                        groupedRecords.Count(record => record.Winner == CMURoundStatisticsWinner.Draw),
+                        groupedRecords.Count(record => record.Winner == CMURoundStatisticsWinner.Unknown),
+                        groupedRecords.Count,
+                        AverageDurationSeconds(groupedRecords));
+                })
+                .ToList();
+
+            var platoonMatchups = modeRecords
+                .Where(record => !string.IsNullOrWhiteSpace(record.GovforPlatoonId) ||
+                                 !string.IsNullOrWhiteSpace(record.OpforPlatoonId))
+                .GroupBy(record => new
+                {
+                    Govfor = string.IsNullOrWhiteSpace(record.GovforPlatoonId)
+                        ? "Unknown"
+                        : record.GovforPlatoonId!.Trim(),
+                    Opfor = string.IsNullOrWhiteSpace(record.OpforPlatoonId)
+                        ? "Unknown"
+                        : record.OpforPlatoonId!.Trim(),
+                })
+                .OrderByDescending(group => group.Count())
+                .ThenBy(group => group.Key.Govfor)
+                .ThenBy(group => group.Key.Opfor)
+                .Select(group =>
+                {
+                    var groupedRecords = group.ToList();
+                    return new CMURoundPlatoonMatchupBreakdown(
+                        group.Key.Govfor,
+                        group.Key.Opfor,
+                        groupedRecords.Count(IsSideAWin),
+                        groupedRecords.Count(IsSideBWin),
+                        groupedRecords.Count(record => record.Winner == CMURoundStatisticsWinner.Draw),
+                        groupedRecords.Count(record => record.Winner == CMURoundStatisticsWinner.Unknown),
+                        groupedRecords.Count);
+                })
+                .ToList();
+
+            return new CMURoundModeStatistics(
+                preset,
+                title,
+                sideA,
+                sideB,
+                sideAWins,
+                sideBWins,
+                draws,
+                unknown,
+                outcomes,
+                threats,
+                new CMURoundRecentForm(
+                    recentRecords.Count,
+                    recentRecords.Count(IsSideAWin),
+                    recentRecords.Count(IsSideBWin),
+                    recentRecords.Count(record => record.Winner == CMURoundStatisticsWinner.Draw),
+                    recentRecords.Count(record => record.Winner == CMURoundStatisticsWinner.Unknown),
+                    recentRecords.Select(record => record.Winner).ToList()),
+                BuildCurrentStreak(modeRecords),
+                BuildLongestStreak(modeRecords),
+                new CMURoundDurationBreakdown(
+                    AverageDurationSeconds(modeRecords),
+                    AverageDurationSeconds(modeRecords.Where(IsSideAWin)),
+                    AverageDurationSeconds(modeRecords.Where(IsSideBWin)),
+                    AverageDurationSeconds(modeRecords.Where(record => record.Winner == CMURoundStatisticsWinner.Draw)),
+                    AverageDurationSeconds(modeRecords.Where(record => record.Winner == CMURoundStatisticsWinner.Unknown))),
+                planets,
+                platoonMatchups,
+                BuildPlayerCountBands(modeRecords));
+        }
+
+        private static CMURoundStreak BuildCurrentStreak(List<CMURoundOutcomeRecord> records)
+        {
+            if (records.Count == 0)
+                return new CMURoundStreak(CMURoundStatisticsWinner.Unknown, 0);
+
+            var winner = GetDecidedWinner(records.FirstOrDefault());
+            if (winner == null)
+                return new CMURoundStreak(CMURoundStatisticsWinner.Unknown, 0);
+
+            var count = 0;
+            foreach (var record in records)
+            {
+                if (GetDecidedWinner(record) != winner)
+                    break;
+
+                count++;
+            }
+
+            return new CMURoundStreak(winner.Value, count);
+        }
+
+        private static CMURoundStreak BuildLongestStreak(List<CMURoundOutcomeRecord> records)
+        {
+            var bestWinner = CMURoundStatisticsWinner.Unknown;
+            var bestCount = 0;
+            CMURoundStatisticsWinner? currentWinner = null;
+            var currentCount = 0;
+
+            foreach (var record in records.OrderBy(record => record.RecordedAt).ThenBy(record => record.RoundId))
+            {
+                var winner = GetDecidedWinner(record);
+                if (winner == null)
+                {
+                    currentWinner = null;
+                    currentCount = 0;
+                    continue;
+                }
+
+                if (winner == currentWinner)
+                {
+                    currentCount++;
+                }
+                else
+                {
+                    currentWinner = winner;
+                    currentCount = 1;
+                }
+
+                if (currentCount <= bestCount)
+                    continue;
+
+                bestWinner = winner.Value;
+                bestCount = currentCount;
+            }
+
+            return new CMURoundStreak(bestWinner, bestCount);
+        }
+
+        private static CMURoundStatisticsWinner? GetDecidedWinner(CMURoundOutcomeRecord record)
+        {
+            if (IsSideAWin(record) || IsSideBWin(record))
+                return record.Winner;
+
+            return null;
+        }
+
+        private static int AverageDurationSeconds(IEnumerable<CMURoundOutcomeRecord> records)
+        {
+            var durations = records
+                .Where(record => record.DurationSeconds > 0)
+                .Select(record => record.DurationSeconds)
+                .ToList();
+
+            return durations.Count == 0
+                ? 0
+                : (int) Math.Round(durations.Average());
+        }
+
+        private static List<CMURoundPlayerCountBandBreakdown> BuildPlayerCountBands(List<CMURoundOutcomeRecord> records)
+        {
+            return new List<CMURoundPlayerCountBandBreakdown>
+            {
+                BuildPlayerCountBand(records, "0-59", 0, 59),
+                BuildPlayerCountBand(records, "60-99", 60, 99),
+                BuildPlayerCountBand(records, "100+", 100, int.MaxValue),
+            }
+                .Where(band => band.Total > 0)
+                .ToList();
+        }
+
+        private static CMURoundPlayerCountBandBreakdown BuildPlayerCountBand(
+            List<CMURoundOutcomeRecord> records,
+            string label,
+            int min,
+            int max)
+        {
+            var bandRecords = records
+                .Where(record => record.PlayerCount >= min && record.PlayerCount <= max)
+                .ToList();
+
+            return new CMURoundPlayerCountBandBreakdown(
+                label,
+                min,
+                max == int.MaxValue ? -1 : max,
+                bandRecords.Count(IsSideAWin),
+                bandRecords.Count(IsSideBWin),
+                bandRecords.Count(record => record.Winner == CMURoundStatisticsWinner.Draw),
+                bandRecords.Count(record => record.Winner == CMURoundStatisticsWinner.Unknown),
+                bandRecords.Count);
+        }
+
+        private static bool IsSideAWin(CMURoundOutcomeRecord record)
+        {
+            return record.Preset switch
+            {
+                CMURoundStatisticsPreset.DistressSignal => record.Winner == CMURoundStatisticsWinner.Xeno,
+                CMURoundStatisticsPreset.Insurgency => record.Winner == CMURoundStatisticsWinner.Govfor,
+                CMURoundStatisticsPreset.ColonyFall => record.Winner == CMURoundStatisticsWinner.Colonists,
+                _ => false,
+            };
+        }
+
+        private static bool IsSideBWin(CMURoundOutcomeRecord record)
+        {
+            return record.Preset switch
+            {
+                CMURoundStatisticsPreset.DistressSignal => record.Winner == CMURoundStatisticsWinner.Govfor,
+                CMURoundStatisticsPreset.Insurgency => record.Winner == CMURoundStatisticsWinner.Clf,
+                CMURoundStatisticsPreset.ColonyFall => record.Winner == CMURoundStatisticsWinner.Threat,
+                _ => false,
+            };
         }
 
         [return: NotNullIfNotNull(nameof(round))]

--- a/Content.Server/Database/ServerDbManager.cs
+++ b/Content.Server/Database/ServerDbManager.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Content.Server._RMC14.LinkAccount;
 using Content.Server.Administration.Logs;
 using Content.Shared.Administration.Logs;
+using Content.Shared._CMU14.RoundStatistics;
 using Content.Shared.CCVar;
 using Content.Shared.Construction.Prototypes;
 using Content.Shared.Database;
@@ -241,6 +242,10 @@ namespace Content.Server.Database
         Task<int> AddNewRound(Server server, params Guid[] playerIds);
         Task<Round> GetRound(int id);
         Task AddRoundPlayers(int id, params Guid[] playerIds);
+        Task UpsertCMURoundOutcome(CMURoundOutcomeRecord record);
+        Task<CMURoundStatisticsDashboard> GetCMURoundStatisticsDashboard(
+            int recentRounds,
+            CancellationToken cancel = default);
 
         #endregion
 
@@ -824,6 +829,20 @@ namespace Content.Server.Database
         {
             DbWriteOpsMetric.Inc();
             return RunDbCommand(() => _db.AddRoundPlayers(id, playerIds));
+        }
+
+        public Task UpsertCMURoundOutcome(CMURoundOutcomeRecord record)
+        {
+            DbWriteOpsMetric.Inc();
+            return RunDbCommand(() => _db.UpsertCMURoundOutcome(record));
+        }
+
+        public Task<CMURoundStatisticsDashboard> GetCMURoundStatisticsDashboard(
+            int recentRounds,
+            CancellationToken cancel = default)
+        {
+            DbReadOpsMetric.Inc();
+            return RunDbCommand(() => _db.GetCMURoundStatisticsDashboard(recentRounds, cancel));
         }
 
         public Task UpdateAdminRankAsync(AdminRank rank, CancellationToken cancel = default)

--- a/Content.Server/_CMU14/RoundStatistics/CMURoundStatisticsCommand.cs
+++ b/Content.Server/_CMU14/RoundStatistics/CMURoundStatisticsCommand.cs
@@ -1,0 +1,26 @@
+using Content.Server.Administration;
+using Content.Server.EUI;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server._CMU14.RoundStatistics;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed partial class CMURoundStatisticsCommand : LocalizedCommands
+{
+    [Dependency] private EuiManager _eui = default!;
+
+    public override string Command => "cmuroundstats";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var player = shell.Player;
+        if (player == null)
+        {
+            shell.WriteLine("shell-only-players-can-run-this-command");
+            return;
+        }
+
+        _eui.OpenEui(new CMURoundStatisticsEui(), player);
+    }
+}

--- a/Content.Server/_CMU14/RoundStatistics/CMURoundStatisticsCommand.cs
+++ b/Content.Server/_CMU14/RoundStatistics/CMURoundStatisticsCommand.cs
@@ -1,11 +1,10 @@
-using Content.Server.Administration;
 using Content.Server.EUI;
 using Content.Shared.Administration;
 using Robust.Shared.Console;
 
 namespace Content.Server._CMU14.RoundStatistics;
 
-[AdminCommand(AdminFlags.Admin)]
+[AnyCommand]
 public sealed partial class CMURoundStatisticsCommand : LocalizedCommands
 {
     [Dependency] private EuiManager _eui = default!;

--- a/Content.Server/_CMU14/RoundStatistics/CMURoundStatisticsEui.cs
+++ b/Content.Server/_CMU14/RoundStatistics/CMURoundStatisticsEui.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Collections.Generic;
-using Content.Server.Administration;
-using Content.Server.Administration.Managers;
 using Content.Server.Database;
 using Content.Server.EUI;
 using Content.Shared._CMU14.RoundStatistics;
-using Content.Shared.Administration;
 using Content.Shared.Eui;
 using Robust.Shared.Asynchronous;
 using Robust.Shared.Log;
@@ -16,7 +13,6 @@ public sealed partial class CMURoundStatisticsEui : BaseEui
 {
     private const int RecentRounds = 30;
 
-    [Dependency] private IAdminManager _admin = default!;
     [Dependency] private IServerDbManager _db = default!;
     [Dependency] private ITaskManager _task = default!;
 
@@ -32,15 +28,7 @@ public sealed partial class CMURoundStatisticsEui : BaseEui
     {
         base.Opened();
 
-        _admin.OnPermsChanged += OnAdminPermsChanged;
         LoadFromDb();
-    }
-
-    public override void Closed()
-    {
-        base.Closed();
-
-        _admin.OnPermsChanged -= OnAdminPermsChanged;
     }
 
     public override EuiStateBase GetNewState()
@@ -51,9 +39,6 @@ public sealed partial class CMURoundStatisticsEui : BaseEui
     public override void HandleMessage(EuiMessageBase msg)
     {
         base.HandleMessage(msg);
-
-        if (!_admin.HasAdminFlag(Player, AdminFlags.Admin))
-            return;
 
         if (msg is CMURoundStatisticsRefreshMsg)
             LoadFromDb();
@@ -74,15 +59,6 @@ public sealed partial class CMURoundStatisticsEui : BaseEui
         {
             _sawmill.Error($"Failed to load CMU round statistics dashboard:\n{e}");
         }
-    }
-
-    private void OnAdminPermsChanged(AdminPermsChangedEventArgs args)
-    {
-        if (args.Player != Player)
-            return;
-
-        if (!_admin.HasAdminFlag(Player, AdminFlags.Admin))
-            Close();
     }
 
     private static CMURoundStatisticsDashboard EmptyDashboard()

--- a/Content.Server/_CMU14/RoundStatistics/CMURoundStatisticsEui.cs
+++ b/Content.Server/_CMU14/RoundStatistics/CMURoundStatisticsEui.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using Content.Server.Administration;
+using Content.Server.Administration.Managers;
+using Content.Server.Database;
+using Content.Server.EUI;
+using Content.Shared._CMU14.RoundStatistics;
+using Content.Shared.Administration;
+using Content.Shared.Eui;
+using Robust.Shared.Asynchronous;
+using Robust.Shared.Log;
+
+namespace Content.Server._CMU14.RoundStatistics;
+
+public sealed partial class CMURoundStatisticsEui : BaseEui
+{
+    private const int RecentRounds = 30;
+
+    [Dependency] private IAdminManager _admin = default!;
+    [Dependency] private IServerDbManager _db = default!;
+    [Dependency] private ITaskManager _task = default!;
+
+    private readonly ISawmill _sawmill = Logger.GetSawmill("cmu.round_statistics");
+    private CMURoundStatisticsDashboard _dashboard = EmptyDashboard();
+
+    public CMURoundStatisticsEui()
+    {
+        IoCManager.InjectDependencies(this);
+    }
+
+    public override void Opened()
+    {
+        base.Opened();
+
+        _admin.OnPermsChanged += OnAdminPermsChanged;
+        LoadFromDb();
+    }
+
+    public override void Closed()
+    {
+        base.Closed();
+
+        _admin.OnPermsChanged -= OnAdminPermsChanged;
+    }
+
+    public override EuiStateBase GetNewState()
+    {
+        return new CMURoundStatisticsEuiState(_dashboard);
+    }
+
+    public override void HandleMessage(EuiMessageBase msg)
+    {
+        base.HandleMessage(msg);
+
+        if (!_admin.HasAdminFlag(Player, AdminFlags.Admin))
+            return;
+
+        if (msg is CMURoundStatisticsRefreshMsg)
+            LoadFromDb();
+    }
+
+    private async void LoadFromDb()
+    {
+        try
+        {
+            var dashboard = await _db.GetCMURoundStatisticsDashboard(RecentRounds);
+            _task.RunOnMainThread(() =>
+            {
+                _dashboard = dashboard;
+                StateDirty();
+            });
+        }
+        catch (Exception e)
+        {
+            _sawmill.Error($"Failed to load CMU round statistics dashboard:\n{e}");
+        }
+    }
+
+    private void OnAdminPermsChanged(AdminPermsChangedEventArgs args)
+    {
+        if (args.Player != Player)
+            return;
+
+        if (!_admin.HasAdminFlag(Player, AdminFlags.Admin))
+            Close();
+    }
+
+    private static CMURoundStatisticsDashboard EmptyDashboard()
+    {
+        return new CMURoundStatisticsDashboard(
+            new List<CMURoundModeStatistics>
+            {
+                new(
+                    CMURoundStatisticsPreset.DistressSignal,
+                    "Distress Signal",
+                    "Xeno",
+                    "Govfor",
+                    0,
+                    0,
+                    0,
+                    0,
+                    new List<CMURoundOutcomeBreakdown>(),
+                    new List<CMURoundThreatBreakdown>(),
+                    EmptyRecentForm(),
+                    EmptyStreak(),
+                    EmptyStreak(),
+                    EmptyDurations(),
+                    new List<CMURoundPlanetBreakdown>(),
+                    new List<CMURoundPlatoonMatchupBreakdown>(),
+                    new List<CMURoundPlayerCountBandBreakdown>()),
+                new(
+                    CMURoundStatisticsPreset.Insurgency,
+                    "Insurgency",
+                    "Govfor",
+                    "CLF",
+                    0,
+                    0,
+                    0,
+                    0,
+                    new List<CMURoundOutcomeBreakdown>(),
+                    new List<CMURoundThreatBreakdown>(),
+                    EmptyRecentForm(),
+                    EmptyStreak(),
+                    EmptyStreak(),
+                    EmptyDurations(),
+                    new List<CMURoundPlanetBreakdown>(),
+                    new List<CMURoundPlatoonMatchupBreakdown>(),
+                    new List<CMURoundPlayerCountBandBreakdown>()),
+                new(
+                    CMURoundStatisticsPreset.ColonyFall,
+                    "Colony Fall",
+                    "Colonists",
+                    "Threat",
+                    0,
+                    0,
+                    0,
+                    0,
+                    new List<CMURoundOutcomeBreakdown>(),
+                    new List<CMURoundThreatBreakdown>(),
+                    EmptyRecentForm(),
+                    EmptyStreak(),
+                    EmptyStreak(),
+                    EmptyDurations(),
+                    new List<CMURoundPlanetBreakdown>(),
+                    new List<CMURoundPlatoonMatchupBreakdown>(),
+                    new List<CMURoundPlayerCountBandBreakdown>()),
+            },
+            new List<CMURoundOutcomeRecord>());
+    }
+
+    private static CMURoundRecentForm EmptyRecentForm()
+    {
+        return new CMURoundRecentForm(0, 0, 0, 0, 0, new List<CMURoundStatisticsWinner>());
+    }
+
+    private static CMURoundStreak EmptyStreak()
+    {
+        return new CMURoundStreak(CMURoundStatisticsWinner.Unknown, 0);
+    }
+
+    private static CMURoundDurationBreakdown EmptyDurations()
+    {
+        return new CMURoundDurationBreakdown(0, 0, 0, 0, 0);
+    }
+}

--- a/Content.Server/_CMU14/RoundStatistics/CMURoundStatisticsSystem.cs
+++ b/Content.Server/_CMU14/RoundStatistics/CMURoundStatisticsSystem.cs
@@ -1,0 +1,219 @@
+using System;
+using Content.Server.AU14.Round;
+using Content.Server.Database;
+using Content.Server.GameTicking;
+using Content.Shared._CMU14.RoundStatistics;
+using Content.Shared._RMC14.Rules;
+using Content.Shared.GameTicking;
+using Robust.Shared.Log;
+
+namespace Content.Server._CMU14.RoundStatistics;
+
+public sealed partial class CMURoundStatisticsSystem : EntitySystem
+{
+    private const string DistressSignalPreset = "DistressSignal";
+    private const string InsurgencyPreset = "Insurgency";
+    private const string ColonyFallPreset = "ColonyFall";
+
+    [Dependency] private AuRoundSystem _auRound = default!;
+    [Dependency] private GameTicker _gameTicker = default!;
+    [Dependency] private IServerDbManager _db = default!;
+    [Dependency] private PlatoonSpawnRuleSystem _platoons = default!;
+
+    private readonly ISawmill _sawmill = Logger.GetSawmill("cmu.round_statistics");
+
+    private PendingRoundOutcome? _pendingOutcome;
+    private int? _recordedRoundId;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RoundEndMessageEvent>(OnRoundEndMessage);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup);
+    }
+
+    public void RecordKillAllGovforRule()
+    {
+        if (GetCurrentPreset() != CMURoundStatisticsPreset.Insurgency)
+            return;
+
+        TrySetPendingOutcome(
+            CMURoundStatisticsWinner.Clf,
+            CMURoundStatisticsOutcome.InsurgencyClfVictory,
+            "KillAllGovforRule");
+    }
+
+    public void RecordKillAllClfRule()
+    {
+        if (GetCurrentPreset() != CMURoundStatisticsPreset.Insurgency)
+            return;
+
+        TrySetPendingOutcome(
+            CMURoundStatisticsWinner.Govfor,
+            CMURoundStatisticsOutcome.InsurgencyGovforVictory,
+            "KillAllClfRule");
+    }
+
+    public void RecordKillAllColonistRule()
+    {
+        if (GetCurrentPreset() != CMURoundStatisticsPreset.ColonyFall)
+            return;
+
+        TrySetPendingOutcome(
+            CMURoundStatisticsWinner.Threat,
+            CMURoundStatisticsOutcome.ColonyFallThreatVictory,
+            "KillAllColonistRule");
+    }
+
+    public void RecordKillAllHumanRule()
+    {
+        if (GetCurrentPreset() != CMURoundStatisticsPreset.ColonyFall)
+            return;
+
+        TrySetPendingOutcome(
+            CMURoundStatisticsWinner.Threat,
+            CMURoundStatisticsOutcome.ColonyFallThreatVictory,
+            "KillAllHumanRule");
+    }
+
+    public void RecordThreatSurviveRule()
+    {
+        if (GetCurrentPreset() != CMURoundStatisticsPreset.ColonyFall)
+            return;
+
+        TrySetPendingOutcome(
+            CMURoundStatisticsWinner.Threat,
+            CMURoundStatisticsOutcome.ColonyFallThreatVictory,
+            "ThreatSurviveRule");
+    }
+
+    public void RecordThreatDefeatedRule(string source)
+    {
+        if (GetCurrentPreset() != CMURoundStatisticsPreset.ColonyFall)
+            return;
+
+        TrySetPendingOutcome(
+            CMURoundStatisticsWinner.Colonists,
+            CMURoundStatisticsOutcome.ColonyFallSurvivorVictory,
+            source);
+    }
+
+    private void TrySetPendingOutcome(
+        CMURoundStatisticsWinner winner,
+        CMURoundStatisticsOutcome outcome,
+        string source)
+    {
+        _pendingOutcome ??= new PendingRoundOutcome(winner, outcome, source);
+    }
+
+    private void OnRoundRestartCleanup(RoundRestartCleanupEvent ev)
+    {
+        _pendingOutcome = null;
+        _recordedRoundId = null;
+    }
+
+    private async void OnRoundEndMessage(RoundEndMessageEvent ev)
+    {
+        if (_recordedRoundId == ev.RoundId)
+            return;
+
+        var preset = GetCurrentPreset();
+        if (preset == null)
+            return;
+
+        var outcome = preset == CMURoundStatisticsPreset.DistressSignal
+            ? GetDistressOutcome()
+            : _pendingOutcome;
+
+        outcome ??= new PendingRoundOutcome(
+            CMURoundStatisticsWinner.Unknown,
+            CMURoundStatisticsOutcome.Unknown,
+            "RoundEndMessageEvent");
+
+        var record = new CMURoundOutcomeRecord(
+            ev.RoundId,
+            preset.Value,
+            outcome.Value.Winner,
+            outcome.Value.Outcome,
+            outcome.Value.Source,
+            _auRound.SelectedThreat?.ID,
+            _auRound.GetSelectedPlanetId(),
+            _platoons.SelectedGovforPlatoon?.ID,
+            _platoons.SelectedOpforPlatoon?.ID,
+            ev.PlayerCount,
+            (int) ev.RoundDuration.TotalSeconds,
+            DateTime.UtcNow);
+
+        _recordedRoundId = ev.RoundId;
+
+        try
+        {
+            await _db.UpsertCMURoundOutcome(record);
+        }
+        catch (Exception e)
+        {
+            _sawmill.Error($"Failed to save CMU round outcome for round {ev.RoundId}:\n{e}");
+        }
+    }
+
+    private PendingRoundOutcome? GetDistressOutcome()
+    {
+        var query = EntityQueryEnumerator<CMDistressSignalRuleComponent>();
+        while (query.MoveNext(out var distress))
+        {
+            if (distress.Result is not { } result ||
+                result == DistressSignalRuleResult.None)
+            {
+                continue;
+            }
+
+            return result switch
+            {
+                DistressSignalRuleResult.MajorXenoVictory => new PendingRoundOutcome(
+                    CMURoundStatisticsWinner.Xeno,
+                    CMURoundStatisticsOutcome.XenoMajorHijackWin,
+                    nameof(DistressSignalRuleResult.MajorXenoVictory)),
+                DistressSignalRuleResult.MinorXenoVictory => new PendingRoundOutcome(
+                    CMURoundStatisticsWinner.Xeno,
+                    CMURoundStatisticsOutcome.XenoMinorHijackLoss,
+                    nameof(DistressSignalRuleResult.MinorXenoVictory)),
+                DistressSignalRuleResult.MinorMarineVictory => new PendingRoundOutcome(
+                    CMURoundStatisticsWinner.Govfor,
+                    CMURoundStatisticsOutcome.MarineMinorHiveCollapse,
+                    nameof(DistressSignalRuleResult.MinorMarineVictory)),
+                DistressSignalRuleResult.MajorMarineVictory => new PendingRoundOutcome(
+                    CMURoundStatisticsWinner.Govfor,
+                    CMURoundStatisticsOutcome.MarineMajorXenoWipe,
+                    nameof(DistressSignalRuleResult.MajorMarineVictory)),
+                DistressSignalRuleResult.AllDied => new PendingRoundOutcome(
+                    CMURoundStatisticsWinner.Draw,
+                    CMURoundStatisticsOutcome.DrawAlmayerAutodestruct,
+                    nameof(DistressSignalRuleResult.AllDied)),
+                _ => null,
+            };
+        }
+
+        return null;
+    }
+
+    private CMURoundStatisticsPreset? GetCurrentPreset()
+    {
+        var presetId = _gameTicker.CurrentPreset?.ID ??
+                       _gameTicker.Preset?.ID ??
+                       _auRound.SelectedPreset?.ID;
+
+        return presetId switch
+        {
+            DistressSignalPreset => CMURoundStatisticsPreset.DistressSignal,
+            InsurgencyPreset => CMURoundStatisticsPreset.Insurgency,
+            ColonyFallPreset => CMURoundStatisticsPreset.ColonyFall,
+            _ => null,
+        };
+    }
+
+    private readonly record struct PendingRoundOutcome(
+        CMURoundStatisticsWinner Winner,
+        CMURoundStatisticsOutcome Outcome,
+        string Source);
+}

--- a/Content.Server/_CMU14/Threats/Rules/KillAllAbominationsRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/KillAllAbominationsRuleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._CMU14.RoundStatistics;
 using Content.Server.AU14.Round;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
@@ -25,6 +26,7 @@ public sealed partial class KillAllAbominationsRuleSystem : GameRuleSystem<KillA
     [Dependency] private AuRoundSystem _auRoundSystem = default!;
     [Dependency] private IEntityManager _entMan = default!;
     [Dependency] private GameTicker _gameTicker = default!;
+    [Dependency] private CMURoundStatisticsSystem _roundStats = default!;
     [Dependency] private ThreatRuleHelper _threatRuleHelper = default!;
     private const string DefaultWinMsg = "The Threat has been Eliminated";
 
@@ -87,6 +89,7 @@ public sealed partial class KillAllAbominationsRuleSystem : GameRuleSystem<KillA
             return;
 
         string? winMessage = _auRoundSystem.SelectedThreat?.WinMessage;
+        _roundStats.RecordThreatDefeatedRule("KillAllAbominationsRule");
         _gameTicker.EndRound(!string.IsNullOrEmpty(winMessage) ? winMessage : DefaultWinMsg);
     }
 }

--- a/Content.Server/_CMU14/Threats/Rules/KillAllApeRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/KillAllApeRuleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._CMU14.RoundStatistics;
 using Content.Server.AU14.Round;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
@@ -15,6 +16,7 @@ public sealed partial class KillAllApeRuleSystem : GameRuleSystem<KillAllApeRule
     [Dependency] private AuRoundSystem _auRoundSystem = default!;
     [Dependency] private IEntityManager _entMan = default!;
     [Dependency] private GameTicker _gameTicker = default!;
+    [Dependency] private CMURoundStatisticsSystem _roundStats = default!;
     [Dependency] private ThreatRuleHelper _threatRuleHelper = default!;
     private const string DefaultWinMsg = "The Threat has been Eliminated";
 
@@ -72,6 +74,7 @@ public sealed partial class KillAllApeRuleSystem : GameRuleSystem<KillAllApeRule
             return;
 
         string? winMessage = _auRoundSystem.SelectedThreat?.WinMessage;
+        _roundStats.RecordThreatDefeatedRule("KillAllApeRule");
         _gameTicker.EndRound(!string.IsNullOrEmpty(winMessage) ? winMessage : DefaultWinMsg);
     }
 }

--- a/Content.Server/_CMU14/Threats/Rules/KillAllClfRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/KillAllClfRuleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._CMU14.RoundStatistics;
 using Content.Server.AU14.Round;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
@@ -27,6 +28,7 @@ public sealed partial class KillAllClfRuleSystem : GameRuleSystem<KillAllClfRule
     [Dependency] private GameTicker _gameTicker = default!;
     [Dependency] private InventorySystem _inventory = default!;
     [Dependency] private RMCPlanetSystem _rmcPlanet = default!;
+    [Dependency] private CMURoundStatisticsSystem _roundStats = default!;
     [Dependency] private ThreatRuleHelper _threatRuleHelper = default!;
     private const string DefaultWinMsg = "Govfor victory: Required percentage of CLF eliminated.";
 
@@ -132,6 +134,7 @@ public sealed partial class KillAllClfRuleSystem : GameRuleSystem<KillAllClfRule
         string? winMessage = !string.IsNullOrEmpty(ruleComp.WinMessage)
             ? ruleComp.WinMessage
             : _auRoundSystem.SelectedThreat?.WinMessage;
+        _roundStats.RecordKillAllClfRule();
         _gameTicker.EndRound(!string.IsNullOrEmpty(winMessage) ? winMessage : DefaultWinMsg);
     }
 }

--- a/Content.Server/_CMU14/Threats/Rules/KillAllColonistRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/KillAllColonistRuleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._CMU14.RoundStatistics;
 using Content.Server.AU14.Round;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
@@ -22,6 +23,7 @@ public sealed partial class KillAllColonistRuleSystem : GameRuleSystem<KillAllCo
     [Dependency] private IEntityManager _entMan = default!;
     [Dependency] private GameTicker _gameTicker = default!;
     [Dependency] private RMCPlanetSystem _rmcPlanet = default!;
+    [Dependency] private CMURoundStatisticsSystem _roundStats = default!;
     [Dependency] private ThreatRuleHelper _threatRuleHelper = default!;
     private const string DefaultWinMsg = "Threat victory: Required percentage of Colonists eliminated.";
 
@@ -107,6 +109,7 @@ public sealed partial class KillAllColonistRuleSystem : GameRuleSystem<KillAllCo
             return;
 
         string? winMessage = _auRoundSystem.SelectedThreat?.WinMessage;
+        _roundStats.RecordKillAllColonistRule();
         _gameTicker.EndRound(!string.IsNullOrEmpty(winMessage) ? winMessage : DefaultWinMsg);
     }
 }

--- a/Content.Server/_CMU14/Threats/Rules/KillAllGovforRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/KillAllGovforRuleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._CMU14.RoundStatistics;
 using Content.Server.AU14.Round;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
@@ -25,6 +26,7 @@ public sealed partial class KillAllGovforRuleSystem : GameRuleSystem<KillAllGovf
     [Dependency] private IEntityManager _entMan = default!;
     [Dependency] private GameTicker _gameTicker = default!;
     [Dependency] private InventorySystem _inventory = default!;
+    [Dependency] private CMURoundStatisticsSystem _roundStats = default!;
     [Dependency] private ThreatRuleHelper _threatRuleHelper = default!;
     private const string DefaultWinMsg = "Threat victory: Required percentage of Govfor eliminated.";
 
@@ -129,6 +131,7 @@ public sealed partial class KillAllGovforRuleSystem : GameRuleSystem<KillAllGovf
             ? ruleComp.WinMessage
             : _auRoundSystem.SelectedThreat?.WinMessage;
 
+        _roundStats.RecordKillAllGovforRule();
         _gameTicker.EndRound(!string.IsNullOrEmpty(winMessage) ? winMessage : DefaultWinMsg);
     }
 }

--- a/Content.Server/_CMU14/Threats/Rules/KillAllHumanRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/KillAllHumanRuleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._CMU14.RoundStatistics;
 using Content.Server.AU14.Round;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
@@ -27,6 +28,7 @@ public sealed partial class KillAllHumanRuleSystem : GameRuleSystem<KillAllHuman
     [Dependency] private GameTicker _gameTicker = default!;
     [Dependency] private InventorySystem _inventory = default!;
     [Dependency] private RMCPlanetSystem _rmcPlanet = default!;
+    [Dependency] private CMURoundStatisticsSystem _roundStats = default!;
     [Dependency] private ThreatRuleHelper _threatRuleHelper = default!;
     private const string DefaultWinMsg = "Threat victory: Required percentage of humans eliminated.";
 
@@ -132,6 +134,7 @@ public sealed partial class KillAllHumanRuleSystem : GameRuleSystem<KillAllHuman
             ? ruleComp.WinMessage
             : _auRoundSystem.SelectedThreat?.WinMessage;
 
+        _roundStats.RecordKillAllHumanRule();
         _gameTicker.EndRound(!string.IsNullOrEmpty(winMessage) ? winMessage : DefaultWinMsg);
     }
 }

--- a/Content.Server/_CMU14/Threats/Rules/KillAllTribeRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/KillAllTribeRuleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._CMU14.RoundStatistics;
 using Content.Server.AU14.Round;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
@@ -15,6 +16,7 @@ public sealed partial class KillAllTribeRuleSystem : GameRuleSystem<KillAllTribe
     [Dependency] private AuRoundSystem _auRoundSystem = default!;
     [Dependency] private EntityManager _entMan = default!;
     [Dependency] private GameTicker _gameTicker = default!;
+    [Dependency] private CMURoundStatisticsSystem _roundStats = default!;
     [Dependency] private ThreatRuleHelper _threatRuleHelper = default!;
     private const string DefaultWinMsg = "The Threat has been Eliminated";
 
@@ -71,6 +73,7 @@ public sealed partial class KillAllTribeRuleSystem : GameRuleSystem<KillAllTribe
             return;
 
         string? winMessage = _auRoundSystem.SelectedThreat?.WinMessage;
+        _roundStats.RecordThreatDefeatedRule("KillAllTribeRule");
         _gameTicker.EndRound(!string.IsNullOrEmpty(winMessage) ? winMessage : DefaultWinMsg);
     }
 }

--- a/Content.Server/_CMU14/Threats/Rules/KillAllXenoRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/KillAllXenoRuleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._CMU14.RoundStatistics;
 using Content.Server.AU14.Round;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
@@ -19,6 +20,7 @@ public sealed partial class KillAllXenoRuleSystem : GameRuleSystem<KillAllXenoRu
     [Dependency] private AuRoundSystem _auRoundSystem = default!;
     [Dependency] private IEntityManager _entMan = default!;
     [Dependency] private GameTicker _gameTicker = default!;
+    [Dependency] private CMURoundStatisticsSystem _roundStats = default!;
     [Dependency] private ThreatRuleHelper _threatRuleHelper = default!;
 
     private static readonly ProtoId<JobPrototype> LesserDroneRole = "CMXenoLesserDrone";
@@ -94,6 +96,7 @@ public sealed partial class KillAllXenoRuleSystem : GameRuleSystem<KillAllXenoRu
             return;
 
         string? winMessage = _auRoundSystem.SelectedThreat?.WinMessage;
+        _roundStats.RecordThreatDefeatedRule("KillAllXenoRule");
         _gameTicker.EndRound(string.IsNullOrEmpty(winMessage) ? DefaultWinMsg : winMessage);
     }
 }

--- a/Content.Server/_CMU14/Threats/Rules/KillAllYautjaRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/KillAllYautjaRuleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._CMU14.RoundStatistics;
 using Content.Server.AU14.Round;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
@@ -15,6 +16,7 @@ public sealed partial class KillAllYautjaRuleSystem : GameRuleSystem<KillAllYaut
     [Dependency] private AuRoundSystem _auRoundSystem = default!;
     [Dependency] private IEntityManager _entMan = default!;
     [Dependency] private GameTicker _gameTicker = default!;
+    [Dependency] private CMURoundStatisticsSystem _roundStats = default!;
     [Dependency] private ThreatRuleHelper _threatRuleHelper = default!;
     private const string DefaultWinMsg = "The Bad Blood Clan has been eliminated.";
 
@@ -69,6 +71,7 @@ public sealed partial class KillAllYautjaRuleSystem : GameRuleSystem<KillAllYaut
             return;
 
         string? winMessage = _auRoundSystem.SelectedThreat?.WinMessage;
+        _roundStats.RecordThreatDefeatedRule("KillAllYautjaRule");
         _gameTicker.EndRound(!string.IsNullOrEmpty(winMessage) ? winMessage : DefaultWinMsg);
     }
 }

--- a/Content.Server/_CMU14/Threats/Rules/ThreatSurviveRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/ThreatSurviveRuleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._CMU14.RoundStatistics;
 using Content.Server.AU14.Round;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
@@ -12,6 +13,7 @@ public sealed partial class ThreatSurviveRuleSystem : GameRuleSystem<ThreatSurvi
 {
     [Dependency] private AuRoundSystem _auRoundSystem = default!;
     [Dependency] private GameTicker _gameTicker = default!;
+    [Dependency] private CMURoundStatisticsSystem _roundStats = default!;
     [Dependency] private RoundEndSystem _roundEnd = default!;
     [Dependency] private IGameTiming _timing = default!;
 
@@ -35,6 +37,7 @@ public sealed partial class ThreatSurviveRuleSystem : GameRuleSystem<ThreatSurvi
             return;
 
         string? winMessage = _auRoundSystem.SelectedThreat?.WinMessage;
+        _roundStats.RecordThreatSurviveRule();
         _gameTicker.EndRound(!string.IsNullOrEmpty(winMessage)
             ? winMessage
             : $"Threat victory: Survived {_minutes} minutes.");

--- a/Content.Shared/_CMU14/RoundStatistics/CMURoundStatistics.cs
+++ b/Content.Shared/_CMU14/RoundStatistics/CMURoundStatistics.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using Content.Shared.Eui;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._CMU14.RoundStatistics;
+
+[Serializable, NetSerializable]
+public enum CMURoundStatisticsPreset : byte
+{
+    DistressSignal,
+    Insurgency,
+    ColonyFall,
+}
+
+[Serializable, NetSerializable]
+public enum CMURoundStatisticsWinner : byte
+{
+    Xeno,
+    Govfor,
+    Clf,
+    Colonists,
+    Threat,
+    Draw,
+    Unknown,
+}
+
+[Serializable, NetSerializable]
+public enum CMURoundStatisticsOutcome : byte
+{
+    Unknown,
+    XenoMajorHijackWin,
+    XenoMinorHijackLoss,
+    MarineMinorHiveCollapse,
+    MarineMajorXenoWipe,
+    DrawAlmayerAutodestruct,
+    InsurgencyClfVictory,
+    InsurgencyGovforVictory,
+    ColonyFallThreatVictory,
+    ColonyFallSurvivorVictory,
+}
+
+[Serializable, NetSerializable]
+public readonly record struct CMURoundOutcomeRecord(
+    int RoundId,
+    CMURoundStatisticsPreset Preset,
+    CMURoundStatisticsWinner Winner,
+    CMURoundStatisticsOutcome Outcome,
+    string Source,
+    string? SelectedThreatId,
+    string? PlanetId,
+    string? GovforPlatoonId,
+    string? OpforPlatoonId,
+    int PlayerCount,
+    int DurationSeconds,
+    DateTime RecordedAt);
+
+[Serializable, NetSerializable]
+public readonly record struct CMURoundOutcomeBreakdown(
+    CMURoundStatisticsOutcome Outcome,
+    CMURoundStatisticsWinner Winner,
+    int Count);
+
+[Serializable, NetSerializable]
+public readonly record struct CMURoundThreatBreakdown(
+    string ThreatId,
+    int SideAWins,
+    int SideBWins,
+    int Draws,
+    int Unknown,
+    int Total);
+
+[Serializable, NetSerializable]
+public readonly record struct CMURoundRecentForm(
+    int Rounds,
+    int SideAWins,
+    int SideBWins,
+    int Draws,
+    int Unknown,
+    List<CMURoundStatisticsWinner> Winners);
+
+[Serializable, NetSerializable]
+public readonly record struct CMURoundStreak(
+    CMURoundStatisticsWinner Winner,
+    int Count);
+
+[Serializable, NetSerializable]
+public readonly record struct CMURoundDurationBreakdown(
+    int AverageSeconds,
+    int SideAAverageSeconds,
+    int SideBAverageSeconds,
+    int DrawAverageSeconds,
+    int UnknownAverageSeconds);
+
+[Serializable, NetSerializable]
+public readonly record struct CMURoundPlanetBreakdown(
+    string PlanetId,
+    int SideAWins,
+    int SideBWins,
+    int Draws,
+    int Unknown,
+    int Total,
+    int AverageDurationSeconds);
+
+[Serializable, NetSerializable]
+public readonly record struct CMURoundPlatoonMatchupBreakdown(
+    string GovforPlatoonId,
+    string OpforPlatoonId,
+    int SideAWins,
+    int SideBWins,
+    int Draws,
+    int Unknown,
+    int Total);
+
+[Serializable, NetSerializable]
+public readonly record struct CMURoundPlayerCountBandBreakdown(
+    string Band,
+    int MinPlayers,
+    int MaxPlayers,
+    int SideAWins,
+    int SideBWins,
+    int Draws,
+    int Unknown,
+    int Total);
+
+[Serializable, NetSerializable]
+public sealed class CMURoundModeStatistics(
+    CMURoundStatisticsPreset preset,
+    string title,
+    string sideA,
+    string sideB,
+    int sideAWins,
+    int sideBWins,
+    int draws,
+    int unknown,
+    List<CMURoundOutcomeBreakdown> outcomes,
+    List<CMURoundThreatBreakdown> threats,
+    CMURoundRecentForm recentForm,
+    CMURoundStreak currentStreak,
+    CMURoundStreak longestStreak,
+    CMURoundDurationBreakdown durations,
+    List<CMURoundPlanetBreakdown> planets,
+    List<CMURoundPlatoonMatchupBreakdown> platoonMatchups,
+    List<CMURoundPlayerCountBandBreakdown> playerCountBands)
+{
+    public readonly CMURoundStatisticsPreset Preset = preset;
+    public readonly string Title = title;
+    public readonly string SideA = sideA;
+    public readonly string SideB = sideB;
+    public readonly int SideAWins = sideAWins;
+    public readonly int SideBWins = sideBWins;
+    public readonly int Draws = draws;
+    public readonly int Unknown = unknown;
+    public readonly List<CMURoundOutcomeBreakdown> Outcomes = outcomes;
+    public readonly List<CMURoundThreatBreakdown> Threats = threats;
+    public readonly CMURoundRecentForm RecentForm = recentForm;
+    public readonly CMURoundStreak CurrentStreak = currentStreak;
+    public readonly CMURoundStreak LongestStreak = longestStreak;
+    public readonly CMURoundDurationBreakdown Durations = durations;
+    public readonly List<CMURoundPlanetBreakdown> Planets = planets;
+    public readonly List<CMURoundPlatoonMatchupBreakdown> PlatoonMatchups = platoonMatchups;
+    public readonly List<CMURoundPlayerCountBandBreakdown> PlayerCountBands = playerCountBands;
+
+    public int Total => SideAWins + SideBWins + Draws + Unknown;
+    public int DecidedTotal => SideAWins + SideBWins;
+}
+
+[Serializable, NetSerializable]
+public sealed class CMURoundStatisticsDashboard(
+    List<CMURoundModeStatistics> modes,
+    List<CMURoundOutcomeRecord> recentRounds)
+{
+    public readonly List<CMURoundModeStatistics> Modes = modes;
+    public readonly List<CMURoundOutcomeRecord> RecentRounds = recentRounds;
+}
+
+[Serializable, NetSerializable]
+public sealed class CMURoundStatisticsEuiState(CMURoundStatisticsDashboard dashboard) : EuiStateBase
+{
+    public readonly CMURoundStatisticsDashboard Dashboard = dashboard;
+}
+
+[Serializable, NetSerializable]
+public sealed class CMURoundStatisticsRefreshMsg : EuiMessageBase;


### PR DESCRIPTION
:cl:
- add: Added CMU round outcome tracking for Distress Signal, Insurgency, and Colony Fall.
- add: Added a public round stats panel with win rates, recent form, streaks, durations, major/minor splits, and threat/planet/platoon/player-count breakdowns.
- add: Added the command to check the stats panel "cmuroundstats"