### PR TITLE
Adds back V3's blood decals

### DIFF
--- a/Content.Server/Fluids/Components/PuddleDecalVisualsComponent.cs
+++ b/Content.Server/Fluids/Components/PuddleDecalVisualsComponent.cs
@@ -1,0 +1,31 @@
+using System.Numerics;
+using Content.Server.Fluids.EntitySystems;
+using Content.Shared.Decals;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Fluids.Components;
+
+[RegisterComponent, Access(typeof(PuddleSystem))]
+public sealed partial class PuddleDecalVisualsComponent : Component
+{
+    [DataField(required: true)]
+    public List<ProtoId<DecalPrototype>> Decals = new();
+
+    [DataField]
+    public Vector2 Offset = new(-0.5f, -0.5f);
+
+    [DataField]
+    public int ZIndex;
+
+    [DataField]
+    public bool Cleanable = true;
+
+    [DataField]
+    public bool RandomRotation = true;
+
+    [ViewVariables]
+    public uint? DecalId;
+
+    [ViewVariables]
+    public EntityUid? GridUid;
+}

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -1,5 +1,7 @@
+using System.Numerics;
 using Content.Server.Administration.Logs;
 using Content.Server.Chemistry.TileReactions;
+using Content.Server.Decals;
 using Content.Server.Fluids.Components;
 using Content.Server.Spreader;
 using Content.Shared.ActionBlocker;
@@ -11,8 +13,10 @@ using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reaction;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Database;
+using Content.Shared.Decals;
 using Content.Shared.Effects;
 using Content.Shared.FixedPoint;
+using Content.Shared.FootPrint;
 using Content.Shared.Fluids;
 using Content.Shared.Fluids.Components;
 using Content.Shared.Friction;
@@ -40,22 +44,27 @@ namespace Content.Server.Fluids.EntitySystems;
 /// </summary>
 public sealed partial class PuddleSystem : SharedPuddleSystem
 {
+    private static readonly EntProtoId PuddlePrototype = "Puddle";
+    private static readonly EntProtoId BloodDecalPuddlePrototype = "BloodDecalPuddle";
+    private static readonly ProtoId<ReagentPrototype> BloodReagent = "Blood";
+
     [Dependency] private ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private IAdminLogManager _adminLogger = default!;
-    [Dependency] private IGameTiming _timing = default!;
-    [Dependency] private SharedMapSystem _map = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
-    [Dependency] private RMCReagentSystem _reagent = default!;
-    [Dependency] private IRobustRandom _random = default!;
     [Dependency] private AudioSystem _audio = default!;
-    [Dependency] private EntityLookupSystem _lookup = default!;
-    [Dependency] private ReactiveSystem _reactive = default!;
     [Dependency] private SharedColorFlashEffectSystem _color = default!;
+    [Dependency] private DecalSystem _decals = default!;
+    [Dependency] private EntityLookupSystem _lookup = default!;
+    [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private SharedPopupSystem _popups = default!;
+    [Dependency] private IPrototypeManager _prototypeManager = default!;
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private ReactiveSystem _reactive = default!;
+    [Dependency] private RMCReagentSystem _reagent = default!;
     [Dependency] private SharedSolutionContainerSystem _solutionContainerSystem = default!;
-    [Dependency] private StepTriggerSystem _stepTrigger = default!;
     [Dependency] private SpeedModifierContactsSystem _speedModContacts = default!;
+    [Dependency] private StepTriggerSystem _stepTrigger = default!;
     [Dependency] private TileFrictionController _tile = default!;
+    [Dependency] private IGameTiming _timing = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private TurfSystem _turf = default!;
 
@@ -81,10 +90,20 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
         SubscribeLocalEvent<PuddleComponent, AnchorStateChangedEvent>(OnAnchorChanged);
         SubscribeLocalEvent<PuddleComponent, SpreadNeighborsEvent>(OnPuddleSpread);
         SubscribeLocalEvent<PuddleComponent, SlipEvent>(OnPuddleSlip);
+        SubscribeLocalEvent<PuddleDecalVisualsComponent, ComponentShutdown>(OnPuddleDecalShutdown);
 
         SubscribeLocalEvent<EvaporationComponent, MapInitEvent>(OnEvaporationMapInit);
 
         InitializeTransfers();
+    }
+
+    private void OnPuddleDecalShutdown(Entity<PuddleDecalVisualsComponent> entity, ref ComponentShutdown args)
+    {
+        if (entity.Comp.DecalId is { } decalId &&
+            entity.Comp.GridUid is { } gridUid)
+        {
+            _decals.RemoveDecal(gridUid, decalId);
+        }
     }
 
     private void OnPuddleSpread(Entity<PuddleComponent> entity, ref SpreadNeighborsEvent args)
@@ -335,6 +354,8 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
         if (!TryComp<StepTriggerComponent>(entity, out var comp))
             return;
 
+        var canPrintFootprints = HasComp<PuddleFootPrintsComponent>(entity);
+
         // Ensure we actually have the component
         EnsureComp<TileFrictionModifierComponent>(entity);
 
@@ -360,13 +381,22 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
         // Check if the puddle is big enough to slip in to avoid doing unnecessary logic
         if (solution.Volume <= smallPuddleThreshold)
         {
-            _stepTrigger.SetActive(entity, false, comp);
+            _stepTrigger.SetActive(entity, canPrintFootprints, comp);
+            if (canPrintFootprints)
+                _stepTrigger.SetRequiredTriggerSpeed(entity, 0f, comp);
+
             _tile.SetModifier(entity, 1f);
             return;
         }
 
         if (!TryComp<SlipperyComponent>(entity, out var slipComp))
+        {
+            _stepTrigger.SetActive(entity, canPrintFootprints, comp);
+            if (canPrintFootprints)
+                _stepTrigger.SetRequiredTriggerSpeed(entity, 0f, comp);
+
             return;
+        }
 
         foreach (var (reagent, quantity) in solution.Contents)
         {
@@ -392,13 +422,15 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
                 superSlipperyUnits += quantity;
         }
 
-        // Turn on the step trigger if it's slippery
-        _stepTrigger.SetActive(entity, slipperyUnits > smallPuddleThreshold, comp);
-
         // This is based of the total volume and not just the slippery volume because there is a default
         // slippery for all reagents even if they aren't technically slippery.
-        slipComp.SlipData.RequiredSlipSpeed = (float)(slipStepTrigger / solution.Volume);
+        slipComp.SlipData.RequiredSlipSpeed = canPrintFootprints
+            ? 0f
+            : (float)(slipStepTrigger / solution.Volume);
         _stepTrigger.SetRequiredTriggerSpeed(entity, slipComp.SlipData.RequiredSlipSpeed);
+
+        // Turn on the step trigger if it's slippery or can transfer footprints.
+        _stepTrigger.SetActive(entity, canPrintFootprints || slipperyUnits > smallPuddleThreshold, comp);
 
         // Divide these both by only total amount of slippery reagents.
         // A puddle with 10 units of lube vs a puddle with 10 of lube and 20 catchup should stun and launch forward the same amount.
@@ -473,7 +505,8 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
         bool sound = true,
         bool checkForOverflow = true,
         PuddleComponent? puddleComponent = null,
-        SolutionContainerManagerComponent? sol = null)
+        SolutionContainerManagerComponent? sol = null,
+        EntityCoordinates? decalCoordinates = null)
     {
         if (!Resolve(puddleUid, ref puddleComponent, ref sol))
             return false;
@@ -494,12 +527,10 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
             EnsureComp<ActiveEdgeSpreaderComponent>(puddleUid);
         }
 
