### PR TITLE
Add xeno sunder effects to armor and healing

### DIFF
--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared._RMC14.Medical.Surgery.Steps;
 using Content.Shared._RMC14.Weapons.Ranged;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit.Slowing;
+using Content.Shared._RMC14.Xenonids.Sunder;
 using Content.Shared.Alert;
 using Content.Shared.Armor;
 using Content.Shared.Clothing.Components;
@@ -121,22 +122,29 @@ public sealed partial class CMArmorSystem : EntitySystem
 
         var ev = new CMGetArmorEvent(SlotFlags.OUTERCLOTHING | SlotFlags.INNERCLOTHING);
         RaiseLocalEvent(armored, ref ev);
+        var sunder = CompOrNull<XenoSunderComponent>(armored);
+        var xenoArmor = GetEffectiveXenoArmor(ev.XenoArmor * ev.ArmorModifier, sunder);
+        var frontalArmor = GetEffectiveXenoArmor((ev.XenoArmor + ev.FrontalArmor) * ev.ArmorModifier, sunder);
+        var sideArmor = GetEffectiveXenoArmor((ev.XenoArmor + ev.SideArmor) * ev.ArmorModifier, sunder);
         var armorMessage = ev.FrontalArmor == 0 &&
                            ev.SideArmor == 0 &&
                            armored.Comp.FrontalArmor == 0 &&
                            armored.Comp.SideArmor == 0
-            ? $"{FixedPoint2.New(ev.XenoArmor * ev.ArmorModifier)} / {armored.Comp.XenoArmor}"
-            : $"Overall: {FixedPoint2.New(ev.XenoArmor * ev.ArmorModifier)} / {armored.Comp.XenoArmor}";
+            ? $"{FixedPoint2.New(xenoArmor)} / {armored.Comp.XenoArmor}"
+            : $"Overall: {FixedPoint2.New(xenoArmor)} / {armored.Comp.XenoArmor}";
 
         if (armored.Comp.FrontalArmor != 0 || ev.FrontalArmor != 0)
-            armorMessage = $"{armorMessage}\nFrontal: {FixedPoint2.New((ev.XenoArmor + ev.FrontalArmor) * ev.ArmorModifier)} / {armored.Comp.XenoArmor + armored.Comp.FrontalArmor}";
+            armorMessage = $"{armorMessage}\nFrontal: {FixedPoint2.New(frontalArmor)} / {armored.Comp.XenoArmor + armored.Comp.FrontalArmor}";
 
         if (armored.Comp.SideArmor != 0 || ev.SideArmor != 0)
-            armorMessage = $"{armorMessage}\nSide: {FixedPoint2.New((ev.XenoArmor + ev.SideArmor) * ev.ArmorModifier)} / {armored.Comp.XenoArmor + armored.Comp.SideArmor}";
+            armorMessage = $"{armorMessage}\nSide: {FixedPoint2.New(sideArmor)} / {armored.Comp.XenoArmor + armored.Comp.SideArmor}";
+
+        if (sunder != null && sunder.Amount > FixedPoint2.Zero)
+            armorMessage = $"{armorMessage}\nSunder: {FixedPoint2.New(GetSunderPercent(sunder))}%";
 
         var max = _alerts.GetMaxSeverity(xeno.ArmorAlert);
 
-        var severity = max - ContentHelpers.RoundToLevels(ev.XenoArmor * ev.ArmorModifier, MaxXenoArmor, max + 1);
+        var severity = max - ContentHelpers.RoundToLevels(xenoArmor, MaxXenoArmor, max + 1);
         _alerts.ShowAlert(armored, xeno.ArmorAlert, (short)severity, dynamicMessage: armorMessage);
     }
 
