### PR TITLE
Expanded Apparel Options For Colonists 

### DIFF
--- a/Resources/Locale/en-US/_AU14/roles/loadouts.ftl
+++ b/Resources/Locale/en-US/_AU14/roles/loadouts.ftl
@@ -14,6 +14,7 @@ au14-loadout-group-doctor-equipment = Specialization
 au14-loadout-group-civilian-footwear = Civilian footwear
 au14-loadout-group-civilian-jumpsuit = Civilian jumpsuits
 au14-loadout-group-civilian-jacket = Civilian jackets
+au14-loadout-group-civilian-glasses = Civilian glasses
 au14-loadout-group-civilian-suit-special = Civilian suit (Special)
 au14-loadout-group-civilian-hat = Civilian hats
 au14-loadout-group-civilian-satchel = Civilian satchels

--- a/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFGuerilla.yml
+++ b/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFGuerilla.yml
@@ -79,6 +79,7 @@
   - CivSatchelAU14
   - CivFootwearAU14
   - CivHatsAU14
+  - CivGlassesAU14
   - CivJumpsuitAU14
   - CivJacketAU14
   - PaperworkRMC

--- a/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFGuerilla.yml
+++ b/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFGuerilla.yml
@@ -78,7 +78,9 @@
   groups:
   - CivSatchelAU14
   - CivFootwearAU14
+  - CivHatsAU14
   - CivJumpsuitAU14
+  - CivJacketAU14
   - PaperworkRMC
   - RecreationalRMC
   - CannedDrinksAU14

--- a/Resources/Prototypes/_CMU14/Roles/Colony/General/AU14JobCivilianColonist.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/General/AU14JobCivilianColonist.yml
@@ -81,6 +81,7 @@
   - CivSatchelAU14
   - CivFootwearAU14
   - CivHatsAU14
+  - CivGlassesAU14
   - CivJumpsuitAU14
   - CivJacketAU14
   - PaperworkRMC

--- a/Resources/Prototypes/_CMU14/Roles/Colony/General/AU14JobCivilianColonist.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/General/AU14JobCivilianColonist.yml
@@ -80,7 +80,9 @@
   groups:
   - CivSatchelAU14
   - CivFootwearAU14
+  - CivHatsAU14
   - CivJumpsuitAU14
+  - CivJacketAU14
   - PaperworkRMC
   - RecreationalRMC
   - CannedDrinksAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivGlassesAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivGlassesAU14.yml
@@ -11,5 +11,5 @@
   - GlassesTriMaxYellowAU14
   - GlassesTriMaxBlackAU14
   - GlassesTriMaxBronzeAU14
-  - GlassesAviatorsAU14
+  - GlassesPersonalOrangeAU14
   - GlassesBiMexOrangeAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivGlassesAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivGlassesAU14.yml
@@ -1,0 +1,15 @@
+- type: loadoutGroup
+  id: CivGlassesAU14
+  name: au14-loadout-group-civilian-glasses
+  minLimit: 0
+  maxLimit: 2
+  loadouts:
+  - SunglassesAU14
+  - HipsterGlassesAU14
+  - SunglassesBigAU14
+  - GlassesAviatorsAU14
+  - GlassesTriMaxYellowAU14
+  - GlassesTriMaxBlackAU14
+  - GlassesTriMaxBronzeAU14
+  - GlassesAviatorsAU14
+  - GlassesBiMexOrangeAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivHatsAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivHatsAU14.yml
@@ -8,3 +8,7 @@
   - CivBallCapBlueTruckerAU14
   - CivBallCapRedTruckerAU14
   - USCMVeteranCapAU14
+  - HeadCommandoBeanieAU14
+  - CivFedoraTanAU14
+  - CivFedoraBrownAU14
+  - CivFedoraGrayAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivJacketAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivJacketAU14.yml
@@ -17,5 +17,8 @@
   - WindbreakerBlueAU14
   - CivilianJacketSnowSuitAU14
   - CivilianJacketOldCoatAU14
-  - CivilianJacketGreenParkaAU14
   - CivilianJacketBomberJacketAU14
+  - CivilianJacketGreenParkaAU14
+  - CivilianJacketBlueParkaAU14
+  - CivilianJacketRedParkaAU14
+  - CivilianJacketYellowParkaAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivJacketAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivJacketAU14.yml
@@ -6,6 +6,16 @@
   loadouts:
   - JacketCorporateBrownAU14
   - CivilianJacketGrayPufferVestAU14
