### PR TITLE
Filled Loadouts Two: LEO Factions

### DIFF
--- a/Resources/Prototypes/_CMU14/Entities/Clothing/Universal/pouches.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Clothing/Universal/pouches.yml
@@ -69,6 +69,17 @@
     - id: CMBodyBagFolded #intended since giving Stasis Body Bag to Colony wouldn't make sense since all Stasis bag's is slow down larva growth and since First Contact and all
 
 - type: entity
+  parent: RMCPouchGeneralLarge
+  id: AU14PouchGeneralLargeLEOFilled
+  suffix: AU14, Filled, LEO
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCBinocularsCivPVE
+    - id: RMCHandcuffs
+    - id: RMCRadioHandheldColonyOff
+  
+- type: entity
   parent: RMCPouchPistol
   id: AU14PouchPistolAlt
   suffix: AU14, Black

--- a/Resources/Prototypes/_CMU14/Entities/Objects/Kits/Weapons/pistols.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/Kits/Weapons/pistols.yml
@@ -54,9 +54,10 @@
        - RMCMagazinePistolL54
     - type: StorageFill
       contents:
+      - id: RMCAttachmentRailFlashlight
       - id: RMCWeaponPistolL54
       - id: RMCMagazinePistolL54
-        amount: 7
+        amount: 6
 
 - type: entity
   parent: RMCKitBase
@@ -83,6 +84,27 @@
         amount: 1
       - id: CMMagazinePistolM1984
         amount: 7
+      
+- type: entity
+  parent: RMCGunCaseBase
+  id: AU14GunCasePistolT73
+  name: Type 73 service pistol case
+  description:
+  components:
+    - type: Storage
+      maxItemSize: Huge
+      grid:
+      - 0,0,15,1
+      whitelist:
+       tags:
+       - RMCWeaponPistolT73
+       - RMCMagazinePistolT73
+    - type: StorageFill
+      contents:
+      - id: RMCAttachmentRailFlashlight
+      - id: RMCWeaponPistolT73
+      - id: RMCMagazinePistolT73
+        amount: 6
 
 - type: entity
   parent: RMCKitBase

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianCMBDeputy.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianCMBDeputy.yml
@@ -71,12 +71,20 @@
   equipment:
     head: RMCHeadCapBureau
     jumpsuit: AU14CMBUniform
+    back: CMSatchelSecurity
     belt: CMBeltSecurityMarshalFilled
     shoes: RMCBootsPMCFilled
     id: AU14IDCardColonyCMBDeputy
     ears: AU14CMBHeadset
-    outerClothing: AU14CMBDeputyWindbreaker
-    pocket1: AU14GuidebookLawColonial
+    outerClothing: RMCCoatSnowSurvivorCMBDeputy
+    suitstorage: AU14BeltHolsterPistolBlack
+    pocket1: AU14PouchIFAKFill
+    pocket2: AU14PouchGeneralLargeLEOFilled
+  inhand:
+  - RMCGunCasePistolM1984
+  storage:
+    back:
+    - AU14GuidebookLawColonial
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianCMBDeputy.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianCMBDeputy.yml
@@ -82,9 +82,6 @@
     pocket2: AU14PouchGeneralLargeLEOFilled
   inhand:
   - RMCGunCasePistolM1984
-  storage:
-    back:
-    - AU14GuidebookLawColonial
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianCMBDeputy.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianCMBDeputy.yml
@@ -82,6 +82,9 @@
     pocket2: AU14PouchGeneralLargeLEOFilled
   inhand:
   - RMCGunCasePistolM1984
+  storage:
+    back:
+    - AU14GuidebookLawColonial
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianCMBMarshal.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianCMBMarshal.yml
@@ -56,13 +56,21 @@
   equipment:
     head: RMCHeadCapBureau
     jumpsuit: AU14CMBUniform
+    back: CMSatchelSecurity
     belt: CMBeltSecurityMarshalFilled
     shoes: RMCBootsPMCFilled
     id: AU14IDCardColonyCMBMarshal
     ears: AU14CMBHeadset
-    outerClothing: AU14CMBMarshalWindbreaker
-    pocket1: AU14GuidebookLawColonial
-    pocket2: AU14StampCMBM
+    outerClothing: RMCCoatSnowSurvivorCMBDeputy
+    suitstorage: AU14BeltHolsterPistolBlack
+    pocket1: AU14PouchIFAKFill
+    pocket2: AU14PouchGeneralLargeLEOFilled
+  inhand:
+  - RMCGunCasePistolM1984
+  storage:
+    back:
+    - AU14GuidebookLawColonial
+    - AU14StampCMBM
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianCWPSRanger.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianCWPSRanger.yml
@@ -71,6 +71,7 @@
   equipment:
     head: AU14CWPSCampaignHat
     jumpsuit: AU14CWPSUniform