-        if (!sound)
-        {
-            return true;
-        }
+        if (sound)
+            _audio.PlayPvs(puddleComponent.SpillSound, puddleUid);
 
-        _audio.PlayPvs(puddleComponent.SpillSound, puddleUid);
+        TrySpawnPuddleDecal(puddleUid, decalCoordinates);
         return true;
     }
 
@@ -608,7 +639,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
             return false;
         }
 
-        return TrySpillAt(_map.GetTileRef(gridUid.Value, mapGrid, coordinates), solution, out puddleUid, sound);
+        return TrySpillAt(_map.GetTileRef(gridUid.Value, mapGrid, coordinates), coordinates, solution, out puddleUid, sound);
     }
 
     /// <inheritdoc/>
@@ -628,6 +659,25 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
     public override bool TrySpillAt(TileRef tileRef, Solution solution, out EntityUid puddleUid, bool sound = true,
         bool tileReact = true)
     {
+        var gridId = tileRef.GridUid;
+        if (!TryComp<MapGridComponent>(gridId, out var mapGrid))
+        {
+            puddleUid = EntityUid.Invalid;
+            return false;
+        }
+
+        var coords = _map.GridTileToLocal(gridId, mapGrid, tileRef.GridIndices);
+        return TrySpillAt(tileRef, coords, solution, out puddleUid, sound, tileReact, mapGrid);
+    }
+
+    private bool TrySpillAt(TileRef tileRef,
+        EntityCoordinates spillCoordinates,
+        Solution solution,
+        out EntityUid puddleUid,
+        bool sound = true,
+        bool tileReact = true,
+        MapGridComponent? mapGrid = null)
+    {
         if (solution.Volume <= 0)
         {
             puddleUid = EntityUid.Invalid;
@@ -643,7 +693,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
 
         // Let's not spill to invalid grids.
         var gridId = tileRef.GridUid;
-        if (!TryComp<MapGridComponent>(gridId, out var mapGrid))
+        if (!Resolve(gridId, ref mapGrid, false))
         {
             puddleUid = EntityUid.Invalid;
             return false;
@@ -664,6 +714,10 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
 
         // Get normalized co-ordinate for spill location and spill it in the centre
         // TODO: Does SnapGrid or something else already do this?
+        var puddlePrototype = GetPuddlePrototype(solution);
+        var decalCoordinates = puddlePrototype == BloodDecalPuddlePrototype
+            ? spillCoordinates
+            : _map.GridTileToLocal(gridId, mapGrid, tileRef.GridIndices);
         var anchored = _map.GetAnchoredEntitiesEnumerator(gridId, mapGrid, tileRef.GridIndices);
         var puddleQuery = GetEntityQuery<PuddleComponent>();
         var sparklesQuery = GetEntityQuery<EvaporationSparkleComponent>();
@@ -680,7 +734,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
             if (!puddleQuery.TryGetComponent(ent, out var puddle))
                 continue;
 
-            if (TryAddSolution(ent.Value, solution, sound, puddleComponent: puddle))
+            if (TryAddSolution(ent.Value, solution, sound, puddleComponent: puddle, decalCoordinates: decalCoordinates))
             {
                 EnsureComp<ActiveEdgeSpreaderComponent>(ent.Value);
             }
@@ -690,9 +744,9 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
         }
 
         var coords = _map.GridTileToLocal(gridId, mapGrid, tileRef.GridIndices);
-        puddleUid = Spawn("Puddle", coords);
+        puddleUid = Spawn(puddlePrototype, coords);
         EnsureComp<PuddleComponent>(puddleUid);
-        if (TryAddSolution(puddleUid, solution, sound))
+        if (TryAddSolution(puddleUid, solution, sound, decalCoordinates: decalCoordinates))
         {
             EnsureComp<ActiveEdgeSpreaderComponent>(puddleUid);
         }
@@ -702,10 +756,162 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
 
     #endregion
 
+    private EntProtoId GetPuddlePrototype(Solution solution)
+    {
+        foreach (var (reagent, _) in solution.Contents)
+        {
+            if (reagent.Prototype == BloodReagent)
+                return BloodDecalPuddlePrototype;
+        }
+
+        return PuddlePrototype;
+    }
+
+    private void TrySpawnPuddleDecal(EntityUid puddleUid, EntityCoordinates? coordinates = null)
+    {
+        if (TryComp<PuddleDecalVisualsComponent>(puddleUid, out var decalVisuals))
+            TrySpawnPuddleDecal((puddleUid, decalVisuals), coordinates ?? Transform(puddleUid).Coordinates);
+    }
+
+    private void TrySpawnPuddleDecal(Entity<PuddleDecalVisualsComponent> ent, EntityCoordinates coordinates)
+    {
+        if (ent.Comp.DecalId != null ||
+            ent.Comp.Decals.Count == 0)
+            return;
+
+        if (_transform.GetGrid(coordinates) is not { } gridUid)
+            return;
+
+        var rotation = ent.Comp.RandomRotation ? _random.NextAngle() : Angle.Zero;
+        if (_decals.TryAddDecal(
+                _random.Pick(ent.Comp.Decals),
+                coordinates.Offset(ent.Comp.Offset),
+                out var decalId,
+                rotation: rotation,
+                zIndex: ent.Comp.ZIndex,
+                cleanable: ent.Comp.Cleanable))
+        {
+            ent.Comp.DecalId = decalId;
+            ent.Comp.GridUid = gridUid;
+        }
+    }
+
+    public override bool CleanDecalsAt(TileRef tileRef)
+    {
+        if (!TryGetDecalsAt(tileRef, out var grid, out var decalGrid, out var decals))
+            return false;
+
+        var removedAny = false;
+
+        ClearMissingPuddleDecalReferences(tileRef, grid, decalGrid);
+
+        foreach (var (index, decal) in decals)
+        {
+            if (!decal.Cleanable)
+                continue;
+
+            if (!_decals.RemoveDecal(tileRef.GridUid, index, decalGrid))
+                continue;
+
+            ClearPuddleDecalReference(tileRef, grid, index);
+            removedAny = true;
+        }
+
+        return removedAny;
+    }
+
+    public override bool HasCleanableDecalsAt(TileRef tileRef)
+    {
+        if (!TryGetDecalsAt(tileRef, out _, out _, out var decals))
+            return false;
+
+        foreach (var (_, decal) in decals)
+        {
+            if (decal.Cleanable)
+                return true;
+        }
+
+        return false;
+    }
+
+    private bool TryGetDecalsAt(
+        TileRef tileRef,
+        out MapGridComponent grid,
+        out DecalGridComponent decalGrid,
+        out HashSet<(uint Index, Decal Decal)> decals)
+    {
+        grid = default!;
+        decalGrid = default!;
+        decals = default!;
+
+        if (!TryComp<MapGridComponent>(tileRef.GridUid, out var gridComp) ||
+            !TryComp<DecalGridComponent>(tileRef.GridUid, out var decalGridComp))
+        {
+            return false;
+        }
+
+        grid = gridComp;
+        decalGrid = decalGridComp;
+
+        var bounds = _lookup.GetLocalBounds(tileRef, grid.TileSize)
+            .Enlarged(0.5f)
+            .Translated(new Vector2(-0.5f, -0.5f));
+        decals = _decals.GetDecalsIntersecting(tileRef.GridUid, bounds, decalGrid);
+        return true;
+    }
+
+    private void ClearMissingPuddleDecalReferences(TileRef tileRef, MapGridComponent grid, DecalGridComponent decalGrid)
+    {
+        var anchored = _map.GetAnchoredEntitiesEnumerator(tileRef.GridUid, grid, tileRef.GridIndices);
+
+        while (anchored.MoveNext(out var ent))
+        {
+            if (!TryComp<PuddleDecalVisualsComponent>(ent.Value, out var decalVisuals) ||
+                decalVisuals.GridUid != tileRef.GridUid ||
+                decalVisuals.DecalId is not { } decalId ||
+                PuddleDecalExists(decalGrid, decalId))
+            {
+                continue;
+            }
+
+            decalVisuals.DecalId = null;
+            decalVisuals.GridUid = null;
+        }
+    }
+
+    private static bool PuddleDecalExists(DecalGridComponent decalGrid, uint decalId)
+    {
+        foreach (var chunk in decalGrid.ChunkCollection.ChunkCollection.Values)
+        {
+            if (chunk.Decals.ContainsKey(decalId))
+                return true;
+        }
+
+        return false;
+    }
+
+    private void ClearPuddleDecalReference(TileRef tileRef, MapGridComponent grid, uint decalId)
+    {
+        var anchored = _map.GetAnchoredEntitiesEnumerator(tileRef.GridUid, grid, tileRef.GridIndices);
+
+        while (anchored.MoveNext(out var ent))
+        {
+            if (!TryComp<PuddleDecalVisualsComponent>(ent.Value, out var decalVisuals) ||
+                decalVisuals.GridUid != tileRef.GridUid ||
+                decalVisuals.DecalId != decalId)
+            {
+                continue;
+            }
+
+            decalVisuals.DecalId = null;
+            decalVisuals.GridUid = null;
+        }
+    }
+
     /// <summary>
     /// Tries to get the relevant puddle entity for a tile.
     /// </summary>
-    public bool TryGetPuddle(TileRef tile, out EntityUid puddleUid)
+    public override bool TryGetPuddle(TileRef tile, out EntityUid puddleUid)
     {
         puddleUid = EntityUid.Invalid;
 

--- a/Content.Server/FootPrint/FootPrintsSystem.cs
+++ b/Content.Server/FootPrint/FootPrintsSystem.cs
@@ -7,27 +7,29 @@ using Content.Shared.Mobs.Components;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.FootPrint;
 
 public sealed partial class FootPrintsSystem : EntitySystem
 {
-    [Dependency] private IRobustRandom _random = default!;
     [Dependency] private DecalSystem _decals = default!;
-    [Dependency] private IMapManager _map = default!;
-    [Dependency] private SharedMapSystem _mapSystem = default!;
-    [Dependency] private SharedXenoWeedsSystem _weeds = default!;
+    [Dependency] private SharedMapSystem _map = default!;
+    [Dependency] private IRobustRandom _random = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private SharedXenoWeedsSystem _weeds = default!;
 
-    private EntityQuery<TransformComponent> _transformQuery;
-    private EntityQuery<MobThresholdsComponent> _mobThresholdQuery;
-    private EntityQuery<MapGridComponent> _gridQuery;
     private EntityQuery<DecalGridComponent> _decalGridQuery;
+    private EntityQuery<MapGridComponent> _gridQuery;
+    private EntityQuery<MobThresholdsComponent> _mobThresholdQuery;
+    private EntityQuery<TransformComponent> _transformQuery;
 
-    // Cap how many dragging footprint decals can coexist on a single tile.
+    // Cap how many footprint decals can coexist on a single tile.
     private const int MaxFootprintsPerTile = 8;
     private static readonly Vector2 DecalCenterOffset = new(-0.5f, -0.5f);
+    private static readonly Angle DraggingRotationOffset = Angle.FromDegrees(-90f);
+    private static readonly Angle StepRotationOffset = Angle.FromDegrees(180f);
 
     // Multiplier applied to a footprint's alpha when it is placed on xeno weeds;
     // keeps the weeds underneath visible.
@@ -37,10 +39,10 @@ public sealed partial class FootPrintsSystem : EntitySystem
     {
         base.Initialize();
 
-        _transformQuery = GetEntityQuery<TransformComponent>();
-        _mobThresholdQuery = GetEntityQuery<MobThresholdsComponent>();
-        _gridQuery = GetEntityQuery<MapGridComponent>();
         _decalGridQuery = GetEntityQuery<DecalGridComponent>();
+        _gridQuery = GetEntityQuery<MapGridComponent>();
+        _mobThresholdQuery = GetEntityQuery<MobThresholdsComponent>();
+        _transformQuery = GetEntityQuery<TransformComponent>();
 
         SubscribeLocalEvent<FootPrintsComponent, ComponentStartup>(OnStartupComponent);
         SubscribeLocalEvent<FootPrintsComponent, MoveEvent>(OnMove);
@@ -56,17 +58,17 @@ public sealed partial class FootPrintsSystem : EntitySystem
         if (component.PrintsColor.A <= 0f
             || !_transformQuery.TryComp(uid, out var transform)
             || !_mobThresholdQuery.TryComp(uid, out var mobThreshHolds)
-            || !_mapSystem.TryFindGridAt(_transform.GetMapCoordinates((uid, transform)), out var gridUid, out _))
+            || !_map.TryFindGridAt(_transform.GetMapCoordinates((uid, transform)), out var gridUid, out _))
             return;
 
         var dragging = mobThreshHolds.CurrentThresholdState is MobState.Critical or MobState.Dead;
-        var distance = (transform.LocalPosition - component.StepPos).Length();
+        var stepDelta = transform.LocalPosition - component.StepPos;
         var stepSize = dragging ? component.DragSize : component.StepSize;
 
-        if (!(distance > stepSize))
+        if (stepDelta.LengthSquared() <= stepSize * stepSize)
             return;
 
-        if (!dragging || component.DraggingDecals.Count == 0)
+        if (dragging && component.DraggingDecals.Count == 0)
         {
             component.StepPos = transform.LocalPosition;
             return;
@@ -74,21 +76,26 @@ public sealed partial class FootPrintsSystem : EntitySystem
 
         component.RightStep = !component.RightStep;
 
-        var spawnCoords = new EntityCoordinates(gridUid, transform.LocalPosition);
+        var spawnCoords = CalcCoords(gridUid, component, transform, dragging);
+        MapGridComponent? gridComp = null;
+        _gridQuery.TryComp(gridUid, out gridComp);
 
-        if (_gridQuery.TryComp(gridUid, out var gridComp))
+        if (!dragging)
         {
-            var tile = _mapSystem.CoordinatesToTile(gridUid, gridComp, spawnCoords);
-            if (_decalGridQuery.TryComp(gridUid, out var decalGrid) &&
-                CountDraggingDecalsInTile(gridUid, tile, component, decalGrid) >= MaxFootprintsPerTile)
+            if (IsFootprintTileAtCap(gridUid, spawnCoords, component, gridComp, draggingOnly: false))
                 return;
+
+            SpawnStepFootprintDecal(component, transform, gridUid, spawnCoords, gridComp);
+            component.StepPos = transform.LocalPosition;
+            return;
         }
 
-        var stepColor = component.PrintsColor;
-        if (gridComp != null && _weeds.IsOnWeeds((gridUid, gridComp), spawnCoords))
-            stepColor = stepColor.WithAlpha(stepColor.A * WeedAlphaMultiplier);
+        if (IsFootprintTileAtCap(gridUid, spawnCoords, component, gridComp, draggingOnly: true))
+            return;
 
-        var rotation = (transform.LocalPosition - component.StepPos).ToAngle() + Angle.FromDegrees(-90f);
+        var stepColor = GetFootprintColor(component, gridUid, spawnCoords, gridComp);
+
+        var rotation = stepDelta.ToAngle() + DraggingRotationOffset;
         _decals.TryAddDecal(
             _random.Pick(component.DraggingDecals),
             spawnCoords.Offset(DecalCenterOffset),
@@ -97,29 +104,136 @@ public sealed partial class FootPrintsSystem : EntitySystem
             rotation,
             cleanable: true);
 
-        component.PrintsColor = component.PrintsColor.WithAlpha(Math.Max(0f, component.PrintsColor.A - component.ColorReduceAlpha));
+        FadePrintColor(component);
         component.StepPos = transform.LocalPosition;
     }
 
-    private int CountDraggingDecalsInTile(
+    private void SpawnStepFootprintDecal(
+        FootPrintsComponent component,
+        TransformComponent transform,
+        EntityUid gridUid,
+        EntityCoordinates spawnCoords,
+        MapGridComponent? gridComp)
+    {
+        _decals.TryAddDecal(
+            PickStepDecal(component),
+            spawnCoords.Offset(DecalCenterOffset),
+            out _,
+            GetFootprintColor(component, gridUid, spawnCoords, gridComp),
+            transform.LocalRotation + StepRotationOffset,
+            cleanable: true);
+
+        FadePrintColor(component);
+    }
+
+    private Color GetFootprintColor(
+        FootPrintsComponent component,
+        EntityUid gridUid,
+        EntityCoordinates spawnCoords,
+        MapGridComponent? gridComp)
+    {
+        var stepColor = component.PrintsColor;
+        if (gridComp != null && _weeds.IsOnWeeds((gridUid, gridComp), spawnCoords))
+            return stepColor.WithAlpha(stepColor.A * WeedAlphaMultiplier);
+
+        return stepColor;
+    }
+
+    private static void FadePrintColor(FootPrintsComponent component)
+    {
+        var alpha = Math.Max(0f, component.PrintsColor.A - component.ColorReduceAlpha);
+        component.PrintsColor = component.PrintsColor.WithAlpha(alpha);
+
+        if (alpha > 0f)
+            return;
+
+        component.ColorQuantity = 0f;
+        component.ReagentToTransfer = null;
+    }
+
+    private static EntityCoordinates CalcCoords(
+        EntityUid gridUid,
+        FootPrintsComponent component,
+        TransformComponent transform,
+        bool dragging)
+    {
+        if (dragging)
+            return new EntityCoordinates(gridUid, transform.LocalPosition);
+
+        var offset = component.RightStep
+            ? new Angle(StepRotationOffset + transform.LocalRotation).RotateVec(component.OffsetPrint)
+            : new Angle(transform.LocalRotation).RotateVec(component.OffsetPrint);
+
+        return new EntityCoordinates(gridUid, transform.LocalPosition + offset);
+    }
+
+    private static ProtoId<DecalPrototype> PickStepDecal(FootPrintsComponent component)
+    {
+        return component.RightStep ? component.RightBareDecal : component.LeftBareDecal;
+    }
+
+    private bool IsFootprintTileAtCap(
+        EntityUid gridUid,
+        EntityCoordinates spawnCoords,
+        FootPrintsComponent component,
+        MapGridComponent? gridComp,
+        bool draggingOnly)
+    {
+        if (gridComp == null ||
+            !_decalGridQuery.TryComp(gridUid, out var decalGrid))
+        {
+            return false;
+        }
+
+        var tile = _map.CoordinatesToTile(gridUid, gridComp, spawnCoords);
+        return IsFootprintTileAtCap(gridUid, tile, component, decalGrid, draggingOnly);
+    }
+
+    private bool IsFootprintTileAtCap(
         EntityUid gridUid,
         Vector2i tile,
         FootPrintsComponent component,
-        DecalGridComponent decalGrid)
+        DecalGridComponent decalGrid,
+        bool draggingOnly)
     {
         var min = new Vector2(tile.X, tile.Y);
         var bounds = new Box2(min, min + Vector2.One);
-        var decals = _decals.GetDecalsIntersecting(gridUid, bounds, decalGrid);
+        var chunkCollection = decalGrid.ChunkCollection.ChunkCollection;
+        var chunks = new Robust.Shared.Map.Enumerators.ChunkIndicesEnumerator(bounds, SharedDecalSystem.ChunkSize);
         var count = 0;
 
-        foreach (var (_, decal) in decals)
+        while (chunks.MoveNext(out var chunkOrigin))
         {
-            if (!component.DraggingDecals.Contains(decal.Id))
+            if (!chunkCollection.TryGetValue(chunkOrigin.Value, out var chunk))
                 continue;
 
-            count++;
+            foreach (var (_, decal) in chunk.Decals)
+            {
+                if (!bounds.Contains(decal.Coordinates))
+                    continue;
+
+                if (!IsFootprintDecal(decal.Id, component, draggingOnly))
+                    continue;
+
+                count++;
+
+                if (count >= MaxFootprintsPerTile)
+                    return true;
+            }
         }
 
-        return count;
+        return false;
+    }
+
+    private static bool IsFootprintDecal(string id, FootPrintsComponent component, bool draggingOnly)
+    {
+        if (component.DraggingDecals.Contains(id))
+            return true;
+
+        return !draggingOnly &&
+               (id == component.LeftBareDecal ||
+                id == component.RightBareDecal ||
+                id == component.ShoesDecal ||
+                id == component.SuitDecal);
     }
 }

--- a/Content.Server/FootPrint/PuddleFootPrintsSystem.cs
+++ b/Content.Server/FootPrint/PuddleFootPrintsSystem.cs
@@ -1,41 +1,56 @@
-using System.Linq;
-using Content.Shared.FootPrint;
+using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Fluids;
 using Content.Shared.Fluids.Components;
-using Robust.Shared.Physics.Events;
+using Content.Shared.FootPrint;
+using Content.Shared.StepTrigger.Systems;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.FootPrint;
 
 public sealed partial class PuddleFootPrintsSystem : EntitySystem
 {
+    private static readonly ProtoId<ReagentPrototype> WaterReagent = "Water";
+
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] private SharedSolutionContainerSystem _solutionContainer = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<PuddleFootPrintsComponent, EndCollideEvent>(OnStepTrigger);
+        SubscribeLocalEvent<PuddleFootPrintsComponent, StepTriggerAttemptEvent>(OnStepTriggerAttempt);
+        SubscribeLocalEvent<PuddleFootPrintsComponent, StepTriggeredOffEvent>(OnStepTrigger);
     }
 
-    private void OnStepTrigger(EntityUid uid, PuddleFootPrintsComponent component, ref EndCollideEvent args)
+    private void OnStepTriggerAttempt(EntityUid uid, PuddleFootPrintsComponent component, ref StepTriggerAttemptEvent args)
+    {
+        args.Continue |= HasComp<FootPrintsComponent>(args.Tripper);
+    }
+
+    private void OnStepTrigger(EntityUid uid, PuddleFootPrintsComponent component, ref StepTriggeredOffEvent args)
     {
         if (!TryComp<AppearanceComponent>(uid, out var appearance)
             || !TryComp<PuddleComponent>(uid, out var puddle)
-            || !TryComp<FootPrintsComponent>(args.OtherEntity, out var tripper)
+            || !TryComp<FootPrintsComponent>(args.Tripper, out var tripper)
             || !TryComp<SolutionContainerManagerComponent>(uid, out var solutionManager)
             || !_solutionContainer.ResolveSolution((uid, solutionManager), puddle.SolutionName, ref puddle.Solution, out var solutions))
             return;
 
-        var totalSolutionQuantity = solutions.Contents.Sum(sol => (float) sol.Quantity);
-        var waterQuantity = (from sol in solutions.Contents where sol.Reagent.Prototype == "Water" select (float) sol.Quantity).FirstOrDefault();
-
-        if (waterQuantity / (totalSolutionQuantity / 100f) > component.OffPercent || solutions.Contents.Count <= 0)
+        if (solutions.Contents.Count <= 0)
             return;
 
-        tripper.ReagentToTransfer =
-            solutions.Contents.Aggregate((l, r) => l.Quantity > r.Quantity ? l : r).Reagent.Prototype;
+        if (!TryGetFootprintReagent(solutions, out var totalSolutionQuantity, out var waterQuantity, out var reagentToTransfer))
+            return;
+
+        if (waterQuantity > totalSolutionQuantity * component.OffPercent / 100f ||
+            !component.ActivatedEntities.Add(args.Tripper))
+        {
+            return;
+        }
+
+        tripper.ReagentToTransfer = reagentToTransfer;
 
         if (_appearance.TryGetData(uid, PuddleVisuals.SolutionColor, out var color, appearance)
             && _appearance.TryGetData(uid, PuddleVisuals.CurrentVolume, out var volume, appearance))
@@ -44,9 +59,40 @@ public sealed partial class PuddleFootPrintsSystem : EntitySystem
         _solutionContainer.RemoveEachReagent(puddle.Solution.Value, 1);
     }
 
-    private void AddColor(Color col, float quantity, FootPrintsComponent component)
+    private static bool TryGetFootprintReagent(
+        Solution solution,
+        out float totalQuantity,
+        out float waterQuantity,
+        out string? reagentToTransfer)
     {
-        component.PrintsColor = component.ColorQuantity == 0f ? col : Color.InterpolateBetween(component.PrintsColor, col, component.ColorInterpolationFactor);
+        totalQuantity = 0f;
+        waterQuantity = 0f;
+        reagentToTransfer = null;
+        var largestQuantity = 0f;
+
+        foreach (var reagentQuantity in solution.Contents)
+        {
+            var quantity = (float) reagentQuantity.Quantity;
+            totalQuantity += quantity;
+
+            if (reagentQuantity.Reagent.Prototype == WaterReagent)
+                waterQuantity += quantity;
+
+            if (quantity <= largestQuantity)
+                continue;
+
+            largestQuantity = quantity;
+            reagentToTransfer = reagentQuantity.Reagent.Prototype;
+        }
+
+        return totalQuantity > 0f && reagentToTransfer != null;
+    }
+
+    private static void AddColor(Color col, float quantity, FootPrintsComponent component)
+    {
+        component.PrintsColor = component.ColorQuantity == 0f
+            ? col
+            : Color.InterpolateBetween(component.PrintsColor, col, component.ColorInterpolationFactor);
         component.ColorQuantity += quantity;
     }
 }

--- a/Content.Shared/Fluids/SharedAbsorbentSystem.cs
+++ b/Content.Shared/Fluids/SharedAbsorbentSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Popups;
 using Content.Shared.Timing;
 using Content.Shared.Weapons.Melee;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
 
@@ -50,11 +51,18 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
 
     private void OnAfterInteract(Entity<AbsorbentComponent> ent, ref AfterInteractEvent args)
     {
-        if (!args.CanReach || args.Handled || args.Target is not { } target)
+        if (!args.CanReach || args.Handled)
             return;
 
-        Mop(ent, args.User, target);
-        args.Handled = true;
+        if (args.Target is { } target)
+        {
+            Mop(ent, args.User, target);
+            args.Handled = true;
+            return;
+        }
+
+        if (TryTileInteract(ent, args.User, args.ClickLocation))
+            args.Handled = true;
     }
 
     private void OnAbsorbentSolutionChange(Entity<AbsorbentComponent> ent, ref SolutionContainerChangedEvent args)
@@ -105,6 +113,71 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
 
         // If it's refillable try to transfer
         TryRefillableInteract((absorbEnt.Owner, absorbEnt.Comp, useDelay), absorberSoln.Value, user, target);
+    }
+
+    private bool TryTileInteract(Entity<AbsorbentComponent> absorbEnt, EntityUid user, EntityCoordinates clickLocation)
+    {
+        if (!TryGetTileRef(clickLocation, out var tileRef))
+            return false;
+
+        if (Puddle.TryGetPuddle(tileRef, out var puddle))
+        {
+            Mop(absorbEnt, user, puddle);
+            return true;
+        }
+
+        if (!Puddle.HasCleanableDecalsAt(tileRef))
+            return false;
+
+        if (!SolutionContainer.TryGetSolution(absorbEnt.Owner, absorbEnt.Comp.SolutionName, out var absorberSoln))
+            return false;
+
+        if (TryComp<UseDelayComponent>(absorbEnt, out var useDelay)
+            && _useDelay.IsDelayed((absorbEnt.Owner, useDelay)))
+        {
+            return false;
+        }
+
+        var absorber = absorbEnt.Comp;
+        if (absorber.UseAbsorberSolution)
+        {
+            var absorberSolution = absorberSoln.Value.Comp.Solution;
+            var available = absorberSolution.GetTotalPrototypeQuantity(Puddle.GetAbsorbentReagents(absorberSolution));
+
+            if (available == FixedPoint2.Zero)
+            {
+                _popups.PopupClient(Loc.GetString("mopping-system-no-water", ("used", absorbEnt)), absorbEnt, user);
+                return true;
+            }
+
+            Puddle.DoTileReactions(tileRef, absorberSolution);
+            SolutionContainer.UpdateChemicals(absorberSoln.Value);
+        }
+
+        Puddle.CleanDecalsAt(tileRef);
+
+        _audio.PlayPredicted(absorber.PickupSound, absorbEnt, user);
+        PredictedSpawnAttachedTo(absorber.MoppedEffect, clickLocation);
+
+        if (useDelay != null)
+            _useDelay.TryResetDelay((absorbEnt.Owner, useDelay));
+
+        DoMopLunge(user, absorbEnt, clickLocation);
+        return true;
+    }
+
+    private bool TryGetTileRef(EntityCoordinates coordinates, out TileRef tileRef)
+    {
+        tileRef = default;
+        var gridUid = _transform.GetGrid(coordinates);
+        if (gridUid == null ||
+            !TryComp<MapGridComponent>(gridUid, out var mapGrid) ||
+            !_mapSystem.TryGetTileRef(gridUid.Value, mapGrid, coordinates, out tileRef))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary>
@@ -320,6 +393,7 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
             {
                 var tileRef = _mapSystem.GetTileRef(gridUid.Value, mapGrid, targetXform.Coordinates);
                 Puddle.DoTileReactions(tileRef, absorberSplit);
+                Puddle.CleanDecalsAt(tileRef);
             }
             SolutionContainer.AddSolution(puddle.Solution.Value, absorberSplit);
         }
