### PR TITLE
Bug fixes

### DIFF
--- a/Content.Client/Ghost/GhostSystem.cs
+++ b/Content.Client/Ghost/GhostSystem.cs
@@ -2,6 +2,7 @@ using Content.Client._RMC14.NightVision;
 using Content.Client.Movement.Systems;
 using Content.Shared._RMC14.Mentor.ImaginaryFriend;
 using Content.Shared.Actions;
+using Content.Shared.GameTicking;
 using Content.Shared.Ghost;
 using Robust.Client.Console;
 using Robust.Client.GameObjects;
@@ -54,6 +55,7 @@ namespace Content.Client.Ghost
         public event Action<GhostComponent>? PlayerAttached;
         public event Action? PlayerDetached;
         public event Action<GhostWarpsResponseEvent>? GhostWarpsResponse;
+        public event Action? GhostWarpsReset;
         public event Action<GhostUpdateGhostRoleCountEvent>? GhostRoleCountUpdated;
 
         public override void Initialize()
@@ -68,6 +70,7 @@ namespace Content.Client.Ghost
             SubscribeLocalEvent<GhostComponent, LocalPlayerDetachedEvent>(OnGhostPlayerDetach);
 
             SubscribeNetworkEvent<GhostWarpsResponseEvent>(OnGhostWarpsResponse);
+            SubscribeNetworkEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup);
             SubscribeNetworkEvent<GhostUpdateGhostRoleCountEvent>(OnUpdateGhostRoleCount);
 
             SubscribeLocalEvent<EyeComponent, ToggleLightingActionEvent>(OnToggleLighting);
@@ -191,6 +194,11 @@ namespace Content.Client.Ghost
             }
 
             GhostWarpsResponse?.Invoke(msg);
+        }
+
+        private void OnRoundRestartCleanup(RoundRestartCleanupEvent _)
+        {
+            GhostWarpsReset?.Invoke();
         }
 
         private void OnUpdateGhostRoleCount(GhostUpdateGhostRoleCountEvent msg)

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -114,6 +114,19 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
                 .ToList();
         }
 
+        public void ClearWarps(bool clearSearch = false)
+        {
+            _warps.Clear();
+
+            if (clearSearch)
+            {
+                _searchText = string.Empty;
+                SearchBar.Text = string.Empty;
+            }
+
+            Populate();
+        }
+
         public void Populate()
         {
             var previousTab = _activeTab?.Name;

--- a/Content.Client/UserInterface/Systems/Ghost/GhostUIController.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/GhostUIController.cs
@@ -45,6 +45,7 @@ public sealed partial class GhostUIController : UIController, IOnSystemChanged<G
         system.PlayerAttached += OnPlayerAttached;
         system.PlayerDetached += OnPlayerDetached;
         system.GhostWarpsResponse += OnWarpsResponse;
+        system.GhostWarpsReset += OnWarpsReset;
         system.GhostRoleCountUpdated += OnRoleCountUpdated;
     }
 
@@ -55,6 +56,7 @@ public sealed partial class GhostUIController : UIController, IOnSystemChanged<G
         system.PlayerAttached -= OnPlayerAttached;
         system.PlayerDetached -= OnPlayerDetached;
         system.GhostWarpsResponse -= OnWarpsResponse;
+        system.GhostWarpsReset -= OnWarpsReset;
         system.GhostRoleCountUpdated -= OnRoleCountUpdated;
     }
 
@@ -100,6 +102,11 @@ public sealed partial class GhostUIController : UIController, IOnSystemChanged<G
 
         window.UpdateWarps(msg.Warps);
         window.Populate();
+    }
+
+    private void OnWarpsReset()
+    {
+        Gui?.TargetWindow.ClearWarps(clearSearch: true);
     }
 
     private void OnRoleCountUpdated(GhostUpdateGhostRoleCountEvent msg)
@@ -156,7 +163,11 @@ public sealed partial class GhostUIController : UIController, IOnSystemChanged<G
 
     private void RequestWarps()
     {
-        Gui?.TargetWindow.OpenCentered();
+        if (Gui?.TargetWindow is not { } window)
+            return;
+
+        window.ClearWarps();
+        window.OpenCentered();
         _system?.RequestWarps();
     }
 