+    back: CMSatchelSecurity
     belt: CMBeltSecurityMarshalFilled
     shoes: RMCBootsPMCFilled
     id: AU14IDCardcivilianCWPSranger

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianCWPSRanger.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianCWPSRanger.yml
@@ -75,8 +75,16 @@
     shoes: RMCBootsPMCFilled
     id: AU14IDCardcivilianCWPSranger
     ears: AU14CMBHeadset
-    pocket1: AU14GuidebookLawColonial
-
+    outerClothing: AU14CWPSBomber
+    suitstorage: RMCBeltHolsterRevolver
+    pocket1: AU14PouchIFAKFill
+    pocket2: AU14PouchGeneralLargeLEOFilled
+  inhand:
+  - AU14GunCasePistolM44Civ
+  storage:
+    back:
+    - AU14GuidebookLawColonial
+  
 - type: entity
   parent: CMSpawnPointJobBase
   id: AU14SpawnPointCivilianCWPSRanger

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianColonySecurityLeader.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianColonySecurityLeader.yml
@@ -57,11 +57,20 @@
   equipment:
     head: RMCHeadCapBureau
     jumpsuit: AU14CMBUniform
+    back: CMSatchelSecurity
     belt: CMBeltSecurityMarshalFilled
     shoes: RMCBootsPMCFilled
     id: AU14IDCardColonyCMBMarshal
     ears: AU14ColonySecurityHeadset
-    outerClothing: AU14CMBMarshalWindbreaker
+    outerClothing: RMCCoatSnowSurvivorCMBDeputy
+    suitstorage: AU14BeltHolsterPistolBlack
+    pocket1: AU14PouchIFAKFill
+    pocket2: AU14PouchGeneralLargeLEOFilled
+  inhand:
+  - RMCGunCasePistolM1984
+  storage:
+    back:
+    - AU14GuidebookLawColonial
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianColonySecurityOfficer.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianColonySecurityOfficer.yml
@@ -56,6 +56,7 @@
     belt: CMBeltSecurityMarshalFilled
     shoes: RMCBootsPMCFilled
     id: AU14IDCardColonyCMBDeputy
+    ears: AU14ColonySecurityHeadset
     outerClothing: RMCCoatSnowSurvivorCMBDeputy
     suitstorage: AU14BeltHolsterPistolBlack
     pocket1: AU14PouchIFAKFill

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianColonySecurityOfficer.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianColonySecurityOfficer.yml
@@ -51,11 +51,20 @@
   id: AU14GearColonySecurityOfficer
   equipment:
     head: RMCHeadCapBureau
+    back: CMSatchelSecurity
     jumpsuit: AU14CMBUniform
     belt: CMBeltSecurityMarshalFilled
     shoes: RMCBootsPMCFilled
     id: AU14IDCardColonyCMBDeputy
-    outerClothing: AU14CMBDeputyWindbreaker
+    outerClothing: RMCCoatSnowSurvivorCMBDeputy
+    suitstorage: AU14BeltHolsterPistolBlack
+    pocket1: AU14PouchIFAKFill
+    pocket2: AU14PouchGeneralLargeLEOFilled
+  inhand:
+  - RMCGunCasePistolM1984
+  storage:
+    back:
+    - AU14GuidebookLawColonial
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianNSPAConstable.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianNSPAConstable.yml
@@ -73,12 +73,21 @@
   id: AU14GearCivilianNSPAConstable
   equipment:
     head: RMCHeadCapTSEPAPeaked
+    back: RMCSatchelTSEPA
     jumpsuit: RMCJumpsuitTSEPA
     belt: CMBeltSecurityMarshalFilled
     shoes: RMCBootsPMCFilled
     id: AU14IDCardCivilianNSPAConstable
     ears: AU14CMBHeadset
-    pocket1: AU14GuidebookLawColonial
+    outerClothing: RMCArmorVestTSEPA
+    suitstorage: AU14BeltHolsterPistolBlack
+    pocket1: AU14PouchIFAKFill
+    pocket2: AU14PouchGeneralLargeLEOFilled
+  inhand:
+  - AU14GunCasePistolL45
+  storage:
+    back:
+    - AU14GuidebookLawColonial
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianNSPAInspector.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianNSPAInspector.yml
@@ -65,6 +65,7 @@
   equipment:
     id: AU14IDCardColonyNSPAInspector
     outerClothing: RMCCoatTSEPA
+    back: RMCSatchelTSEPA
     jumpsuit: RMCJumpsuitTSEPA
     shoes: RMCBootsPMCFilled
     head: RMCHeadCapTSEPAPeakedGold

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianNSPAInspector.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianNSPAInspector.yml
@@ -64,15 +64,13 @@
   id: AU14GearCivilianNSPAInspector
   equipment:
     id: AU14IDCardColonyNSPAInspector