@@ -331,7 +405,15 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
             if (puddleSolution.Volume == FixedPoint2.Zero)
             {
                 // Spawn a *sparkle*
-                PredictedSpawnAttachedTo(absorber.MoppedEffect, Transform(target).Coordinates);
+                var targetXform = Transform(target);
+                var gridUid = targetXform.GridUid;
+                if (TryComp<MapGridComponent>(gridUid, out var mapGrid))
+                {
+                    var tileRef = _mapSystem.GetTileRef(gridUid.Value, mapGrid, targetXform.Coordinates);
+                    Puddle.CleanDecalsAt(tileRef);
+                }
+
+                PredictedSpawnAttachedTo(absorber.MoppedEffect, targetXform.Coordinates);
                 PredictedQueueDel(target);
                 isRemoved = true;
             }
@@ -344,13 +426,18 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
         if (useDelay != null)
             _useDelay.TryResetDelay((absorbEnt, useDelay));
 
+        DoMopLunge(user, absorbEnt, Transform(target).Coordinates);
+
+        return true;
+    }
+
+    private void DoMopLunge(EntityUid user, Entity<AbsorbentComponent> absorbEnt, EntityCoordinates targetCoordinates)
+    {
         var userXform = Transform(user);
-        var targetPos = _transform.GetWorldPosition(target);
+        var targetPos = _transform.ToMapCoordinates(targetCoordinates).Position;
         var localPos = Vector2.Transform(targetPos, _transform.GetInvWorldMatrix(userXform));
         localPos = userXform.LocalRotation.RotateVec(localPos);
 
         _melee.DoLunge(user, absorbEnt, Angle.Zero, localPos, null);
-
-        return true;
     }
 }