@@ -326,6 +334,9 @@ public sealed partial class CMArmorSystem : EntitySystem
     private void ModifyDamage(EntityUid ent, ref DamageModifyEvent args)
     {
         // TODO RMC14 the slot should depend on the part that is receiving the damage once part damage is in
+        var xeno = HasComp<XenoComponent>(ent);
+        TryComp<XenoSunderComponent>(ent, out var sunder);
+
         var ev = new CMGetArmorEvent(SlotFlags.OUTERCLOTHING | SlotFlags.INNERCLOTHING);
         RaiseLocalEvent(ent, ref ev);
 
@@ -338,7 +349,7 @@ public sealed partial class CMArmorSystem : EntitySystem
         }
 
         var immuneToAP = TryComp<CMArmorComponent>(ent, out var armorComp) && armorComp.ImmuneToAP;
-        if (HasComp<XenoComponent>(ent))
+        if (xeno)
         {
             ev.XenoArmor = (int)(ev.XenoArmor * ev.ArmorModifier);
             if (!immuneToAP)
@@ -379,11 +390,14 @@ public sealed partial class CMArmorSystem : EntitySystem
             }
         }
 
+        if (xeno)
+            ev.XenoArmor = Math.Max((int)Math.Round(GetEffectiveXenoArmor(ev.XenoArmor, sunder)), 0);
+
         //Default modifier
         var mod = EnsureComp<RMCArmorModifierComponent>(ent);
 
         args.Damage = new DamageSpecifier(args.Damage);
-        if (!HasComp<XenoComponent>(ent))
+        if (!xeno)
         {
             if (HasComp<RMCBulletComponent>(args.Tool))
             {
@@ -533,6 +547,26 @@ public sealed partial class CMArmorSystem : EntitySystem
             return;
 
         EntityManager.AddComponents(ent, allowed);
+    }
+
+    private static double GetEffectiveXenoArmor(double armor, XenoSunderComponent? sunder)
+    {
+        if (sunder == null ||
+            sunder.Amount <= FixedPoint2.Zero ||
+            sunder.Max <= FixedPoint2.Zero)
+        {
+            return armor;
+        }
+
+        return armor * Math.Clamp(1 - sunder.Amount.Float() / sunder.Max.Float(), 0, 1);
+    }
+
+    private static double GetSunderPercent(XenoSunderComponent sunder)
+    {
+        if (sunder.Max <= FixedPoint2.Zero)
+            return 0;
+
+        return Math.Clamp(sunder.Amount.Float() / sunder.Max.Float() * 100, 0, 100);
     }
 
     private FormattedMessage GetArmorExamine(CMArmorComponent armorComponent)

--- a/Content.Shared/_RMC14/Xenonids/Heal/SharedXenoHealSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Heal/SharedXenoHealSystem.cs
@@ -10,7 +10,9 @@ using Content.Shared._RMC14.Xenonids.Energy;
 using Content.Shared._RMC14.Xenonids.Eye;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Parasite;
+using Content.Shared._RMC14.Xenonids.Pheromones;
 using Content.Shared._RMC14.Xenonids.Plasma;
+using Content.Shared._RMC14.Xenonids.Sunder;
 using Content.Shared._RMC14.Xenonids.Strain;
 using Content.Shared.Body.Systems;
 using Content.Shared.Coordinates;
@@ -53,6 +55,7 @@ public abstract partial class SharedXenoHealSystem : EntitySystem
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private SharedBodySystem _body = default!;
+    [Dependency] private XenoSunderSystem _sunder = default!;
     [Dependency] private XenoPlasmaSystem _xenoPlasma = default!;
     [Dependency] private XenoEnergySystem _xenoEnergy = default!;
     [Dependency] private SharedXenoAnnounceSystem _xenoAnnounce = default!;
@@ -63,6 +66,7 @@ public abstract partial class SharedXenoHealSystem : EntitySystem
     private static readonly ProtoId<DamageGroupPrototype> BruteGroup = "Brute";
     private static readonly ProtoId<DamageGroupPrototype> BurnGroup = "Burn";
     private static readonly ProtoId<DamageTypePrototype> BluntGroup = "Blunt";
+    private static readonly FixedPoint2 SunderHealMultiplier = 0.03;
 
     private readonly HashSet<Entity<XenoComponent>> _xenos = new();
 
@@ -126,6 +130,7 @@ public abstract partial class SharedXenoHealSystem : EntitySystem
             };
 
             heal.HealStacks.Add(healStack);