--- a/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml.cs
@@ -34,6 +34,7 @@ public sealed partial class GhostGui : UIWidget
 
     public void Hide()
     {
+        TargetWindow.ClearWarps(clearSearch: true);
         TargetWindow.Close();
         Visible = false;
     }

--- a/Content.IntegrationTests/_AU14/ThirdParty/RmcErtThirdPartyDropshipMapTest.cs
+++ b/Content.IntegrationTests/_AU14/ThirdParty/RmcErtThirdPartyDropshipMapTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Content.Server._CMU14.Ops.ThirdParty;
 using Content.Shared._RMC14.Dropship;
 using Content.Shared.AU14.Round;
 using Content.Shared.AU14.Scenario;
@@ -7,7 +8,9 @@ using Content.Shared._CMU14.Threats;
 using Robust.Shared.EntitySerialization;
 using Robust.Shared.EntitySerialization.Systems;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using ThirdPartySystem = Content.Server._CMU14.Ops.ThirdParty.ThirdPartySystem;
 
 namespace Content.IntegrationTests._AU14.ThirdParty;
 
@@ -33,6 +36,8 @@ public sealed class RmcErtThirdPartyDropshipMapTest
         (new("/Maps/_CMU14/Shuttles/icrctransport_ert.yml"), 4, 6, 3),
         (new("/Maps/_CMU14/Shuttles/white_ert.yml"), 4, 8, 3),
     };
+
+    private static readonly ProtoId<ThirdPartyPrototype> MissionariesParty = "MissionariesParty";
 
     [Test]
     public async Task RmcErtThirdPartyDropshipsLoadWithSpawnPlans()
@@ -141,6 +146,60 @@ public sealed class RmcErtThirdPartyDropshipMapTest
             {
                 Assert.That(scenarioLeaderMarkers, Is.EqualTo(1));
                 Assert.That(legacyLeaderMarkers, Is.EqualTo(1));
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ThirdPartyShuttleSpawnUsesAvailableThirdPartyLandingDestination()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        EntityUid genericDestination = EntityUid.Invalid;
+        EntityUid returnedDestination = EntityUid.Invalid;
+        EntityUid thirdPartyDestination = EntityUid.Invalid;
+
+        await server.WaitPost(() =>
+        {
+            var entities = server.EntMan;
+            var prototypes = server.ResolveDependency<IPrototypeManager>();
+            var thirdPartySystem = server.System<ThirdPartySystem>();
+            var thirdParty = prototypes.Index<ThirdPartyPrototype>(MissionariesParty);
+            var partySpawn = prototypes.Index<PartySpawnPrototype>(thirdParty.PartySpawn);
+
+            genericDestination = entities.SpawnEntity("CMDropshipDestination", map.GridCoords);
+
+            returnedDestination = entities.SpawnEntity("CMDropshipDestinationThirdPartyReturn", map.GridCoords);
+            var returnDestination = entities.EnsureComponent<ThirdPartyDropshipReturnDestinationComponent>(
+                returnedDestination);
+            returnDestination.Shuttle = EntityUid.Invalid;
+
+            thirdPartyDestination = entities.SpawnEntity("CMDropshipDestinationThirdPartyWhitelist", map.GridCoords);
+
+            thirdPartySystem.SpawnThirdParty(thirdParty, partySpawn, false);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            var entities = server.EntMan;
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    entities.GetComponent<DropshipDestinationComponent>(genericDestination).Ship,
+                    Is.Null,
+                    "Generic dropship destinations must not be selected for strict third-party shuttles.");
+                Assert.That(
+                    entities.GetComponent<DropshipDestinationComponent>(returnedDestination).Ship,
+                    Is.Null,
+                    "Returned third-party holding vectors must not be reused as active landing destinations.");
+                Assert.That(
+                    entities.GetComponent<DropshipDestinationComponent>(thirdPartyDestination).Ship,
+                    Is.Not.Null,
+                    "The spawned third-party shuttle should be routed to the active third-party landing destination.");
             });
         });
 

--- a/Content.IntegrationTests/_RMC14/XenoBulwarkTest.cs
+++ b/Content.IntegrationTests/_RMC14/XenoBulwarkTest.cs
@@ -30,6 +30,13 @@ public sealed class XenoBulwarkTest
   components:
   - type: XenoBulwark
     reflecting: true
+
+- type: entity
+  parent: CMXenoWarriorBulwark
+  id: RMCTestXenoBulwarkLongTailSwing
+  components:
+  - type: XenoBulwark
+    tailSwingRange: 3
 ";
 
     [Test]