--- a/Content.Shared/Fluids/SharedPuddleSystem.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.cs
@@ -194,6 +194,31 @@ public abstract partial class SharedPuddleSystem : EntitySystem
         }
     }
 
+    /// <summary>
+    ///     Removes cleanable decals from a tile. Server-side puddle systems override this.
+    /// </summary>
+    public virtual bool CleanDecalsAt(TileRef tileRef)
+    {
+        return false;
+    }
+
+    /// <summary>
+    ///     Returns true if a tile has any cleanable decals. Server-side puddle systems override this.
+    /// </summary>
+    public virtual bool HasCleanableDecalsAt(TileRef tileRef)
+    {
+        return false;
+    }
+
+    /// <summary>
+    ///     Tries to get the puddle entity for a tile. On the client, this always returns false.
+    /// </summary>
+    public virtual bool TryGetPuddle(TileRef tile, out EntityUid puddleUid)
+    {
+        puddleUid = EntityUid.Invalid;
+        return false;
+    }
+
     #region Spill
     // These methods are in Shared to make it easier to interact with PuddleSystem in Shared code.
     // Note that they always fail when run on the client, not creating a puddle and returning false.

--- a/Content.Shared/FootPrint/FootPrintsComponent.cs
+++ b/Content.Shared/FootPrint/FootPrintsComponent.cs
@@ -44,6 +44,18 @@ public sealed partial class FootPrintsComponent : Component
     };
 
     [ViewVariables(VVAccess.ReadOnly), DataField]