+  - CivilianJacketKhakiPufferVestAU14
+  - CivilianJacketTanPufferVestAU14
+  - CivilianJacketGrayPufferJacketAU14
+  - CivilianJacketKhakiPufferVestAU14
+  - CivilianJacketOrangePufferJacketAU14
   - WindbreakerBlueAU14
+  - WindbreakerKhakiAU14
+  - WindbreakerGrayAU14
+  - WindbreakerGreenAU14
   - CivilianJacketSnowSuitAU14
   - CivilianJacketOldCoatAU14
+  - CivilianJacketGreenParkaAU14
+  - CivilianJacketBomberJacketAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivJacketAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivJacketAU14.yml
@@ -5,16 +5,16 @@
   maxLimit: 1
   loadouts:
   - JacketCorporateBrownAU14
+  - JacketCorporateBlueAU14
+  - JacketCorporateBlackAU14
+  - JacketCorporateKhakiAU14
   - CivilianJacketGrayPufferVestAU14
   - CivilianJacketKhakiPufferVestAU14
   - CivilianJacketTanPufferVestAU14
   - CivilianJacketGrayPufferJacketAU14
-  - CivilianJacketKhakiPufferVestAU14
+  - CivilianJacketKhakiPufferJacketAU14
   - CivilianJacketOrangePufferJacketAU14
   - WindbreakerBlueAU14
-  - WindbreakerKhakiAU14
-  - WindbreakerGrayAU14
-  - WindbreakerGreenAU14
   - CivilianJacketSnowSuitAU14
   - CivilianJacketOldCoatAU14
   - CivilianJacketGreenParkaAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivJumpsuitAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivJumpsuitAU14.yml
@@ -17,6 +17,8 @@
   - CivilianFloralRedAU14
   - CivilianFloralBlueAU14
   - CivilianFloralYellowAU14
+  - CivilianFlannelPurpleAU14
+  - CivilianFlannelRedAU14
   - WYJumpsuitLiaisonBlackAU14
   - WYJumpsuitLiaisonBlazerAU14
   - WYJumpsuitLiaisonAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivJumpsuitAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/CivJumpsuitAU14.yml
@@ -8,3 +8,17 @@
   - JumpsuitCivilianAU14
   - JumpsuitTShirtWhiteAU14
   - JumpsuitTShirtGrayAU14
+  - JumpsuitTShirtRedAU14
+  - CivilianWorkwearYellowAU14
+  - CivilianWorkwearPinkAU14
+  - CivilianWorkwearBlueAU14
+  - CivilianWorkwearGreenAU14
+  - JumpsuitDutchBandolierAU14
+  - CivilianFloralRedAU14
+  - CivilianFloralBlueAU14
+  - CivilianFloralYellowAU14
+  - WYJumpsuitLiaisonBlackAU14
+  - WYJumpsuitLiaisonBlazerAU14
+  - WYJumpsuitLiaisonAU14
+  - WYJumpsuitLiaisonCharcoalAU14
+  - WYJumpsuitLiaisonIvyAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/glasses.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/glasses.yml
@@ -59,10 +59,10 @@
     - RMCGlassesTriMaxBronze
 
 - type: loadout
-  id: GlassesAviatorsAU14
+  id: GlassesPersonalOrangeAU14
   storage:
     back:
-    - RMCGlassesAviators
+    - AU14GlassesPersonalOrange
 
 - type: loadout
   id: GlassesBiMexOrangeAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/glasses.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/glasses.yml
@@ -15,3 +15,57 @@
   storage:
     back:
     - RMCGlassesReagentHUDGlasses
+
+- type: loadout
+  id: SunglassesAU14
+  storage:
+    back:
+    - RMCSunglasses
+
+- type: loadout
+  id: HipsterGlassesAU14
+  storage:
+    back:
+    - RMCHipsterGlasses
+
+- type: loadout
+  id: SunglassesBigAU14
+  storage:
+    back:
+    - RMCSunglassesBig
+
+- type: loadout
+  id: GlassesAviatorsAU14
+  storage:
+    back:
+    - RMCGlassesAviators
+
+- type: loadout
+  id: GlassesTriMaxYellowAU14
+  storage:
+    back:
+    - RMCGlassesTriMaxYellow
+
+- type: loadout
+  id: GlassesTriMaxBlackAU14
+  storage:
+    back:
+    - RMCGlassesTriMaxBlack
+
+- type: loadout
+  id: GlassesTriMaxBronzeAU14
+  storage:
+    back:
+    - RMCGlassesTriMaxBronze
+
+- type: loadout
+  id: GlassesAviatorsAU14
+  storage:
+    back:
+    - RMCGlassesAviators
+
+- type: loadout
+  id: GlassesBiMexOrangeAU14
+  storage:
+    back:
+    - AU14GlassesBiMexOrange

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/head.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/head.yml
@@ -12,11 +12,6 @@
   id: CivBallCapRedTruckerAU14
   equipment:
     head: AU14CivBallCapRedTrucker