@@ -195,6 +202,39 @@ public sealed class XenoBulwarkTest
             {
                 entMan.DeleteEntity(xeno);
                 entMan.DeleteEntity(grenade);
+                entMan.DeleteEntity(action.Owner);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task TailSwingDoesNotHitThroughWalls()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var xeno = entMan.SpawnEntity("RMCTestXenoBulwarkLongTailSwing", map.GridCoords);
+            var wall = entMan.SpawnEntity("CMWallMetal", map.GridCoords.Offset(new Vector2(1, 0)));
+            var target = entMan.SpawnEntity("CMMobHuman", map.GridCoords.Offset(new Vector2(2, 0)));
+            var action = SpawnAction(entMan);
+
+            try
+            {
+                RaiseTailSwing(entMan, xeno, action);
+
+                Assert.That(TotalDamage(entMan, target), Is.Zero);
+            }
+            finally
+            {
+                entMan.DeleteEntity(xeno);
+                entMan.DeleteEntity(wall);
+                entMan.DeleteEntity(target);
                 entMan.DeleteEntity(action.Owner);
             }
         });

--- a/Content.Server/_CMU14/DroneOperator/CMUDroneOperatorSystem.cs
+++ b/Content.Server/_CMU14/DroneOperator/CMUDroneOperatorSystem.cs
@@ -6,6 +6,9 @@ using Content.Server.NPC;
 using Content.Server.NPC.HTN;
 using Content.Server.NPC.Pathfinding;
 using Content.Server.NPC.Systems;
+using Content.Server.Radio;
+using Content.Server.Radio.Components;
+using Content.Server.Radio.EntitySystems;
 using Content.Server._RMC14.Humanoid.Markings;
 using Content.Shared._CMU14.DroneOperator;
 using Content.Shared._CMU14.Threats.Mobs.Xeno.Caste.Warlock;
@@ -36,6 +39,7 @@ using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.NPC;
 using Content.Shared.Popups;
 using Content.Shared.Random.Helpers;
+using Content.Shared.Radio.Components;
 using Content.Shared.SSDIndicator;
 using Content.Shared.StatusEffectNew;
 using Content.Shared.Throwing;
@@ -48,6 +52,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -70,12 +75,14 @@ public sealed partial class CMUDroneOperatorSystem : EntitySystem
     [Dependency] private MetaDataSystem _metaData = default!;
     [Dependency] private MindSystem _mind = default!;
     [Dependency] private MobStateSystem _mobState = default!;
+    [Dependency] private INetManager _netMan = default!;
     [Dependency] private NPCSystem _npc = default!;
     [Dependency] private SharedPhysicsSystem _physics = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private IPrototypeManager _prototypes = default!;
     [Dependency] private QuickDialogSystem _quickDialog = default!;
     [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private RadioSystem _radio = default!;
     [Dependency] private SkillsSystem _skills = default!;
     [Dependency] private SharedStatusEffectsSystem _statusEffects = default!;
     [Dependency] private IGameTiming _timing = default!;
@@ -146,6 +153,7 @@ public sealed partial class CMUDroneOperatorSystem : EntitySystem
         SubscribeLocalEvent<CMURemotePilotingComponent, ComponentShutdown>(OnPilotingShutdown);
         SubscribeLocalEvent<CMURemotePilotingComponent, PlayerAttachedEvent>(OnPilotingPlayerAttached, after: [typeof(SSDIndicatorSystem)]);
         SubscribeLocalEvent<CMURemotePilotingComponent, PlayerDetachedEvent>(OnPilotingPlayerDetached, after: [typeof(SSDIndicatorSystem)]);
+        SubscribeLocalEvent<CMURemotePilotingComponent, HeadsetRadioReceiveRelayEvent>(OnPilotingHeadsetReceive);
         SubscribeLocalEvent<CMURemotePilotingComponent, UpdateCanMoveEvent>(OnPilotingUpdateCanMove);
         SubscribeLocalEvent<CMURemotePilotingComponent, MoveEvent>(OnPilotingMove);
         SubscribeLocalEvent<CMURemotePilotingComponent, MobStateChangedEvent>(OnPilotingMobStateChanged);
@@ -498,6 +506,17 @@ public sealed partial class CMUDroneOperatorSystem : EntitySystem
             return;
         }
 