+    public ProtoId<DecalPrototype> LeftBareDecal = "FootprintBareLeft";
+
+    [ViewVariables(VVAccess.ReadOnly), DataField]
+    public ProtoId<DecalPrototype> RightBareDecal = "FootprintBareRight";
+
+    [ViewVariables(VVAccess.ReadOnly), DataField]
+    public ProtoId<DecalPrototype> ShoesDecal = "FootprintShoes";
+
+    [ViewVariables(VVAccess.ReadOnly), DataField]
+    public ProtoId<DecalPrototype> SuitDecal = "FootprintSuit";
+
+    [ViewVariables(VVAccess.ReadOnly), DataField]
     public EntProtoId<FootPrintComponent> StepProtoId = "Footstep";
 
     [ViewVariables(VVAccess.ReadOnly), DataField]

--- a/Content.Shared/FootPrint/PuddleFootPrintsComponent.cs
+++ b/Content.Shared/FootPrint/PuddleFootPrintsComponent.cs
@@ -8,4 +8,7 @@ public sealed partial class PuddleFootPrintsComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite)]
     public float OffPercent = 80f;
+
+    [ViewVariables]
+    public HashSet<EntityUid> ActivatedEntities = new();
 }

--- a/Resources/Prototypes/Decals/footprints.yml
+++ b/Resources/Prototypes/Decals/footprints.yml
@@ -1,4 +1,40 @@
 - type: decal