-  
-- type: loadout
-  id: USCMVeteranCapAU14
-  equipment:
-    head: AU14USCMVeteranCap
 
 - type: loadout
   id: CivFedoraTanAU14
@@ -29,7 +24,7 @@
     head: AU14CivFedoraBrown
 
 - type: loadout
-  id: 
+  id: CivFedoraGrayAU14
   equipment:
     head: AU14CivFedoraGray
 

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/head.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/head.yml
@@ -12,6 +12,31 @@
   id: CivBallCapRedTruckerAU14
   equipment:
     head: AU14CivBallCapRedTrucker
+  
+- type: loadout
+  id: USCMVeteranCapAU14
+  equipment:
+    head: AU14USCMVeteranCap
+
+- type: loadout
+  id: CivFedoraTanAU14
+  equipment:
+    head: AU14CivFedoraTan
+
+- type: loadout
+  id: CivFedoraBrownAU14
+  equipment:
+    head: AU14CivFedoraBrown
+
+- type: loadout
+  id: 
+  equipment:
+    head: AU14CivFedoraGray
+
+- type: loadout
+  id: HeadCommandoBeanieAU14
+  equipment:
+    head: AU14HeadCommandoBeanie
 
 - type: loadout
   id: USCMVeteranCapAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/jumpsuit.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/jumpsuit.yml
@@ -49,6 +49,32 @@
     jumpsuit: CMJumpsuitTShirtRed
 
 - type: loadout
+  id: CivilianFloralRedAU14
+  equipment:
+    jumpsuit: AU14CivilianFloralRed
+
+- type: loadout
+  id: CivilianFloralBlueAU14
+  equipment:
+    jumpsuit: AU14CivilianFloralBlue
+
+- type: loadout
+  id: CivilianFloralYellowAU14
+  equipment:
+    jumpsuit: AU14CivilianFloralYellow
+
+- type: loadout
+  id: CivilianFlannelRedAU14
+  equipment:
+    jumpsuit: AU14CivilianFlannelRed
+
+- type: loadout
+  id: CivilianFlannelPurpleAU14
+  equipment:
+    jumpsuit: AU14CivilianFlannelPurple
+
+
+- type: loadout
   id: HazardVestAU14
   equipment:
     jumpsuit: RMCHazardVest
@@ -122,6 +148,11 @@
   id: WYJumpsuitLiaisonCharcoalAU14
   equipment:
     jumpsuit: CMJumpsuitLiaisonCharcoal
+
+- type: loadout
+  id: WYJumpsuitLiaisonIvyAU14
+  equipment:
+    jumpsuit: CMJumpsuitLiaisonIvy
 
 - type: loadout
   id: WYJumpsuitLiaisonFormalAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/jumpsuit.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/jumpsuit.yml
@@ -73,7 +73,6 @@
   equipment:
     jumpsuit: AU14CivilianFlannelPurple
 
-
 - type: loadout
   id: HazardVestAU14
   equipment:

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/suit.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/suit.yml
@@ -95,6 +95,24 @@
     - AU14CivilianJacketBomberJacket
 
 - type: loadout
+  id: CivilianTanTrenchCoatAU14
+  storage:
+    back:
+    - AU14CivilianTanTrenchCoat
+
+- type: loadout
+  id: CivilianBrownTrenchCoatAU14
+  storage:
+    back:
+    - AU14CivilianBrownTrenchCoat
+
+- type: loadout
+  id: CivilianGrayTrenchCoatAU14
+  storage:
+    back:
+    - AU14CivilianGrayTrenchCoat
+
+- type: loadout
   id: CivilianFullSuitWeYuEngineerAU14
   storage:
     back:

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/suit.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/suit.yml
@@ -71,12 +71,6 @@
     - AU14WindbreakerBlue
 
 - type: loadout
-  id: CivilianJacketGreenParkaAU14
-  storage:
-    back:
-    - AU14CivilianJacketGreenParka
-
-- type: loadout
   id: CivilianJacketSnowSuitAU14
   storage:
     back:
@@ -111,6 +105,30 @@
   storage:
     back:
     - AU14CivilianGrayTrenchCoat