+        if (args.Channel != null &&
+            TryComp<WearingHeadsetComponent>(session.Operator, out var wearing) &&
+            TryComp<EncryptionKeyHolderComponent>(wearing.Headset, out var keys) &&
+            keys.Channels.Contains(args.Channel.ID) &&
+            !keys.ReadOnlyChannels.Contains(args.Channel.ID))
+        {
+            _radio.SendRadioMessage(session.Operator, args.Message, args.Channel, wearing.Headset, args.Language);
+            args.Channel = null;
+            return;
+        }
+
         _chat.TrySendInGameICMessage(
             session.Operator,
             args.Message,
@@ -827,6 +846,12 @@ public sealed partial class CMUDroneOperatorSystem : EntitySystem
     private void OnPilotingPlayerDetached(Entity<CMURemotePilotingComponent> ent, ref PlayerDetachedEvent args)
     {
         SuppressSsdIndicator(ent.Owner);
+    }
+
+    private void OnPilotingHeadsetReceive(Entity<CMURemotePilotingComponent> ent, ref HeadsetRadioReceiveRelayEvent args)
+    {
+        if (_actorQuery.TryComp(ent.Comp.Drone, out var actor))
+            _netMan.ServerSendMessage(args.RelayedEvent.ChatMsg, actor.PlayerSession.Channel);
     }
 
     private void OnPilotingUpdateCanMove(Entity<CMURemotePilotingComponent> ent, ref UpdateCanMoveEvent args)

--- a/Content.Server/_CMU14/Ops/ThirdParty/ThirdPartySystem.cs
+++ b/Content.Server/_CMU14/Ops/ThirdParty/ThirdPartySystem.cs
@@ -55,6 +55,7 @@ public sealed partial class ThirdPartySystem : EntitySystem
     private static readonly ProtoId<JobPrototype> ThirdPartyLeaderJobId = new("AU14JobThirdPartyLeader");
     private static readonly ProtoId<JobPrototype> ThirdPartyMemberJobId = new("AU14JobThirdPartyMember");
     private static readonly ThreatMarkerType[] ThreatMarkerTypes = Enum.GetValues<ThreatMarkerType>();
+    private const string ThirdPartyFaction = "thirdparty";
     private readonly ISawmill _sawmill = Logger.GetSawmill("thirdparty");
 
     // --- State for round third party spawning ---
@@ -227,7 +228,7 @@ public sealed partial class ThirdPartySystem : EntitySystem
             while (destQuery.MoveNext(out EntityUid destUid, out DropshipDestinationComponent? destComp,
                 out TransformComponent? destXform))
             {
-                if (destComp.Ship == null && string.IsNullOrEmpty(destComp.FactionController))
+                if (IsAvailableThirdPartyDropshipDestination(destUid, destComp))
                 {
                     chosenDestination = destUid;
                     break;
@@ -237,7 +238,7 @@ public sealed partial class ThirdPartySystem : EntitySystem
             if (chosenDestination == null)
             {
                 _sawmill.Error(
-                    "[ThirdPartySystem] No valid dropship destination found (not landed, not controlled). Aborting third party spawn.");
+                    "[ThirdPartySystem] No valid third-party dropship landing destination found. Aborting third party spawn.");
                 return false;
             }
 
@@ -294,7 +295,13 @@ public sealed partial class ThirdPartySystem : EntitySystem
             if (navUid != null && navComp != null)
             {
                 var navEntity = new Entity<DropshipNavigationComputerComponent>(navUid.Value, navComp);
-                _sharedDropshipSystem.FlyTo(navEntity, destination, null);
+                if (!_sharedDropshipSystem.FlyTo(navEntity, destination, null))
+                {
+                    _sawmill.Error($"[ThirdPartySystem] Dropship nav computer {navUid} rejected launch to destination {
+                        destination}. Aborting third party spawn.");
+                    return false;
+                }
+
                 _sawmill.Debug($"[ThirdPartySystem] Commanded dropship nav computer {navUid} to fly to destination {
                     destination}");
             }
@@ -880,6 +887,16 @@ public sealed partial class ThirdPartySystem : EntitySystem
     private static bool IsOnGrid(TransformComponent transform, EntityUid gridUid)
         => (transform.GridUid.HasValue && transform.GridUid.Value == gridUid) ||
             transform.ParentUid == gridUid;
+
+    private bool IsAvailableThirdPartyDropshipDestination(
+        EntityUid destination,
+        DropshipDestinationComponent destinationComponent)
+    {
+        return destinationComponent.Ship == null &&
+               !destinationComponent.Home &&
+               !HasComp<ThirdPartyDropshipReturnDestinationComponent>(destination) &&
+               string.Equals(destinationComponent.FactionController, ThirdPartyFaction, StringComparison.OrdinalIgnoreCase);
+    }
 
     private List<EntityUid> FilterScenarioMarkers(ThreatMarkerType markerType,
         IReadOnlyList<EntityUid> candidateMarkers,

--- a/Content.Server/_RMC14/Medical/Surgery/CMSurgerySystem.cs
+++ b/Content.Server/_RMC14/Medical/Surgery/CMSurgerySystem.cs
@@ -74,7 +74,7 @@ public sealed partial class CMSurgerySystem : SharedCMSurgerySystem
 
     private void OnSynthRepairToolUseAttempt(Entity<SynthComponent> ent, ref RMCSynthRepairToolUseAttemptEvent args)
     {
-        if (args.Handled || args.User == ent.Owner || !HasComp<CMSurgeryTargetComponent>(ent.Owner))
+        if (args.Handled || !HasComp<CMSurgeryTargetComponent>(ent.Owner))
             return;
 
         if (IsSynthReattachStepTool(args.Used)
@@ -150,9 +150,6 @@ public sealed partial class CMSurgerySystem : SharedCMSurgerySystem
             return;
 
         if (!HasComp<SynthComponent>(target) || !HasComp<CMSurgeryTargetComponent>(target))
-            return;
-
-        if (args.User == target)
             return;
 
         if (!HasMissingSynthLimbSlot(target))

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -176,13 +176,10 @@ public abstract partial class SharedChatSystem : EntitySystem
                 ? _prototypeManager.Index<RadioChannelPrototype>(HivemindChannel)
                 : _prototypeManager.Index<RadioChannelPrototype>(CommonChannel);
 
-        // RMC14
-        if (channel?.ID == HivemindChannel.Id &&
-            !_xenoEvolution.HasLiving<XenoEvolutionGranterComponent>(1, null, hive))
+            // RMC14
+            if (channel?.ID == HivemindChannel.Id &&
+                !CanUseHivemind(source, hive, quiet))
             {
-                if (!quiet)
-                    _popup.PopupEntity(Loc.GetString("rmc-no-queen-hivemind-chat"), source, source, PopupType.LargeCaution);
-
                 output = SanitizeMessageCapital(input[1..].TrimStart());
                 return false;
             }
@@ -224,11 +221,8 @@ public abstract partial class SharedChatSystem : EntitySystem
             RaiseLocalEvent(source, ev);
 
             if (ev.Channel == HivemindChannel.Id &&
-                !_xenoEvolution.HasLiving<XenoEvolutionGranterComponent>(1, null, hive))
+                !CanUseHivemind(source, hive, quiet))
             {
-                if (!quiet)
-                    _popup.PopupEntity(Loc.GetString("rmc-no-queen-hivemind-chat"), source, source, PopupType.LargeCaution);
-
                 output = SanitizeMessageCapital(input[1..].TrimStart());
                 return false;
             }
@@ -249,6 +243,12 @@ public abstract partial class SharedChatSystem : EntitySystem
         RaiseLocalEvent(source, ref prefixEv);
         channel = prefixEv.Channel;
 
+        if (channel?.ID == HivemindChannel.Id &&
+            !CanUseHivemind(source, hive, quiet))
+        {
+            return false;
+        }
+
         if (HasComp<XenoComponent>(source) && !IsHivebrokenXeno(source) && channel == null)
         {
             Log.Info("Has XenoComponent but no channel, returning false");
@@ -257,6 +257,17 @@ public abstract partial class SharedChatSystem : EntitySystem
         // RMC14
 
         return true;
+    }
+
+    private bool CanUseHivemind(EntityUid source, Entity<HiveComponent>? hive, bool quiet)
+    {
+        if (_xenoEvolution.HasLiving<XenoEvolutionGranterComponent>(1, null, hive))
+            return true;
+
+        if (!quiet)
+            _popup.PopupEntity(Loc.GetString("rmc-no-queen-hivemind-chat"), source, source, PopupType.LargeCaution);
+
+        return false;
     }
 
     private bool IsHivebrokenXeno(EntityUid uid)

--- a/Content.Shared/_RMC14/Line/LineSystem.cs
+++ b/Content.Shared/_RMC14/Line/LineSystem.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using Content.Shared._RMC14.Barricade;
 using Content.Shared._RMC14.Entrenching;
 using Content.Shared._RMC14.Map;
+using Content.Shared._RMC14.Weapons.Ranged.Prediction;
 using Content.Shared.Beam.Components;
 using Content.Shared.Coordinates.Helpers;
 using Content.Shared.Doors.Components;
@@ -32,12 +33,14 @@ public sealed partial class LineSystem : EntitySystem
 
     private EntityQuery<BarricadeComponent> _barricadeQuery;
     private EntityQuery<DoorComponent> _doorQuery;
+    private EntityQuery<IgnorePredictionHitComponent> _ignorePredictionHitQuery;
     private EntityQuery<MapGridComponent> _mapGridQuery;
 
     public override void Initialize()
     {
         _barricadeQuery = GetEntityQuery<BarricadeComponent>();
         _doorQuery = GetEntityQuery<DoorComponent>();
+        _ignorePredictionHitQuery = GetEntityQuery<IgnorePredictionHitComponent>();
         _mapGridQuery = GetEntityQuery<MapGridComponent>();
     }
 
@@ -150,6 +153,9 @@ public sealed partial class LineSystem : EntitySystem
         var anchored = _mapSystem.GetAnchoredEntitiesEnumerator(grid.Value, grid, indices);
         while (anchored.MoveNext(out var uid))
         {
+            if (_ignorePredictionHitQuery.HasComp(uid))
+                continue;
+
             if (_barricadeQuery.HasComp(uid))
             {
                 if (ignoreBarricades)

--- a/Content.Shared/_RMC14/Weapons/Ranged/Prediction/IgnorePredictionHitComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Prediction/IgnorePredictionHitComponent.cs
@@ -1,7 +1,8 @@
-﻿using Robust.Shared.GameStates;
+using Content.Shared._RMC14.Line;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Weapons.Ranged.Prediction;
 
 [RegisterComponent, NetworkedComponent]
-[Access(typeof(SharedGunPredictionSystem))]
+[Access(typeof(SharedGunPredictionSystem), typeof(LineSystem))]
 public sealed partial class IgnorePredictionHitComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/Bulwark/XenoBulwarkComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Bulwark/XenoBulwarkComponent.cs
@@ -49,6 +49,9 @@ public sealed partial class XenoBulwarkComponent : Component
     public TimeSpan TailSwingParalyzeTime = TimeSpan.FromSeconds(1.2);
 
     [DataField, AutoNetworkedField]
+    public float TailSwingRange = 1.75f;
+
+    [DataField, AutoNetworkedField]
     public ProtoId<TagPrototype> TailSwingFlingable = "Grenade";
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Bulwark/XenoBulwarkSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Bulwark/XenoBulwarkSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared._RMC14.Xenonids.Sweep;
 using Content.Shared.Actions;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
+using Content.Shared.Interaction;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Physics;
@@ -38,6 +39,7 @@ public sealed partial class XenoBulwarkSystem : EntitySystem
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private EntityLookupSystem _entityLookup = default!;
+    [Dependency] private SharedInteractionSystem _interaction = default!;
     [Dependency] private INetManager _net = default!;
     [Dependency] private SharedPhysicsSystem _physics = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
@@ -196,12 +198,15 @@ public sealed partial class XenoBulwarkSystem : EntitySystem
         var origin = _transform.GetMoverCoordinates(xeno);
         var mapOrigin = _transform.GetMapCoordinates(xeno);
         _nearbyTargets.Clear();
-        _entityLookup.GetEntitiesInRange(origin, 1.75f, _nearbyTargets);
+        _entityLookup.GetEntitiesInRange(origin, xeno.Comp.TailSwingRange, _nearbyTargets);
 
         var hit = false;
         foreach (var target in _nearbyTargets)
         {
             if (target == xeno.Owner)
+                continue;
+
+            if (!_interaction.InRangeUnobstructed(xeno.Owner, target, xeno.Comp.TailSwingRange))
                 continue;
 
             if (_tags.HasTag(target, xeno.Comp.TailSwingFlingable))

--- a/Content.Shared/_RMC14/Xenonids/Charge/CursorCharge/XenoChargerMovementSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/CursorCharge/XenoChargerMovementSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Numerics;
 using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Emote;
+using Content.Shared.Mobs;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Stunnable;
@@ -30,6 +31,7 @@ public sealed partial class XenoChargerMovementSystem : EntitySystem
 
         SubscribeNetworkEvent<XenoCursorSteeringMessage>(OnCursorSteeringMessage);
         SubscribeLocalEvent<XenoChargerStateComponent, MoveInputEvent>(OnMoveInput);
+        SubscribeLocalEvent<XenoChargerStateComponent, MobStateChangedEvent>(OnMobStateChanged);
 
     }
 
@@ -232,6 +234,14 @@ public sealed partial class XenoChargerMovementSystem : EntitySystem
     private void OnMoveInput(Entity<XenoChargerStateComponent> ent, ref MoveInputEvent args)
     {
         args.Entity.Comp.HeldMoveButtons &= ~MoveButtons.AnyDirection;
+    }
+
+    private void OnMobStateChanged(Entity<XenoChargerStateComponent> ent, ref MobStateChangedEvent args)
+    {
+        if (_net.IsClient || args.NewMobState == MobState.Alive)
+            return;
+
+        ResetToIdle(ent.Owner);
     }
 
     private static Angle GetWorldRotation(Angle heading)

--- a/Resources/Prototypes/_CMU14/Entities/Mobs/drone_android.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Mobs/drone_android.yml
@@ -12,6 +12,9 @@
   - type: RemoveComponents
     components:
     - type: WorkingJoeVoice
+    - type: IntrinsicRadioReceiver
+    - type: IntrinsicRadioTransmitter
+    - type: ActiveRadio
   - type: Inventory
     templateId: cmuDroneAndroid
   - type: HumanoidAppearance

--- a/Resources/Prototypes/_CMU14/Vehicles/Blackfoot/vehicles.yml
+++ b/Resources/Prototypes/_CMU14/Vehicles/Blackfoot/vehicles.yml
@@ -112,6 +112,7 @@
     reverseAcceleration: 2
     turnDelay: 0.25
     turnInPlace: true
+    movementCollisionInset: 0.17
     xenoBlockMinimumSize: Immobile
     canXenosPush: false
     speedAtZeroIntegrity: 0.25

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/webbing.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/webbing.yml
@@ -11,6 +11,7 @@
       tags:
       #TODO any analyzer - plant etc
       - Radio
+      - RMCG8Pouch
       - Crowbar
       - Handcuffs
       - Binoculars

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
@@ -13,6 +13,7 @@
   - type: Physics
     canCollide: false
   - type: Fixtures
+  - type: IgnorePredictionHit
   - type: Damageable
     damageContainer: Inorganic
   - type: MeleeSound

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/synth.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/synth.yml
@@ -137,6 +137,7 @@
   - type: Temperature
   - type: Stamina
   - type: DamageForceSay
+  - type: DamageMobState
   - type: Dna
   - type: InjectableSolution
   - type: IVDripTarget

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/synth_surgeries.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/synth_surgeries.yml
@@ -82,6 +82,8 @@
   surgery: RMCSynthSurgeryReattachLimb
   displayName: Reattach Synth Limb
   validParts: [Arm, Leg]
+  allowSelfSurgery: true
+  selfSurgeryValidParts: [Arm, Leg]
   category: reattach
   steps:
   - stepId: RMCSynthSurgeryStepCutChassis


### PR DESCRIPTION
:cl:
- fix: Fixed Blackfoot/scout VTOLs being too wide for 3-tile doors.
- fix: Chargers now stop charging when they die.
- fix: Fixed third-party ghost roles spawning on inactive shuttle landing areas.
- fix: Fixed ghost warp showing stale previous-round details.
- fix: Xeno acid spray is no longer blocked by floor coverings like conveyors and grass.
- fix: Bulwark tail sweep no longer hits through walls.
- fix: Drone android pilots now hear their operator radio channels instead of AI.
- fix: Hivemind chat is blocked while no living queen exists.
- fix: Type 48-M utility pouches now fit armor with external webbing.
- fix: Synths no longer receive organic oxygen damage in crit and can self-reattach limbs through synth surgery.