+            _sunder.HealSunder(xeno.Owner, GetQueenSunderHeal(xeno.Owner, ent.Comp, threshold.Value));
 
             if (_net.IsServer)
                 SpawnAttachedTo(ent.Comp.HealEffect, xeno.Owner.ToCoordinates());
@@ -184,8 +189,12 @@ public abstract partial class SharedXenoHealSystem : EntitySystem
         if (_flammable.IsOnFire(target))
             failureMessageId = "rmc-xeno-apply-salve-target-on-fire-failure";
 
-        if (TryComp(target, out DamageableComponent? damageComp) && damageComp.TotalDamage == 0)
+        if (TryComp(target, out DamageableComponent? damageComp) &&
+            damageComp.TotalDamage == 0 &&
+            !_sunder.HasSunder(target))
+        {
             failureMessageId = "rmc-xeno-apply-salve-target-full-health-failure";
+        }
 
         if (failureMessageId != null)
         {
@@ -394,6 +403,13 @@ public abstract partial class SharedXenoHealSystem : EntitySystem
         if (leftover > FixedPoint2.Zero)
             damage = _rmcDamageable.DistributeDamageCached(target, BurnGroup, leftover, damage);
         _damageable.TryChangeDamage(target, -damage, true);
+        _sunder.HealSunder(target, amount * SunderHealMultiplier);
+    }
+
+    private FixedPoint2 GetQueenSunderHeal(EntityUid target, XenoHealComponent heal, FixedPoint2 maxHealth)
+    {
+        var recovery = CompOrNull<XenoRecoveryPheromonesComponent>(target)?.Multiplier ?? FixedPoint2.Zero;
+        return heal.SunderHeal + recovery * maxHealth * heal.SunderHealRecoveryMultiplier;
     }
 
     public void CreateHealStacks(EntityUid target, FixedPoint2 healAmount, TimeSpan timeBetweenHeals, int charges, TimeSpan nextHealAt, bool ignoreFire = false)

--- a/Content.Shared/_RMC14/Xenonids/Heal/XenoHealComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Heal/XenoHealComponent.cs
@@ -24,6 +24,12 @@ public sealed partial class XenoHealComponent : Component
     [DataField, AutoNetworkedField]
     public TimeSpan TimeBetweenHeals = TimeSpan.FromSeconds(2);
 
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 SunderHeal = 1.5;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 SunderHealRecoveryMultiplier = 0.0003;
+
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan NextHeal;
 }

--- a/Content.Shared/_RMC14/Xenonids/Pheromones/XenoRecoveryPheromonesComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Pheromones/XenoRecoveryPheromonesComponent.cs
@@ -6,7 +6,10 @@ using static Robust.Shared.Utility.SpriteSpecifier;
 namespace Content.Shared._RMC14.Xenonids.Pheromones;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(SharedXenoPheromonesSystem))]
+[Access(
+    typeof(Content.Shared._RMC14.Xenonids.Heal.SharedXenoHealSystem),
+    typeof(SharedXenoPheromonesSystem),
+    typeof(Content.Shared._RMC14.Xenonids.Sunder.XenoSunderSystem))]
 public sealed partial class XenoRecoveryPheromonesComponent : Component
 {
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Sunder/XenoSunderComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Sunder/XenoSunderComponent.cs
@@ -1,0 +1,29 @@
+using Content.Shared._RMC14.Armor;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._RMC14.Xenonids.Sunder;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(fieldDeltas: true), AutoGenerateComponentPause]
+[Access(typeof(CMArmorSystem), typeof(XenoSunderSystem))]
+public sealed partial class XenoSunderComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Amount;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Max = 100;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Recover = 0.15;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 IncomingMultiplier = 1;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan RegenCooldown = TimeSpan.FromSeconds(1);
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan NextRegenTime;
+}