+
+- type: loadout
+  id: CivilianJacketBlueParkaAU14
+  storage:
+    back:
+    - AU14CivilianJacketBlueParka
+
+- type: loadout
+  id: CivilianJacketGreenParkaAU14
+  storage:
+    back:
+    - AU14CivilianJacketGreenParka
+
+- type: loadout
+  id: CivilianJacketRedParkaAU14
+  storage:
+    back:
+    - AU14CivilianJacketRedParka
+
+- type: loadout
+  id: CivilianJacketYellowParkaAU14
+  storage:
+    back:
+    - AU14CivilianJacketYellowParka
 
 - type: loadout
   id: CivilianFullSuitWeYuEngineerAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/suit.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/suit.yml
@@ -71,24 +71,6 @@
     - AU14WindbreakerBlue
 
 - type: loadout
-  id: WindbreakerKhakiAU14
-  storage:
-    back:
-    - AU14WindbreakerKhaki
-
-- type: loadout
-  id: WindbreakerGrayAU14
-  storage:
-    back:
-    - AU14WindbreakerGray
-
-- type: loadout
-  id: WindbreakerGreenAU14
-  storage:
-    back:
-    - AU14WindbreakerGreen
-
-- type: loadout
   id: CivilianJacketGreenParkaAU14
   storage:
     back:

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/suit.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/suit.yml
@@ -53,7 +53,7 @@
     - AU14CivilianJacketGrayPufferJacket
   
 - type: loadout
-  id: CivilianJacketKhakiPufferVestAU14
+  id: CivilianJacketKhakiPufferJacketAU14
   storage:
     back:
     - AU14CivilianJacketKhakiPufferJacket

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/suit.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/suit.yml
@@ -11,10 +11,52 @@
     - RMCJacketCorporateBrown
 
 - type: loadout
+  id: JacketCorporateBlueAU14
+  storage:
+    back:
+    - RMCJacketCorporateBlue
+
+- type: loadout
+  id: JacketCorporateBlackAU14
+  storage:
+    back:
+    - RMCJacketCorporateBlack
+
+- type: loadout
+  id: JacketCorporateKhakiAU14
+  storage:
+    back:
+    - RMCJacketCorporateKhaki
+
+- type: loadout
   id: CivilianJacketGrayPufferVestAU14
   storage:
     back:
     - AU14CivilianJacketGrayPufferVest
+
+- type: loadout
+  id: CivilianJacketKhakiPufferVestAU14
+  storage:
+    back:
+    - AU14CivilianJacketKhakiPufferVest
+
+- type: loadout
+  id: CivilianJacketTanPufferVestAU14
+  storage:
+    back:
+    - AU14CivilianJacketTanPufferVest
+
+- type: loadout
+  id: CivilianJacketGrayPufferJacketAU14
+  storage:
+    back:
+    - AU14CivilianJacketGrayPufferJacket
+  
+- type: loadout
+  id: CivilianJacketKhakiPufferVestAU14
+  storage:
+    back:
+    - AU14CivilianJacketKhakiPufferJacket
 
 - type: loadout
   id: CivilianJacketOrangePufferJacketAU14
@@ -27,6 +69,24 @@
   storage:
     back:
     - AU14WindbreakerBlue
+
+- type: loadout
+  id: WindbreakerKhakiAU14
+  storage:
+    back:
+    - AU14WindbreakerKhaki
+
+- type: loadout
+  id: WindbreakerGrayAU14
+  storage:
+    back:
+    - AU14WindbreakerGray
+
+- type: loadout
+  id: WindbreakerGreenAU14
+  storage:
+    back:
+    - AU14WindbreakerGreen
 
 - type: loadout
   id: CivilianJacketGreenParkaAU14
@@ -45,6 +105,12 @@
   storage:
     back:
     - AU14CivilianJacketOldCoat
+
+- type: loadout
+  id: CivilianJacketBomberJacketAU14
+  storage:
+    back:
+    - AU14CivilianJacketBomberJacket
 
 - type: loadout
   id: CivilianFullSuitWeYuEngineerAU14


### PR DESCRIPTION
## About the PR
Added a greater selection of Jumpsuits, Jackets, Hats and Glasses to Colonist Loadout Options, essentially most clothing choices you could get in the colony clothing vendor, with the exception of windbreakers due to an upcoming PR by MerFak that replaces the AU14 Windbreakers with RMC Windbreakers since both exist.

## Why / Balance
It's just nice to have greater variety without the need for vendors or trying your luck with Civilian Surplus Clothes Crates.

## Technical details
Created `CivGlassesAU14.yml` within `Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Colonist Loadouts now have a larger variety of choices for jumpsuits, jackets, hats and glasses to choose from. 
