### PR TITLE
Added Stasis Bag to Colonist First Responder Pouch, Gives EROs Medhud.

### DIFF
--- a/Resources/Prototypes/_CMU14/Entities/Clothing/Universal/pouches.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Clothing/Universal/pouches.yml
@@ -65,8 +65,8 @@
     - id: CMRollerBedSpawnFolded
     - id: CMFireExtinguisherPortable
     - id: AU14NaloxoneAutoInjector
-      amount: 2
-    - id: CMBodyBagFolded #intended since giving Stasis Body Bag to Colony wouldn't make sense since all Stasis bag's is slow down larva growth and since First Contact and all
+    - id: CMBodyBagFolded 
+    - id: CMStasisBagFolded
 
 - type: entity
   parent: RMCPouchPistol

--- a/Resources/Prototypes/_CMU14/Roles/Colony/Medical/Loadouts/ero.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/Medical/Loadouts/ero.yml
@@ -25,5 +25,6 @@
   equipment:
     ears: RMCFlashlightPen
     suitstorage: RMCFireAxe
+    eyes: RMCGlassesMedicalHUDGlasses
   inhand:
   - CMFireExtinguisher


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a stasis bag to the colonist first responder pouch, Give's ERO medhud glasses.

## Why / Balance
About the stasis bag addition; Maertayn raised a good point, about the ERO medhud addition; a bit odd that all medical staff sans the ERO have a medhud, since they are included as medical staff.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: EROs now start with a HealthMate Hud
- tweak: Filled Variant for Colony First Responder Pouches now have a Stasis bag in them
- remove: the second Naloxone injector is gone for said First Responder Pouche.