--- a/Content.Shared/_RMC14/Xenonids/Sunder/XenoSunderSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Sunder/XenoSunderSystem.cs
@@ -1,0 +1,197 @@
+using Content.Shared._RMC14.Armor;
+using Content.Shared._RMC14.Atmos;
+using Content.Shared._RMC14.Projectiles.Penetration;
+using Content.Shared._RMC14.Xenonids.Evolution;
+using Content.Shared._RMC14.Xenonids.Pheromones;
+using Content.Shared._RMC14.Xenonids.Rest;
+using Content.Shared._RMC14.Xenonids.Weeds;
+using Content.Shared.FixedPoint;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Standing;
+using Robust.Shared.Network;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._RMC14.Xenonids.Sunder;
+
+public sealed partial class XenoSunderSystem : EntitySystem
+{
+    private static readonly FixedPoint2 BaseRecoverMultiplier = 0.5;
+    private static readonly FixedPoint2 RestingMultiplier = 2;
+    private static readonly FixedPoint2 WeedsMultiplier = 2;
+    private static readonly FixedPoint2 RecoveryPheromoneMultiplier = 0.1;
+
+    [Dependency] private CMArmorSystem _armor = default!;
+    [Dependency] private MobStateSystem _mobState = default!;
+    [Dependency] private INetManager _net = default!;
+    [Dependency] private SharedRMCFlammableSystem _rmcFlammable = default!;
+    [Dependency] private StandingStateSystem _standing = default!;
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private SharedXenoWeedsSystem _weeds = default!;
+
+    private EntityQuery<AffectableByWeedsComponent> _affectableQuery;
+    private EntityQuery<XenoRecoveryPheromonesComponent> _xenoRecoveryQuery;
+    private EntityQuery<XenoRegenComponent> _xenoRegenQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _affectableQuery = GetEntityQuery<AffectableByWeedsComponent>();
+        _xenoRecoveryQuery = GetEntityQuery<XenoRecoveryPheromonesComponent>();
+        _xenoRegenQuery = GetEntityQuery<XenoRegenComponent>();
+
+        SubscribeLocalEvent<XenoSunderComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<XenoSunderComponent, NewXenoEvolvedEvent>(OnNewXenoEvolved);
+        SubscribeLocalEvent<XenoSunderComponent, XenoDevolvedEvent>(OnXenoDevolved);
+        SubscribeLocalEvent<XenoSunderingComponent, AfterProjectileHitEvent>(OnProjectileHit);
+
+        UpdatesAfter.Add(typeof(SharedXenoPheromonesSystem));
+    }
+
+    private void OnMapInit(Entity<XenoSunderComponent> ent, ref MapInitEvent args)
+    {
+        ent.Comp.NextRegenTime = _timing.CurTime + ent.Comp.RegenCooldown;
+        DirtyField(ent, ent.Comp, nameof(XenoSunderComponent.NextRegenTime));
+    }
+
+    private void OnNewXenoEvolved(Entity<XenoSunderComponent> newXeno, ref NewXenoEvolvedEvent args)
+    {
+        TransferSunder(args.OldXeno, newXeno);
+    }
+
+    private void OnXenoDevolved(Entity<XenoSunderComponent> newXeno, ref XenoDevolvedEvent args)
+    {
+        TransferSunder(args.OldXeno, newXeno);
+    }
+
+    private void OnProjectileHit(Entity<XenoSunderingComponent> ent, ref AfterProjectileHitEvent args)
+    {
+        if (_net.IsClient ||
+            ent.Comp.Amount <= FixedPoint2.Zero)
+        {
+            return;
+        }
+
+        AdjustSunder(args.Target, ent.Comp.Amount);
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (_net.IsClient)
+            return;
+
+        var time = _timing.CurTime;
+        var query = EntityQueryEnumerator<XenoSunderComponent>();
+        while (query.MoveNext(out var uid, out var sunder))
+        {
+            if (sunder.Amount <= FixedPoint2.Zero ||
+                time < sunder.NextRegenTime)
+            {
+                continue;
+            }
+
+            sunder.NextRegenTime = time + sunder.RegenCooldown;
+            DirtyField(uid, sunder, nameof(XenoSunderComponent.NextRegenTime));
+
+            if (_mobState.IsDead(uid) ||
+                _rmcFlammable.IsOnFire(uid) ||
+                !CanRegenerateSunder(uid, out var onFriendlyWeeds))
+            {
+                continue;
+            }
+
+            var recovery = GetPassiveRecovery(uid, sunder, onFriendlyWeeds);
+            if (recovery > FixedPoint2.Zero)
+                AdjustSunder((uid, sunder), -recovery);
+        }
+    }
+
+    public bool HasSunder(EntityUid uid)
+    {
+        return TryComp<XenoSunderComponent>(uid, out var sunder) &&
+               sunder.Amount > FixedPoint2.Zero;
+    }
+
+    public FixedPoint2 HealSunder(Entity<XenoSunderComponent?> ent, FixedPoint2 amount)
+    {
+        if (amount <= FixedPoint2.Zero)
+            return FixedPoint2.Zero;
+
+        return AdjustSunder(ent, -amount);
+    }
+
+    public FixedPoint2 AdjustSunder(Entity<XenoSunderComponent?> ent, FixedPoint2 adjustment)
+    {
+        if (!Resolve(ent, ref ent.Comp, false) ||
+            ent.Comp.Max <= FixedPoint2.Zero ||
+            adjustment == FixedPoint2.Zero)
+        {
+            return FixedPoint2.Zero;
+        }
+
+        if (adjustment > FixedPoint2.Zero)
+            adjustment *= ent.Comp.IncomingMultiplier;
+
+        var old = ent.Comp.Amount;
+        ent.Comp.Amount = FixedPoint2.Min(ent.Comp.Max, FixedPoint2.Max(FixedPoint2.Zero, old + adjustment));
+
+        var delta = ent.Comp.Amount - old;
+        if (delta == FixedPoint2.Zero)
+            return FixedPoint2.Zero;
+
+        Dirty(ent);
+        _armor.UpdateArmorValue(ent.Owner);
+        return delta;
+    }
+
+    private void TransferSunder(EntityUid oldXeno, Entity<XenoSunderComponent> newXeno)
+    {
+        if (!TryComp<XenoSunderComponent>(oldXeno, out var oldSunder) ||
+            oldSunder.Amount <= FixedPoint2.Zero)
+        {
+            return;
+        }
+
+        newXeno.Comp.Amount = FixedPoint2.Min(oldSunder.Amount, newXeno.Comp.Max);
+        Dirty(newXeno);
+        _armor.UpdateArmorValue(newXeno.Owner);
+    }
+
+    private bool CanRegenerateSunder(EntityUid uid, out bool onFriendlyWeeds)
+    {
+        onFriendlyWeeds = IsOnFriendlyWeeds(uid);
+
+        if (!_xenoRegenQuery.TryComp(uid, out var regen))
+            return false;
+
+        return regen.HealOffWeeds || onFriendlyWeeds;
+    }
+
+    private bool IsOnFriendlyWeeds(EntityUid uid)
+    {
+        if (Transform(uid).Anchored)
+            _weeds.UpdateQueued(uid);
+
+        return _affectableQuery.CompOrNull(uid) is { OnXenoWeeds: true, OnFriendlyWeeds: true };
+    }
+
+    private FixedPoint2 GetPassiveRecovery(EntityUid uid, XenoSunderComponent sunder, bool onFriendlyWeeds)
+    {
+        var recovery = sunder.Recover * BaseRecoverMultiplier * FixedPoint2.New(sunder.RegenCooldown.TotalSeconds);
+
+        if (_standing.IsDown(uid) ||
+            HasComp<XenoRestingComponent>(uid))
+        {
+            recovery *= RestingMultiplier;
+        }
+
+        if (onFriendlyWeeds)
+            recovery *= WeedsMultiplier;
+
+        var pheromones = _xenoRecoveryQuery.CompOrNull(uid)?.Multiplier ?? FixedPoint2.Zero;
+        if (pheromones > FixedPoint2.Zero)
+            recovery *= 1 + pheromones * RecoveryPheromoneMultiplier;
+
+        return recovery;
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/Sunder/XenoSunderingComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Sunder/XenoSunderingComponent.cs
@@ -1,0 +1,12 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Sunder;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(XenoSunderSystem))]
+public sealed partial class XenoSunderingComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Amount;
+}