-    outerClothing: RMCCoatTSEPA
     back: RMCSatchelTSEPA
     jumpsuit: RMCJumpsuitTSEPA
     shoes: RMCBootsPMCFilled
     head: RMCHeadCapTSEPAPeakedGold
     belt: CMBeltSecurityMarshalFilled
-    back: RMCSatchelTSEPA
     ears: AU14CMBHeadset
-    outerClothing: RMCArmorVestTSEPA
+    outerClothing: RMCCoatTSEPA
     suitstorage: AU14BeltHolsterPistolBlack
     pocket1: AU14PouchIFAKFill
     pocket2: AU14PouchGeneralLargeLEOFilled

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianNSPAInspector.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianNSPAInspector.yml
@@ -71,10 +71,16 @@
     belt: CMBeltSecurityMarshalFilled
     back: RMCSatchelTSEPA
     ears: AU14CMBHeadset
-    pocket1: AU14StampNSPA
+    outerClothing: RMCArmorVestTSEPA
+    suitstorage: AU14BeltHolsterPistolBlack
+    pocket1: AU14PouchIFAKFill
+    pocket2: AU14PouchGeneralLargeLEOFilled
+  inhand:
+  - AU14GunCasePistolL45
   storage:
     back:
     - AU14GuidebookLawColonial
+    - AU14StampNSPA
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianPaPOfficer.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianPaPOfficer.yml
@@ -71,6 +71,15 @@
     shoes: RMCBootsPMCFilled
     id: AU14IDCardcivilianPaPOfficer
     ears: AU14CMBHeadset
+    outerClothing: RMCCoatPaP
+    suitstorage: AU14BeltHolsterPistolBlack
+    pocket1: AU14PouchIFAKFill
+    pocket2: AU14PouchGeneralLargeLEOFilled
+  inhand:
+  - AU14GunCasePistolT73
+  storage:
+    back:
+    - AU14GuidebookLawColonial
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianPaPOfficer.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianPaPOfficer.yml
@@ -67,6 +67,7 @@
   equipment:
     head: CMHeadCapSPPPeakedPolice
     jumpsuit: RMCJumpsuitSPPPaP
+    back: CMSatchelSecurity
     belt: CMBeltSecurityMarshalFilled
     shoes: RMCBootsPMCFilled
     id: AU14IDCardcivilianPaPOfficer

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/belt.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/belt.yml
@@ -376,7 +376,8 @@
     - id: RMCHandcuffs
       amount: 2
     - id: RMCGrenadeFlashBang
-
+    - id: CMClipboard # CMU change
+    - id: RMCUniversalRecorder #CMU Change
 - type: entity
   parent: RMCBeltHolsterNailgun
   id: RMCBeltHolsterNailgunFill


### PR DESCRIPTION

## About the PR
Added additional starting equipment to the various LEO factions (CMB/Colony Security/NSPA/CWPS/PAP).
They'll now start with
- A Security Satchel (UPE-4 for NSPA)
- A Filled IFAK 
- A Large General Pouch (Contains Binoculars, Shortwave Radio, Handcuffs)
- Faction dependent `outerClothing` so CMB parka, NSPA vest, CWPS bomber jacket
- Pistol Holsters on their suit storage (In the case of CWPS it's a revolver holster)
- Faction related handgun cases (M4A3 Case for CMB/Colony Sec; M44 Case for CWPS; L54 for NSPA; Type 73 for PAP)

Colony Law Guide Book and NSPA Inspector/CMB Marshal Stamp was moved into the Satchels.
I also added two things to the Sec belt, a clipboard and a universal recorder, I also gave a rail light in both the L54 Service Case and the Type 73 Service Case (which I made before I did all the rest).

Also Gave Colony Security their missing comms since they apparently had none at all, only the Colony Security Leader did.

Note: I was originally going to make loadout choices for LEO's and their leaders, but I spent a better part of my day doing that and when I got it to work, the loadout choices froze on a set selection and I could not fix it.

## Why / Balance
Gives essential supplies and gear to LEO factions, since if more and more maps are going to move away vendors -See Barker's- they've got to at least have a proper spread of starting gear to let them perform their job well.

## Technical details
Added Several pieces of `equipment: ` to the various LEO Factions in `Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement`
Created a Type 73 Service Case with under the `id: AU14GunCasePistolT73`
Gave `ears: AU14ColonySecurityHeadset` under `equipment`: in 
`Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/AU14JobCivilianColonySecurityOfficer.yml`
Created `AU14PouchGeneralLargeLEOFilled` in `Resources/Prototypes/_CMU14/Entities/Clothing/Universal/pouches.yml
`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Additional starting gear to LEO officers/Leaders (Security Satchel/IFAK/Large Pouch With Binos, Radio, Cuffs/Faction Dependent Service Pistol/Faction Dependent Jacket/Pistol Holster) 
- tweak: LEO's will now find a clipboard and a universal recorder in their security belts.
- fix: Colony Security now have their missing headset.