+  id: FootprintBareLeft
+  showMenu: false
+  defaultCleanable: true
+  defaultSnap: false
+  sprite:
+    sprite: Effects/footprints.rsi
+    state: footprint-left-bare-human
+
+- type: decal
+  id: FootprintBareRight
+  showMenu: false
+  defaultCleanable: true
+  defaultSnap: false
+  sprite:
+    sprite: Effects/footprints.rsi
+    state: footprint-right-bare-human
+
+- type: decal
+  id: FootprintShoes
+  showMenu: false
+  defaultCleanable: true
+  defaultSnap: false
+  sprite:
+    sprite: Effects/footprints.rsi
+    state: footprint-shoes
+
+- type: decal
+  id: FootprintSuit
+  showMenu: false
+  defaultCleanable: true
+  defaultSnap: false
+  sprite:
+    sprite: Effects/footprints.rsi
+    state: footprint-suit
+
+- type: decal
   id: FootprintDragging1
   showMenu: false
   defaultCleanable: true

--- a/Resources/Prototypes/_RMC14/Entities/Effects/blood_puddle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Effects/blood_puddle.yml
@@ -1,0 +1,61 @@
+- type: entity
+  name: blood puddle
+  id: BloodDecalPuddle
+  description: A puddle of blood.
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: TimedDespawn
+    lifetime: 60
+  - type: Clickable
+  - type: Slippery
+  - type: Transform
+    noRot: true
+    anchored: true
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      slipFixture:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.4,-0.4,0.4,0.4"
+        mask:
+        - ItemMask
+        layer:
+        - SlipLayer
+        hard: false
+  - type: SolutionContainerManager
+    solutions:
+      puddle:
+        maxVol: 1000
+  - type: Puddle
+  - type: PuddleFootPrints
+  - type: PuddleDecalVisuals
+    decals:
+    - RMCDecalBloodFloor1
+    - RMCDecalBloodFloor2
+    - RMCDecalBloodFloor3
+    - RMCDecalBloodFloor4
+    - RMCDecalBloodFloor5
+    - RMCDecalBloodFloor6
+    - RMCDecalBloodFloor7
+  - type: MixableSolution
+    solution: puddle
+  - type: Appearance
+  - type: ActiveEdgeSpreader
+  - type: EdgeSpreader
+    id: Puddle
+  - type: StepTrigger
+  - type: Drink
+    delay: 3
+    transferAmount: 1
+    solution: puddle
+    examinable: false
+  - type: ExaminableSolution
+    solution: puddle
+  - type: BadDrink
+  - type: IgnoresFingerprints
+  - type: Tag
+    tags:
+    - DNASolutionScannable


### PR DESCRIPTION
 :cl:
- add: Blood puddles now use random blood decals instead of puddle sprites.
- add: Footprints return when walking or dragging through blood
- fix: Mops can clean blood and footprint decals from the clicked tile.