--- a/Resources/Prototypes/_CMU14/RoundSetup/Scenario/distress_signal/threats.yml
+++ b/Resources/Prototypes/_CMU14/RoundSetup/Scenario/distress_signal/threats.yml
@@ -11,7 +11,7 @@
       - bucket: Member
         count: 12
         bodies:
-          CMXenoLarva: 3
+          CMXenoLarva: 5
         scaling:
           CMXenoLarva:
             scale: 0.11

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -192,6 +192,7 @@
   - type: Xeno
   - type: VehicleDamageMultiplier
   - type: XenoRegen
+  - type: XenoSunder
   - type: XenoStateVisuals
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_rifle.yml
@@ -657,6 +657,8 @@
         Piercing: 30
   - type: CMArmorPiercing
     amount: 40
+  - type: XenoSundering
+    amount: 0.25
 
 - type: entity
   parent: BulletRifle10x24mm
@@ -670,6 +672,8 @@
         Piercing: 30
   - type: CMArmorPiercing
     amount: 40
+  - type: XenoSundering
+    amount: 0.25
   - type: RMCPenetratingProjectile
   - type: TimedDespawn #Otherwise your game goes all laggy from too many projectiles still flying after going beyond 0 damage
     lifetime: 0.2
@@ -705,6 +709,8 @@
       falloff: 4
   - type: CMArmorPiercing
     amount: 40
+  - type: XenoSundering
+    amount: 0.4
 
 - type: entity
   parent: RMCBaseBullet

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/shotgun_pellets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/shotgun_pellets.yml
@@ -76,6 +76,8 @@
       falloff: 1
   - type: CMArmorPiercing
     amount: 20
+  - type: XenoSundering
+    amount: 0.75
   - type: RMCStunOnHit
     stuns:
     - whitelist:
@@ -130,6 +132,8 @@
       shader: unshaded
   - type: Projectile
     damage: {}
+  - type: XenoSundering
+    amount: 0
   - type: RMCProjectileDamageFalloff
     thresholds:
     - range: 12
@@ -158,6 +162,8 @@
     damage:
       types:
         Piercing: 30
+  - type: XenoSundering
+    amount: 0.1
   - type: ProjectileSpread
     proto: CMPelletShotgunFlechette
     count: 4

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
@@ -67,6 +67,8 @@
       shader: unshaded
   - type: BulletholeGenerator
   - type: RMCBullet
+  - type: XenoSundering
+    amount: 0.05
   - type: RMCProjectileAccuracy
   - type: Projectile
     soundHit:


### PR DESCRIPTION
:cl:
add: Added xeno armor sunder. Marine ballistic fire now gradually wears down xeno armor, reducing its effective armor until it recovers.
tweak: Standard ballistic ammo, including regular rifle, SMG, pistol, smartgun, tracer, and incendiary rounds, applies 0.05% sunder per hit.
tweak: rifle AP and WP ammo applies 0.25% sunder per hit, while pulse rifle HEAP ammo applies 0.4% per hit.
tweak: Shotgun buckshot applies 0.05% sunder per pellet, slugs and incendiary slugs apply 0.75%, flechettes apply 0.1% per pellet, and beanbags apply no sunder.
tweak: At 10% sunder, a 35 armor Defender is reduced to 31.5 effective armor, while a 25 armor Ravager is reduced to 22.5 effective armor.
tweak: Sunder recovery takes about 67 seconds per 10% sunder while standing on weeds, or 33 seconds while resting on weeds, before recovery pheromones.
tweak: A xeno at 50% sunder takes about 5.5 minutes to fully recover while standing on friendly weeds, or 2.8 minutes while resting before recovery pheromones.
tweak: Puts round start larva back to 5