### PR TITLE
Fix chat clarity and diagnostics regressions

### DIFF
--- a/Content.Client/Gameplay/GameplayStateBase.cs
+++ b/Content.Client/Gameplay/GameplayStateBase.cs
@@ -215,21 +215,29 @@ namespace Content.Client.Gameplay
             if (args.Viewport is IViewportControl vp && kArgs.PointerLocation.IsValid)
             {
                 var mousePosWorld = vp.PixelToMap(kArgs.PointerLocation.Position);
+                var mapSystem = _entitySystemManager.GetEntitySystem<MapSystem>();
 
-                if (vp is ScalingViewport svp)
+                if (!mapSystem.MapExists(mousePosWorld.MapId))
                 {
-                    entityToClick = GetClickedEntity(mousePosWorld, svp.Eye);
+                    coordinates = EntityCoordinates.Invalid;
                 }
                 else
                 {
-                    entityToClick = GetClickedEntity(mousePosWorld);
-                }
-                var transformSystem = _entitySystemManager.GetEntitySystem<SharedTransformSystem>();
-                var mapSystem = _entitySystemManager.GetEntitySystem<MapSystem>();
+                    if (vp is ScalingViewport svp)
+                    {
+                        entityToClick = GetClickedEntity(mousePosWorld, svp.Eye);
+                    }
+                    else
+                    {
+                        entityToClick = GetClickedEntity(mousePosWorld);
+                    }
 
-                coordinates = mapSystem.TryFindGridAt(mousePosWorld, out var uid, out _) ?
-                    mapSystem.MapToGrid(uid, mousePosWorld) :
-                    transformSystem.ToCoordinates(mousePosWorld);
+                    var transformSystem = _entitySystemManager.GetEntitySystem<SharedTransformSystem>();
+
+                    coordinates = mapSystem.TryFindGridAt(mousePosWorld, out var uid, out _) ?
+                        mapSystem.MapToGrid(uid, mousePosWorld) :
+                        transformSystem.ToCoordinates(mousePosWorld);
+                }
             }
             else
             {

--- a/Content.Client/_CMU14/Chat/RunechatSpeechBubble.cs
+++ b/Content.Client/_CMU14/Chat/RunechatSpeechBubble.cs
@@ -327,8 +327,10 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
         private const string FallbackItalicFontPath = "/Fonts/RobotoMono/RobotoMono-Italic.ttf";
         private const float CmuMaxAlpha = 1f;
         private const float SyntheticBoldOffset = 1f;
-        private const float TextShadowAlpha = 0.18f;
-        private const float TextShadowOffset = 1f;
+        private const float TextStrokeAlpha = 0.9f;
+        private const float TextHaloAlpha = 0.35f;
+        private const float TextStrokeOffset = 1f;
+        private const float TextHaloOffset = 2f;
         private const float EmoteIconBaseSize = 9f;
         private const float DefaultEmoteIconPixelSize = 1.4f;
         private const float PanicShakeDuration = 0.85f;
@@ -343,6 +345,26 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
         private static readonly Color EmoteIconBlue = Color.FromHex("#3399ff");
         private static readonly CultureInfo EnUsCulture = CultureInfo.GetCultureInfo("en-US");
         private static bool SmallFontsLoadFailed;
+
+        private static readonly Vector2[] TextStrokeOffsets =
+        {
+            new(-1f, -1f),
+            new(0f, -1f),
+            new(1f, -1f),
+            new(-1f, 0f),
+            new(1f, 0f),
+            new(-1f, 1f),
+            new(0f, 1f),
+            new(1f, 1f),
+        };
+
+        private static readonly Vector2[] TextHaloOffsets =
+        {
+            new(0f, -1f),
+            new(-1f, 0f),
+            new(1f, 0f),
+            new(0f, 1f),
+        };
 
         private static readonly string[] EmoteIcon =
         {
@@ -421,7 +443,6 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
 
             var layout = _layouts[Math.Min(_currentPage, _layouts.Count - 1)];
             var textOpacity = _configManager.GetCVar(CCVars.SpeechBubbleTextOpacity) * CmuMaxAlpha;
-            var outlineColor = Color.Black.WithAlpha(textOpacity);
             var textColor = _color.WithAlpha(_color.A * textOpacity);
             var lineHeight = GetLineHeight();
             var y = (PixelSize.Y - layout.Height) / 2f;
@@ -448,11 +469,10 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
                     DrawEmoteIcon(
                         handle,
                         new Vector2(position.X - iconGap - iconWidth - GetVisibleIconLeft(), iconY),
-                        outlineColor,
                         textColor);
                 }
 
-                DrawOutlinedString(handle, position, line, outlineColor, textColor);
+                DrawOutlinedString(handle, position, line, textColor);
                 y += lineHeight;
             }
         }
@@ -702,26 +722,30 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
             DrawingHandleScreen handle,
             Vector2 position,
             string text,
-            Color outlineColor,
             Color textColor)
         {
-            var shadowOffset = TextShadowOffset * _scale * UIScale;
-            var shadowColor = Color.Black.WithAlpha(textColor.A * TextShadowAlpha);
-            var outlineOffset = _scale * UIScale;
-            DrawStringPass(handle, position + new Vector2(shadowOffset, shadowOffset), text, shadowColor);
+            var strokeOffset = GetTextPixelOffset(TextStrokeOffset);
+            var haloOffset = GetTextPixelOffset(TextHaloOffset);
+            var strokeColor = Color.Black.WithAlpha(textColor.A * TextStrokeAlpha);
+            var haloColor = Color.Black.WithAlpha(textColor.A * TextHaloAlpha);
 
-            for (var x = -1; x <= 1; x++)
-            {
-                for (var y = -1; y <= 1; y++)
-                {
-                    if (x == 0 && y == 0)
-                        continue;
-
-                    DrawStringPass(handle, position + new Vector2(x * outlineOffset, y * outlineOffset), text, outlineColor);
-                }
-            }
-
+            DrawStringPasses(handle, position, text, TextHaloOffsets, haloOffset, haloColor);
+            DrawStringPasses(handle, position, text, TextStrokeOffsets, strokeOffset, strokeColor);
             DrawStringPass(handle, position, text, textColor);
+        }
+
+        private void DrawStringPasses(
+            DrawingHandleScreen handle,
+            Vector2 position,
+            string text,
+            IReadOnlyList<Vector2> offsets,
+            float offset,
+            Color color)
+        {
+            foreach (var direction in offsets)
+            {
+                DrawStringPass(handle, position + direction * offset, text, color);
+            }
         }
 
         private void DrawStringPass(DrawingHandleScreen handle, Vector2 position, string text, Color color)
@@ -732,10 +756,14 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
                 handle.DrawString(_font, position + new Vector2(GetSyntheticBoldOffset(), 0f), text, UIScale, color);
         }
 
+        private float GetTextPixelOffset(float pixels)
+        {
+            return MathF.Max(1f, MathF.Round(pixels * UIScale));
+        }
+
         private void DrawEmoteIcon(
             DrawingHandleScreen handle,
             Vector2 position,
-            Color outlineColor,
             Color textColor)
         {
             var scale = MathF.Max(1f, GetIconPixelSize() * UIScale);

--- a/Content.Server/AU14/WithdrawConsole/WithdrawConsoleSystem.cs
+++ b/Content.Server/AU14/WithdrawConsole/WithdrawConsoleSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server._CMU14.RoundStatistics;
+using Content.Server._RMC14.Rules;
 using Content.Server.GameTicking;
 using Content.Shared._RMC14.Marines;
 using Content.Server._RMC14.Marines;
@@ -21,6 +22,7 @@ namespace Content.Server.AU14.WithdrawConsole;
 public sealed partial class WithdrawConsoleSystem : EntitySystem
 {
     [Dependency] private AccessReaderSystem _accessReader = default!;
+    [Dependency] private CMDistressSignalRuleSystem _distressSignal = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private MarineAnnounceSystem _marineAnnounce = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
@@ -380,6 +382,13 @@ public sealed partial class WithdrawConsoleSystem : EntitySystem
             text = Loc.GetString("withdraw-console-round-end-withdrawn", ("faction", faction?.ToUpperInvariant() ?? "UNKNOWN"));
 
         _roundStats.RecordWithdrawal(faction, isStalemate);
+
+        if (!isStalemate &&
+            _distressSignal.TryEndActiveDistressRound(DistressSignalRuleResult.MinorXenoVictory))
+        {
+            return;
+        }
+
         _gameTicker.EndRound(text);
     }
 

--- a/Content.Server/Administration/Commands/ServerPerformanceCommand.cs
+++ b/Content.Server/Administration/Commands/ServerPerformanceCommand.cs
@@ -27,6 +27,8 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
     private static readonly string[] Modes =
     [
         "snapshot",
+        "deep",
+        "baseline",
         "components",
         "entities",
         "prototypes",
@@ -44,6 +46,8 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
     public string Help =>
         "Usage:\n" +
         "  serverperf snapshot [top=20] [dirtyTicks=5]\n" +
+        "  serverperf deep [top=20] [dirtyTicks=30] [filter]\n" +
+        "  serverperf baseline [dirtyTicks=30]\n" +
         "  serverperf components [top=20] [dirtyTicks=5] [filter]\n" +
         "  serverperf entities [top=20] [dirtyTicks=5] [filter]\n" +
         "  serverperf prototypes [top=20] [filter]\n" +
@@ -52,7 +56,10 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
         "  serverperf profile on|off|top|systems|engine [frames=10] [top=20] [filter]\n" +
         "  serverperf metrics on|off|status\n" +
         "\n" +
+        "For before/after lag hunts: serverperf baseline, trigger the action, then serverperf deep 40 120.\n" +
         "Use 'serverperf profile on' during lag, wait a few seconds, then run 'serverperf profile systems'.";
+
+    private static SnapshotState? LastSnapshot;
 
     public void Execute(IConsoleShell shell, string argStr, string[] args)
     {
@@ -62,6 +69,12 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
         {
             case "snapshot":
                 RunSnapshot(shell, args);
+                break;
+            case "deep":
+                RunDeep(shell, args);
+                break;
+            case "baseline":
+                RunBaseline(shell, args);
                 break;
             case "components":
                 RunComponents(shell, args);
@@ -112,19 +125,63 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
         var index = 1;
         var top = ReadInt(args, ref index, DefaultTop, 1, MaxTop);
         var dirtyTicks = ReadInt(args, ref index, DefaultDirtyTicks, 1, MaxDirtyTicks);
+        var snapshot = CollectSnapshot(dirtyTicks, null);
 
         shell.WriteLine("== Server Performance Snapshot ==");
         WriteSummary(shell);
         shell.WriteLine("");
         WriteProfileTop(shell, ProfileMode.Systems, DefaultFrames, Math.Min(top, 15), null, includeDisabledHint: false);
         shell.WriteLine("");
-        WriteComponentReport(shell, top, dirtyTicks, null);
+        WriteSnapshotDeltaReport(shell, snapshot, top, null);
         shell.WriteLine("");
-        WriteEntityReport(shell, top, dirtyTicks, null);
+        WriteComponentReport(shell, snapshot, top, null);
         shell.WriteLine("");
-        WritePrototypeReport(shell, top, null);
+        WriteEntityReport(shell, snapshot, top, null);
         shell.WriteLine("");
-        WriteMapReport(shell, top);
+        WritePrototypeReport(shell, snapshot, top, null);
+        shell.WriteLine("");
+        WriteMapReport(shell, snapshot, top);
+        LastSnapshot = snapshot;
+    }
+
+    private static void RunDeep(IConsoleShell shell, string[] args)
+    {
+        var index = 1;
+        var top = ReadInt(args, ref index, DefaultTop, 1, MaxTop);
+        var dirtyTicks = ReadInt(args, ref index, 30, 1, MaxDirtyTicks);
+        var filter = ReadFilter(args, index);
+        var snapshot = CollectSnapshot(dirtyTicks, filter);
+
+        shell.WriteLine("== Deep Server Performance Snapshot ==");
+        WriteSummary(shell);
+        shell.WriteLine("");
+        WriteProfileTop(shell, ProfileMode.Systems, Math.Max(DefaultFrames, 30), Math.Min(top, 30), filter, includeDisabledHint: true);
+        shell.WriteLine("");
+        WriteSnapshotDeltaReport(shell, snapshot, top, filter);
+        shell.WriteLine("");
+        WriteRecentCreationReport(shell, snapshot, top, filter);
+        shell.WriteLine("");
+        WriteComponentReport(shell, snapshot, top, filter);
+        shell.WriteLine("");
+        WriteEntityReport(shell, snapshot, top, filter);
+        shell.WriteLine("");
+        WriteEntityDetailReport(shell, snapshot, Math.Min(top, 30), filter);
+        shell.WriteLine("");
+        WritePrototypeReport(shell, snapshot, top, filter);
+        shell.WriteLine("");
+        WriteMapReport(shell, snapshot, top);
+        LastSnapshot = snapshot;
+    }
+
+    private static void RunBaseline(IConsoleShell shell, string[] args)
+    {
+        var index = 1;
+        var dirtyTicks = ReadInt(args, ref index, 30, 1, MaxDirtyTicks);
+        LastSnapshot = CollectSnapshot(dirtyTicks, null);
+
+        shell.WriteLine($"Baseline captured at tick {LastSnapshot.Tick.Value:N0}.");
+        shell.WriteLine($"Entities={LastSnapshot.EntityCount:N0} components={LastSnapshot.TotalComponents:N0} prototypes={LastSnapshot.Prototypes.Count:N0} maps={LastSnapshot.Maps.Count:N0}");
+        shell.WriteLine("Trigger the action, then run: serverperf deep 40 120");
     }
 
     private static void RunComponents(IConsoleShell shell, string[] args)
@@ -134,7 +191,7 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
         var dirtyTicks = ReadInt(args, ref index, DefaultDirtyTicks, 1, MaxDirtyTicks);
         var filter = ReadFilter(args, index);
 
-        WriteComponentReport(shell, top, dirtyTicks, filter);
+        WriteComponentReport(shell, CollectComponentStats(dirtyTicks, filter), dirtyTicks, top, filter);
     }
 
     private static void RunEntities(IConsoleShell shell, string[] args)
@@ -144,7 +201,7 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
         var dirtyTicks = ReadInt(args, ref index, DefaultDirtyTicks, 1, MaxDirtyTicks);
         var filter = ReadFilter(args, index);
 
-        WriteEntityReport(shell, top, dirtyTicks, filter);
+        WriteEntityReport(shell, CollectEntityStats(dirtyTicks, filter), dirtyTicks, top, filter);
     }
 
     private static void RunPrototypes(IConsoleShell shell, string[] args)
@@ -153,7 +210,7 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
         var top = ReadInt(args, ref index, DefaultTop, 1, MaxTop);
         var filter = ReadFilter(args, index);
 
-        WritePrototypeReport(shell, top, filter);
+        WritePrototypeReport(shell, CollectPrototypeStats(DefaultDirtyTicks, filter), top, filter);
     }
 
     private static void RunMaps(IConsoleShell shell, string[] args)
@@ -161,7 +218,7 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
         var index = 1;
         var top = ReadInt(args, ref index, DefaultTop, 1, MaxTop);
 
-        WriteMapReport(shell, top);
+        WriteMapReport(shell, CollectMapStats(DefaultDirtyTicks), top);
     }
 
     private static void RunSystems(IConsoleShell shell, string[] args)
@@ -302,10 +359,61 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
         shell.WriteLine($"Endpoint: http://{cfg.GetCVar(CVars.MetricsHost)}:{cfg.GetCVar(CVars.MetricsPort)}/metrics");
     }
 
-    private static void WriteComponentReport(IConsoleShell shell, int top, int dirtyTicks, string? filter)
+    private static void WriteSnapshotDeltaReport(IConsoleShell shell, SnapshotState snapshot, int top, string? filter)
     {
-        var stats = CollectComponentStats(dirtyTicks, filter);
+        shell.WriteLine("== Delta Since Previous Snapshot ==");
+        if (filter != null)
+            shell.WriteLine($"Filter: {filter}");
 
+        if (LastSnapshot == null)
+        {
+            shell.WriteLine("No previous snapshot in memory. This snapshot is now the comparison baseline.");
+            return;
+        }
+
+        var previous = LastSnapshot;
+        var elapsedTicks = snapshot.Tick.Value >= previous.Tick.Value
+            ? snapshot.Tick.Value - previous.Tick.Value
+            : 0;
+
+        shell.WriteLine($"Previous tick={previous.Tick.Value:N0} current tick={snapshot.Tick.Value:N0} elapsedTicks={elapsedTicks:N0}");
+        shell.WriteLine($"Entities {previous.EntityCount:N0} -> {snapshot.EntityCount:N0} ({FormatSigned(snapshot.EntityCount - previous.EntityCount)}) | " +
+                        $"Components {previous.TotalComponents:N0} -> {snapshot.TotalComponents:N0} ({FormatSigned(snapshot.TotalComponents - previous.TotalComponents)})");
+
+        WriteCounterDeltaRows(shell, "Prototype count deltas", previous.PrototypeCounts, snapshot.PrototypeCounts, top);
+        WriteCounterDeltaRows(shell, "Component count deltas", previous.ComponentCounts, snapshot.ComponentCounts, top);
+        WriteMapDeltaRows(shell, previous, snapshot, top);
+        WriteEntityChurnRows(shell, "New entities since previous snapshot", GetNewEntities(previous, snapshot), top);
+        WriteEntityChurnRows(shell, "Removed entities since previous snapshot", GetRemovedEntities(previous, snapshot), top);
+        WriteEntityChurnRows(shell, "Modified entities since previous snapshot", snapshot.Entities.Where(e => e.LastModifiedTick.Value > previous.Tick.Value), top);
+    }
+
+    private static void WriteRecentCreationReport(IConsoleShell shell, SnapshotState snapshot, int top, string? filter)
+    {
+        shell.WriteLine($"== Recent Creations (dirty window {snapshot.DirtyTicks:N0} ticks) ==");
+        if (filter != null)
+            shell.WriteLine($"Filter: {filter}");
+
+        WriteEntityChurnRows(shell, "Created entities by prototype/map", snapshot.Entities.Where(e => IsRecent(e.CreationTick, snapshot.MinRecentTick)), top);
+
+        shell.WriteLine("Created components by type:");
+        var components = snapshot.Components
+            .Where(s => s.Created > 0)
+            .OrderByDescending(s => s.Created)
+            .ThenByDescending(s => s.Count)
+            .Take(top)
+            .ToArray();
+
+        WriteComponentRows(shell, components);
+    }
+
+    private static void WriteComponentReport(IConsoleShell shell, SnapshotState snapshot, int top, string? filter)
+    {
+        WriteComponentReport(shell, snapshot.Components, snapshot.DirtyTicks, top, filter);
+    }
+
+    private static void WriteComponentReport(IConsoleShell shell, List<ComponentStats> stats, int dirtyTicks, int top, string? filter)
+    {
         shell.WriteLine($"== Components (top {top:N0}, dirty window {dirtyTicks:N0} ticks) ==");
         if (filter != null)
             shell.WriteLine($"Filter: {filter}");
@@ -346,9 +454,14 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
         }
     }
 
-    private static void WriteEntityReport(IConsoleShell shell, int top, int dirtyTicks, string? filter)
+    private static void WriteEntityReport(IConsoleShell shell, SnapshotState snapshot, int top, string? filter)
     {
-        var rows = CollectEntityStats(dirtyTicks, filter)
+        WriteEntityReport(shell, snapshot.Entities, snapshot.DirtyTicks, top, filter);
+    }
+
+    private static void WriteEntityReport(IConsoleShell shell, List<EntityStats> stats, int dirtyTicks, int top, string? filter)
+    {
+        var rows = stats
             .OrderByDescending(s => s.DirtyComponents)
             .ThenByDescending(s => s.ComponentCount)
             .ThenByDescending(s => s.LastModifiedTick.Value)
@@ -368,13 +481,50 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
         for (var i = 0; i < rows.Length; i++)
         {
             var row = rows[i];
-            shell.WriteLine($"{i + 1,3}. {row.Uid,-10} comps={row.ComponentCount,3:N0} dirty={row.DirtyComponents,3:N0} net={row.NetworkedComponents,3:N0} tick={row.LastModifiedTick.Value,10:N0} map={row.MapId} proto={row.Prototype} name=\"{Truncate(row.Name, 48)}\"");
+            shell.WriteLine($"{i + 1,3}. {row.Uid,-10} comps={row.ComponentCount,3:N0} dirty={row.DirtyComponents,3:N0} net={row.NetworkedComponents,3:N0} tick={row.LastModifiedTick.Value,10:N0} created={row.CreationTick.Value,10:N0} map={row.MapId} grid={row.GridUid} proto={row.Prototype} name=\"{Truncate(row.Name, 48)}\"");
         }
     }
 
-    private static void WritePrototypeReport(IConsoleShell shell, int top, string? filter)
+    private static void WriteEntityDetailReport(IConsoleShell shell, SnapshotState snapshot, int top, string? filter)
     {
-        var rows = CollectPrototypeStats(filter)
+        var rows = snapshot.Entities
+            .Where(s => s.DirtyComponents > 0 || s.CreatedComponentNames.Length > 0 || IsRecent(s.CreationTick, snapshot.MinRecentTick))
+            .OrderByDescending(s => s.DirtyComponents)
+            .ThenByDescending(s => s.CreatedComponentNames.Length)
+            .ThenByDescending(s => s.ComponentCount)
+            .ThenByDescending(s => s.LastModifiedTick.Value)
+            .Take(top)
+            .ToArray();
+
+        shell.WriteLine($"== Dirty Entity Details (top {top:N0}) ==");
+        if (filter != null)
+            shell.WriteLine($"Filter: {filter}");
+
+        if (rows.Length == 0)
+        {
+            shell.WriteLine("No recently dirty or created entities.");
+            return;
+        }
+
+        for (var i = 0; i < rows.Length; i++)
+        {
+            var row = rows[i];
+            var entityCreated = IsRecent(row.CreationTick, snapshot.MinRecentTick);
+            shell.WriteLine($"{i + 1,3}. {row.Uid,-10} proto={row.Prototype} map={row.MapId} grid={row.GridUid} createdEntity={YesNo(entityCreated)} name=\"{Truncate(row.Name, 40)}\"");
+            shell.WriteLine($"     dirty=[{JoinNames(row.DirtyComponentNames, 12)}]");
+            shell.WriteLine($"     created=[{JoinNames(row.CreatedComponentNames, 12)}]");
+            shell.WriteLine($"     comps=[{JoinNames(row.ComponentNames, 18)}]");
+        }
+    }
+
+    private static void WritePrototypeReport(IConsoleShell shell, SnapshotState snapshot, int top, string? filter)
+    {
+        WritePrototypeReport(shell, snapshot.Prototypes, top, filter);
+    }
+
+    private static void WritePrototypeReport(IConsoleShell shell, List<PrototypeStats> stats, int top, string? filter)
+    {
+        var rows = stats
             .OrderByDescending(s => s.Count)
             .ThenByDescending(s => s.DirtyEntities)
             .ThenBy(s => s.Prototype)
@@ -394,13 +544,18 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
         for (var i = 0; i < rows.Length; i++)
         {
             var row = rows[i];
-            shell.WriteLine($"{i + 1,3}. {row.Prototype,-56} count={row.Count,7:N0} dirtyEntities={row.DirtyEntities,6:N0}");
+            shell.WriteLine($"{i + 1,3}. {row.Prototype,-56} count={row.Count,7:N0} dirtyEntities={row.DirtyEntities,6:N0} createdEntities={row.CreatedEntities,6:N0}");
         }
     }
 
-    private static void WriteMapReport(IConsoleShell shell, int top)
+    private static void WriteMapReport(IConsoleShell shell, SnapshotState snapshot, int top)
     {
-        var rows = CollectMapStats()
+        WriteMapReport(shell, snapshot.Maps, top);
+    }
+
+    private static void WriteMapReport(IConsoleShell shell, List<MapStats> stats, int top)
+    {
+        var rows = stats
             .OrderByDescending(s => s.Entities)
             .ThenByDescending(s => s.Grids)
             .Take(top)
@@ -416,7 +571,7 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
         for (var i = 0; i < rows.Length; i++)
         {
             var row = rows[i];
-            shell.WriteLine($"{i + 1,3}. map={row.MapId,-8} entities={row.Entities,7:N0} dirty={row.DirtyEntities,6:N0} grids={row.Grids,5:N0} inNullspace={row.NullspaceEntities,6:N0}");
+            shell.WriteLine($"{i + 1,3}. map={row.MapId,-8} entities={row.Entities,7:N0} dirty={row.DirtyEntities,6:N0} created={row.CreatedEntities,6:N0} grids={row.Grids,5:N0} inNullspace={row.NullspaceEntities,6:N0}");
         }
     }
 
@@ -460,6 +615,168 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
         {
             var row = rows[i];
             shell.WriteLine($"{i + 1,3}. {row.Name,-52} total={row.TotalMs,9:N3}ms avg={row.AverageMs,8:N3}ms max={row.MaxMs,8:N3}ms calls={row.Count,5:N0} alloc={FormatBytes(row.TotalAlloc),9}");
+        }
+    }
+
+    private static SnapshotState CollectSnapshot(int dirtyTicks, string? filter)
+    {
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+        var timing = IoCManager.Resolve<IGameTiming>();
+        var components = CollectComponentStats(dirtyTicks, filter);
+        var entities = CollectEntityStats(dirtyTicks, filter);
+        var prototypes = CollectPrototypeStats(dirtyTicks, filter);
+        var maps = CollectMapStats(dirtyTicks);
+
+        return new SnapshotState(
+            timing.CurTick,
+            dirtyTicks,
+            MinRecentTick(timing, dirtyTicks),
+            entityManager.EntityCount,
+            components,
+            entities,
+            prototypes,
+            maps);
+    }
+
+    private static void WriteCounterDeltaRows(
+        IConsoleShell shell,
+        string title,
+        IReadOnlyDictionary<string, int> previous,
+        IReadOnlyDictionary<string, int> current,
+        int top)
+    {
+        shell.WriteLine($"{title}:");
+
+        var rows = previous.Keys
+            .Concat(current.Keys)
+            .Distinct(StringComparer.Ordinal)
+            .Select(key =>
+            {
+                previous.TryGetValue(key, out var oldValue);
+                current.TryGetValue(key, out var newValue);
+                return new CounterDeltaRow(key, oldValue, newValue, newValue - oldValue);
+            })
+            .Where(row => row.Delta != 0)
+            .OrderByDescending(row => Math.Abs(row.Delta))
+            .ThenBy(row => row.Name)
+            .Take(top)
+            .ToArray();
+
+        if (rows.Length == 0)
+        {
+            shell.WriteLine("  no count changes");
+            return;
+        }
+
+        for (var i = 0; i < rows.Length; i++)
+        {
+            var row = rows[i];
+            shell.WriteLine($"{i + 1,3}. {row.Name,-56} {row.Previous,7:N0} -> {row.Current,7:N0} ({FormatSigned(row.Delta)})");
+        }
+    }
+
+    private static void WriteMapDeltaRows(IConsoleShell shell, SnapshotState previous, SnapshotState current, int top)
+    {
+        shell.WriteLine("Map deltas:");
+
+        var rows = previous.MapsById.Keys
+            .Concat(current.MapsById.Keys)
+            .Distinct(StringComparer.Ordinal)
+            .Select(mapId =>
+            {
+                previous.MapsById.TryGetValue(mapId, out var oldMap);
+                current.MapsById.TryGetValue(mapId, out var newMap);
+                var oldEntities = oldMap?.Entities ?? 0;
+                var newEntities = newMap?.Entities ?? 0;
+                var oldGrids = oldMap?.Grids ?? 0;
+                var newGrids = newMap?.Grids ?? 0;
+                var oldNullspace = oldMap?.NullspaceEntities ?? 0;
+                var newNullspace = newMap?.NullspaceEntities ?? 0;
+
+                return new MapDeltaRow(
+                    mapId,
+                    oldEntities,
+                    newEntities,
+                    newEntities - oldEntities,
+                    oldGrids,
+                    newGrids,
+                    newGrids - oldGrids,
+                    oldNullspace,
+                    newNullspace,
+                    newNullspace - oldNullspace);
+            })
+            .Where(row => row.EntityDelta != 0 || row.GridDelta != 0 || row.NullspaceDelta != 0)
+            .OrderByDescending(row => Math.Abs(row.EntityDelta) + Math.Abs(row.GridDelta * 25) + Math.Abs(row.NullspaceDelta))
+            .ThenBy(row => row.MapId)
+            .Take(top)
+            .ToArray();
+
+        if (rows.Length == 0)
+        {
+            shell.WriteLine("  no map count changes");
+            return;
+        }
+
+        for (var i = 0; i < rows.Length; i++)
+        {
+            var row = rows[i];
+            shell.WriteLine($"{i + 1,3}. map={row.MapId,-8} entities {row.PreviousEntities,7:N0}->{row.CurrentEntities,7:N0} ({FormatSigned(row.EntityDelta)}) grids {row.PreviousGrids,4:N0}->{row.CurrentGrids,4:N0} ({FormatSigned(row.GridDelta)}) nullspace {row.PreviousNullspace,6:N0}->{row.CurrentNullspace,6:N0} ({FormatSigned(row.NullspaceDelta)})");
+        }
+    }
+
+    private static void WriteEntityChurnRows(IConsoleShell shell, string title, IEnumerable<EntityStats> entities, int top)
+    {
+        shell.WriteLine($"{title}:");
+
+        var rows = entities
+            .GroupBy(entity => new EntityChurnKey(entity.Prototype, entity.MapId))
+            .Select(group =>
+            {
+                var sample = group
+                    .OrderByDescending(entity => entity.LastModifiedTick.Value)
+                    .First();
+
+                return new EntityChurnRow(
+                    group.Key.Prototype,
+                    group.Key.MapId,
+                    group.Count(),
+                    sample.Uid,
+                    sample.Name,
+                    sample.GridUid);
+            })
+            .OrderByDescending(row => row.Count)
+            .ThenBy(row => row.Prototype)
+            .Take(top)
+            .ToArray();
+
+        if (rows.Length == 0)
+        {
+            shell.WriteLine("  none");
+            return;
+        }
+
+        for (var i = 0; i < rows.Length; i++)
+        {
+            var row = rows[i];
+            shell.WriteLine($"{i + 1,3}. {row.Prototype,-48} count={row.Count,6:N0} map={row.MapId,-8} sample={row.SampleUid} grid={row.SampleGrid} name=\"{Truncate(row.SampleName, 40)}\"");
+        }
+    }
+
+    private static IEnumerable<EntityStats> GetNewEntities(SnapshotState previous, SnapshotState current)
+    {
+        foreach (var (uid, entity) in current.EntitiesByUid)
+        {
+            if (!previous.EntitiesByUid.ContainsKey(uid))
+                yield return entity;
+        }
+    }
+
+    private static IEnumerable<EntityStats> GetRemovedEntities(SnapshotState previous, SnapshotState current)
+    {
+        foreach (var (uid, entity) in previous.EntitiesByUid)
+        {
+            if (!current.EntitiesByUid.ContainsKey(uid))
+                yield return entity;
         }
     }
 
@@ -532,14 +849,26 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
 
             var dirty = 0;
             var networked = 0;
+            var componentNames = new List<string>(components.Length);
+            var dirtyComponents = new List<string>();
+            var createdComponents = new List<string>();
 
             foreach (var component in components)
             {
+                var componentName = ComponentName(component);
+                componentNames.Add(componentName);
+
                 if (component.NetSyncEnabled)
                     networked++;
 
                 if (IsRecent(component.LastModifiedTick, minTick))
+                {
                     dirty++;
+                    dirtyComponents.Add(componentName);
+                }
+
+                if (IsRecent(component.CreationTick, minTick))
+                    createdComponents.Add(componentName);
             }
 
             entityManager.TryGetComponent(uid, out TransformComponent? xform);
@@ -552,17 +881,22 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
                 dirty,
                 networked,
                 meta.EntityLastModifiedTick,
-                xform?.MapID.ToString() ?? "<none>"));
+                meta.CreationTick,
+                xform?.MapID.ToString() ?? "<none>",
+                xform?.GridUid?.ToString() ?? "<none>",
+                componentNames.OrderBy(n => n).ToArray(),
+                dirtyComponents.OrderBy(n => n).ToArray(),
+                createdComponents.OrderBy(n => n).ToArray()));
         }
 
         return results;
     }
 
-    private static List<PrototypeStats> CollectPrototypeStats(string? filter)
+    private static List<PrototypeStats> CollectPrototypeStats(int dirtyTicks, string? filter)
     {
         var entityManager = IoCManager.Resolve<IEntityManager>();
         var timing = IoCManager.Resolve<IGameTiming>();
-        var minTick = MinRecentTick(timing, DefaultDirtyTicks);
+        var minTick = MinRecentTick(timing, dirtyTicks);
         var results = new Dictionary<string, PrototypeStats>();
 
         foreach (var uid in entityManager.GetEntities())
@@ -584,16 +918,19 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
 
             if (IsRecent(meta.EntityLastModifiedTick, minTick))
                 stats.DirtyEntities++;
+
+            if (IsRecent(meta.CreationTick, minTick))
+                stats.CreatedEntities++;
         }
 
         return results.Values.ToList();
     }
 
-    private static List<MapStats> CollectMapStats()
+    private static List<MapStats> CollectMapStats(int dirtyTicks)
     {
         var entityManager = IoCManager.Resolve<IEntityManager>();
         var timing = IoCManager.Resolve<IGameTiming>();
-        var minTick = MinRecentTick(timing, DefaultDirtyTicks);
+        var minTick = MinRecentTick(timing, dirtyTicks);
         var results = new Dictionary<string, MapStats>();
         var gridsByMap = new Dictionary<string, HashSet<EntityUid>>();
 
@@ -630,6 +967,9 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
             {
                 stats.DirtyEntities++;
             }
+
+            if (meta != null && IsRecent(meta.CreationTick, minTick))
+                stats.CreatedEntities++;
         }
 
         foreach (var (map, grids) in gridsByMap)
@@ -798,6 +1138,35 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
         return false;
     }
 
+    private static string ComponentName(IComponent component)
+    {
+        const string suffix = "Component";
+        var name = component.GetType().Name;
+        return name.EndsWith(suffix, StringComparison.Ordinal)
+            ? name[..^suffix.Length]
+            : name;
+    }
+
+    private static string JoinNames(IReadOnlyList<string> values, int max)
+    {
+        if (values.Count == 0)
+            return string.Empty;
+
+        var visible = values.Take(max).ToArray();
+        var joined = string.Join(", ", visible);
+        var remaining = values.Count - visible.Length;
+        return remaining <= 0
+            ? joined
+            : $"{joined}, +{remaining:N0} more";
+    }
+
+    private static string FormatSigned(int value)
+    {
+        return value >= 0
+            ? $"+{value:N0}"
+            : value.ToString("N0", CultureInfo.InvariantCulture);
+    }
+
     private static string YesNo(bool value)
     {
         return value ? "yes" : "no";
@@ -836,11 +1205,17 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
         int DirtyComponents,
         int NetworkedComponents,
         GameTick LastModifiedTick,
-        string MapId);
+        GameTick CreationTick,
+        string MapId,
+        string GridUid,
+        string[] ComponentNames,
+        string[] DirtyComponentNames,
+        string[] CreatedComponentNames);
 
     private sealed class PrototypeStats(string prototype)
     {
         public readonly string Prototype = prototype;
+        public int CreatedEntities;
         public int Count;
         public int DirtyEntities;
     }
@@ -848,11 +1223,80 @@ public sealed class ServerPerformanceCommand : IConsoleCommand
     private sealed class MapStats(string mapId)
     {
         public readonly string MapId = mapId;
+        public int CreatedEntities;
         public int DirtyEntities;
         public int Entities;
         public int Grids;
         public int NullspaceEntities;
     }
+
+    private sealed class SnapshotState
+    {
+        public SnapshotState(
+            GameTick tick,
+            int dirtyTicks,
+            uint minRecentTick,
+            int entityCount,
+            List<ComponentStats> components,
+            List<EntityStats> entities,
+            List<PrototypeStats> prototypes,
+            List<MapStats> maps)
+        {
+            Tick = tick;
+            DirtyTicks = dirtyTicks;
+            MinRecentTick = minRecentTick;
+            EntityCount = entityCount;
+            Components = components;
+            Entities = entities;
+            Prototypes = prototypes;
+            Maps = maps;
+            ComponentCounts = components.ToDictionary(row => row.Name, row => row.Count, StringComparer.Ordinal);
+            EntityCountsByMap = maps.ToDictionary(row => row.MapId, row => row.Entities, StringComparer.Ordinal);
+            EntitiesByUid = entities.ToDictionary(row => row.Uid);
+            MapsById = maps.ToDictionary(row => row.MapId, StringComparer.Ordinal);
+            PrototypeCounts = prototypes.ToDictionary(row => row.Prototype, row => row.Count, StringComparer.Ordinal);
+            TotalComponents = components.Sum(row => row.Count);
+        }
+
+        public readonly List<ComponentStats> Components;
+        public readonly Dictionary<string, int> ComponentCounts;
+        public readonly int DirtyTicks;
+        public readonly int EntityCount;
+        public readonly Dictionary<string, int> EntityCountsByMap;
+        public readonly Dictionary<EntityUid, EntityStats> EntitiesByUid;
+        public readonly List<EntityStats> Entities;
+        public readonly List<MapStats> Maps;
+        public readonly Dictionary<string, MapStats> MapsById;
+        public readonly uint MinRecentTick;
+        public readonly Dictionary<string, int> PrototypeCounts;
+        public readonly List<PrototypeStats> Prototypes;
+        public readonly GameTick Tick;
+        public readonly int TotalComponents;
+    }
+
+    private readonly record struct CounterDeltaRow(string Name, int Previous, int Current, int Delta);
+
+    private readonly record struct EntityChurnKey(string Prototype, string MapId);
+
+    private readonly record struct EntityChurnRow(
+        string Prototype,
+        string MapId,
+        int Count,
+        EntityUid SampleUid,
+        string SampleName,
+        string SampleGrid);
+
+    private readonly record struct MapDeltaRow(
+        string MapId,
+        int PreviousEntities,
+        int CurrentEntities,
+        int EntityDelta,
+        int PreviousGrids,
+        int CurrentGrids,
+        int GridDelta,
+        int PreviousNullspace,
+        int CurrentNullspace,
+        int NullspaceDelta);
 
     private sealed class ProfileStats(string name)
     {

--- a/Content.Server/_CMU14/RoundStatistics/CMURoundStatisticsSystem.cs
+++ b/Content.Server/_CMU14/RoundStatistics/CMURoundStatisticsSystem.cs
@@ -126,7 +126,7 @@ public sealed partial class CMURoundStatisticsSystem : EntitySystem
         switch (GetCurrentPreset())
         {
             case CMURoundStatisticsPreset.DistressSignal:
-                TrySetPendingOutcome(GetManualWithdrawalOutcome(faction, isStalemate));
+                TrySetPendingOutcome(GetDistressWithdrawalOutcome(faction, isStalemate));
                 break;
             case CMURoundStatisticsPreset.Insurgency:
                 TrySetPendingOutcome(GetInsurgencyWithdrawalOutcome(faction, isStalemate));
@@ -276,6 +276,23 @@ public sealed partial class CMURoundStatisticsSystem : EntitySystem
             source);
     }
 
+    private PendingRoundOutcome GetDistressWithdrawalOutcome(string? faction, bool isStalemate)
+    {
+        var source = GetWithdrawalSource(faction, isStalemate);
+        if (isStalemate)
+        {
+            return new PendingRoundOutcome(
+                CMURoundStatisticsWinner.Draw,
+                CMURoundStatisticsOutcome.Stalemate,
+                source);
+        }
+
+        return new PendingRoundOutcome(
+            CMURoundStatisticsWinner.Xeno,
+            CMURoundStatisticsOutcome.XenoMinorHijackLoss,
+            source);
+    }
+
     private PendingRoundOutcome GetInsurgencyWithdrawalOutcome(string? faction, bool isStalemate)
     {
         var source = GetWithdrawalSource(faction, isStalemate);
@@ -307,14 +324,6 @@ public sealed partial class CMURoundStatisticsSystem : EntitySystem
             CMURoundStatisticsWinner.Unknown,
             CMURoundStatisticsOutcome.Unknown,
             source);
-    }
-
-    private PendingRoundOutcome GetManualWithdrawalOutcome(string? faction, bool isStalemate)
-    {
-        return new PendingRoundOutcome(
-            CMURoundStatisticsWinner.Unknown,
-            CMURoundStatisticsOutcome.Unknown,
-            GetWithdrawalSource(faction, isStalemate));
     }
 
     private PendingRoundOutcome GetColonyFallWithdrawalOutcome(string? faction, bool isStalemate)

--- a/Content.Server/_CMU14/ZLevels/Core/CMUZLevelsSystem.Activation.cs
+++ b/Content.Server/_CMU14/ZLevels/Core/CMUZLevelsSystem.Activation.cs
@@ -116,7 +116,7 @@ public sealed partial class CMUZLevelsSystem
             WakeZPhysics(ent);
         else
         {
-            SleepZPhysicsDeferred(ent);
+            RemCompDeferred<CMUZFallingComponent>(ent);
         }
     }
 

--- a/Content.Server/_CMU14/ZLevels/Core/CMUZLevelsSystem.Movement.cs
+++ b/Content.Server/_CMU14/ZLevels/Core/CMUZLevelsSystem.Movement.cs
@@ -69,7 +69,7 @@ public sealed partial class CMUZLevelsSystem
         var resolved = new Entity<CMUZPhysicsComponent>(ent.Owner, ent.Comp);
         if (!CanUseZPhysics(resolved))
         {
-            SleepZPhysicsDeferred(ent.Owner);
+            RemCompDeferred<CMUZFallingComponent>(ent.Owner);
             return;
         }
 
@@ -82,7 +82,7 @@ public sealed partial class CMUZLevelsSystem
                 ent.Comp.Velocity,
                 HasComp<CMUVehicleZTraversalComponent>(ent.Owner)))
         {
-            SleepZPhysicsDeferred(ent.Owner);
+            RemCompDeferred<CMUZFallingComponent>(ent.Owner);
             return;
         }
 

--- a/Content.Server/_RMC14/Admin/RMCAdminSystem.cs
+++ b/Content.Server/_RMC14/Admin/RMCAdminSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Robust.Shared.Configuration;
 using Robust.Shared.Console;
+using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
@@ -121,7 +122,8 @@ public sealed partial class RMCAdminSystem : SharedRMCAdminSystem
             return;
 
         if (!TryComp(target, out ActorComponent? actor) ||
-            !_transform.TryGetMapOrGridCoordinates(target, out var coords))
+            !_transform.TryGetMapOrGridCoordinates(target, out var coords) ||
+            _transform.GetMapId(coords.Value) == MapId.Nullspace)
         {
             _popup.PopupEntity(Loc.GetString("admin-player-spawn-failed"), user, user);
             return;
@@ -134,7 +136,7 @@ public sealed partial class RMCAdminSystem : SharedRMCAdminSystem
         var newMind = _mind.CreateMind(player.UserId, profile.Name);
         _mind.SetUserId(newMind, player.UserId);
         _playTimeTracking.PlayerRolesChanged(player);
-        var mobUid = _stationSpawning.SpawnPlayerCharacterOnStation(stationUid, job, profile);
+        var mobUid = _stationSpawning.SpawnPlayerMob(coords.Value, job, profile, stationUid);
 
         _mind.TransferTo(newMind, mobUid);
         _role.MindAddJobRole(newMind, jobPrototype: job);
@@ -142,23 +144,19 @@ public sealed partial class RMCAdminSystem : SharedRMCAdminSystem
         var jobName = _job.MindTryGetJobName(newMind);
         _admin.UpdatePlayerList(player);
 
-        if (mobUid != null)
-        {
-            EnsureComp<RMCAdminSpawnedComponent>(mobUid.Value);
-            _transform.SetCoordinates(mobUid.Value, coords.Value);
+        EnsureComp<RMCAdminSpawnedComponent>(mobUid);
 
-            var spawnEv = new PlayerSpawnCompleteEvent(
-                mobUid.Value,
-                player,
-                job,
-                true,
-                true,
-                0,
-                default,
-                profile
-            );
-            RaiseLocalEvent(mobUid.Value, spawnEv, true);
-        }
+        var spawnEv = new PlayerSpawnCompleteEvent(
+            mobUid,
+            player,
+            job,
+            true,
+            true,
+            0,
+            default,
+            profile
+        );
+        RaiseLocalEvent(mobUid, spawnEv, true);
 
         if (HasComp<GhostComponent>(target))
         {

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -1913,6 +1913,21 @@ public sealed partial class CMDistressSignalRuleSystem : GameRuleSystem<CMDistre
     }
 
     /// <summary>
+    /// Attempts to end the active distress signal rule through the normal distress result path.
+    /// </summary>
+    public bool TryEndActiveDistressRound(DistressSignalRuleResult result, LocId? customMessage = null)
+    {
+        var rules = QueryActiveRules();
+        while (rules.MoveNext(out _, out var distress, out _))
+        {
+            EndRound(distress, result, customMessage);
+            return distress.Result == result;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Sets the hive of all loaded xeno friendly entities (e.g. weeds).
     /// Only makes sense for distress signal with 1 hive, with multiple hives you would need to determine which weeds belong to which hive
     /// </summary>

--- a/Content.Shared/Throwing/ThrownItemComponent.cs
+++ b/Content.Shared/Throwing/ThrownItemComponent.cs
@@ -46,12 +46,6 @@ namespace Content.Shared.Throwing
         public bool PlayLandSound;
 
         /// <summary>
-        /// The physics collision state before the temporary throw fixture was added.
-        /// </summary>
-        [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-        public bool? PreviousCanCollide;
-
-        /// <summary>
         ///     Used to restore state after the throwing scale animation is finished.
         /// </summary>
         [DataField]

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -135,9 +135,6 @@ namespace Content.Shared.Throwing
             var fixture = fixturesComponent.Fixtures.Values.First();
             var shape = fixture.Shape;
             _fixtures.TryCreateFixture(uid, shape, ThrowingFixture, hard: false, collisionMask: (int) CollisionGroup.ThrownItem, manager: fixturesComponent, body: body);
-            component.PreviousCanCollide ??= body.CanCollide;
-            Dirty(uid, component);
-            _physics.WakeBody(uid, manager: fixturesComponent, body: body);
         }
 
         private void HandleCollision(EntityUid uid, ThrownItemComponent component, ref StartCollideEvent args)
@@ -167,11 +164,7 @@ namespace Content.Shared.Throwing
 
         public void StopThrow(EntityUid uid, ThrownItemComponent thrownItemComponent)
         {
-            var previousCanCollide = thrownItemComponent.PreviousCanCollide;
-            PhysicsComponent? physics = null;
-            FixturesComponent? manager = null;
-
-            if (TryComp<PhysicsComponent>(uid, out physics))
+            if (TryComp<PhysicsComponent>(uid, out var physics))
             {
                 _physics.SetBodyStatus(uid, physics, BodyStatus.OnGround);
 
@@ -179,7 +172,7 @@ namespace Content.Shared.Throwing
                     _broadphase.RegenerateContacts((uid, physics));
             }
 
-            if (TryComp(uid, out manager))
+            if (TryComp(uid, out FixturesComponent? manager))
             {
                 var fixture = _fixtures.GetFixtureOrNull(uid, ThrowingFixture, manager: manager);
 
@@ -192,13 +185,6 @@ namespace Content.Shared.Throwing
             var ev = new StopThrowEvent(thrownItemComponent.Thrower);
             RaiseLocalEvent(uid, ref ev);
             RemComp<ThrownItemComponent>(uid);
-
-            if (previousCanCollide is { } canCollide &&
-                physics != null &&
-                physics.CanCollide != canCollide)
-            {
-                _physics.SetCanCollide(uid, canCollide, manager: manager, body: physics);
-            }
         }
 
         public void LandComponent(EntityUid uid, ThrownItemComponent thrownItem, PhysicsComponent physics, bool playSound)

--- a/Content.Shared/_CMU14/ZLevels/Core/EntitySystems/CMUSharedZLevelsSystem.Buckle.cs
+++ b/Content.Shared/_CMU14/ZLevels/Core/EntitySystems/CMUSharedZLevelsSystem.Buckle.cs
@@ -14,7 +14,7 @@ public abstract partial class CMUSharedZLevelsSystem
     private void OnZPhysicsBuckled(Entity<CMUZPhysicsComponent> ent, ref BuckledEvent args)
     {
         if (TrySyncZPhysicsWithStrap(ent, args.Strap.Owner))
-            SleepZPhysicsDeferred(ent.Owner);
+            RemCompDeferred<CMUZFallingComponent>(ent.Owner);
     }
 
     private void OnZPhysicsUnbuckled(Entity<CMUZPhysicsComponent> ent, ref UnbuckledEvent args)

--- a/Content.Shared/_CMU14/ZLevels/Core/EntitySystems/CMUSharedZLevelsSystem.Movement.cs
+++ b/Content.Shared/_CMU14/ZLevels/Core/EntitySystems/CMUSharedZLevelsSystem.Movement.cs
@@ -310,7 +310,7 @@ public abstract partial class CMUSharedZLevelsSystem
                                 uid,
                                 "sleep",
                                 $"settledDistance={settledDistanceToGround:F3} sticky={stickyGround} local={zPhys.LocalPosition:F3}");
-                            SleepZPhysics(uid);
+                            RemComp<CMUZFallingComponent>(uid);
                         }
 
                         continue;
@@ -332,7 +332,7 @@ public abstract partial class CMUSharedZLevelsSystem
                     ShouldSleepZPhysics(0f, stickyGround, zPhys.LocalPosition, zPhys.Velocity, isVehicle))
                 {
                     DebugLogFalling(uid, "sleep", $"settledDistance=0.000 sticky={stickyGround} local={zPhys.LocalPosition:F3}");
-                    SleepZPhysics(uid);
+                    RemComp<CMUZFallingComponent>(uid);
                     DirtyZPhysics(uid, zPhys, oldVelocity, oldHeight);
                     continue;
                 }
@@ -617,7 +617,7 @@ public abstract partial class CMUSharedZLevelsSystem
         zPhys.Velocity = 0;
         zPhys.LocalPosition = 0;
         DirtyZPhysics(uid, zPhys, oldVelocity, oldHeight);
-        SleepZPhysics(uid);
+        RemComp<CMUZFallingComponent>(uid);
     }
 
     private void TryProcessZLevelBoundary(EntityUid uid, CMUZPhysicsComponent zPhys, bool stickyGround)
@@ -762,7 +762,7 @@ public abstract partial class CMUSharedZLevelsSystem
                     HasComp<CMUVehicleZTraversalComponent>(uid)))
             {
                 DebugLogFalling(uid, "post-down-sleep", $"local={zPhys.LocalPosition:F3} sticky={stickyGround}");
-                SleepZPhysics(uid);
+                RemComp<CMUZFallingComponent>(uid);
             }
         }
 
@@ -797,27 +797,6 @@ public abstract partial class CMUSharedZLevelsSystem
 
         if (Math.Abs(oldHeight - zPhys.LocalPosition) > 0.01f)
             DirtyField(uid, zPhys, nameof(CMUZPhysicsComponent.LocalPosition));
-    }
-
-    private void SleepZPhysics(EntityUid uid)
-    {
-        SetZPhysicsBodyOnGround(uid);
-        RemComp<CMUZFallingComponent>(uid);
-    }
-
-    protected void SleepZPhysicsDeferred(EntityUid uid)
-    {
-        SetZPhysicsBodyOnGround(uid);
-        RemCompDeferred<CMUZFallingComponent>(uid);
-    }
-
-    private void SetZPhysicsBodyOnGround(EntityUid uid)
-    {
-        if (TryComp<PhysicsComponent>(uid, out var physics) &&
-            physics.BodyStatus != BodyStatus.OnGround)
-        {
-            _physics.SetBodyStatus(uid, physics, BodyStatus.OnGround);
-        }
     }
 
     protected virtual bool CanProcessZLevelTransition(EntityUid ent, int offset)

--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/rmc_power_loader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/rmc_power_loader.yml
@@ -27,7 +27,6 @@
   - type: InputMover
   - type: InteractionOutline
   - type: MovementSpeedModifier
-    weightlessModifier: 0
     baseWalkSpeed: 1
     baseSprintSpeed: 1
   - type: Tag
@@ -36,8 +35,6 @@
     - FootstepSound
   - type: Physics
     bodyType: KinematicController
-  # CMU
-  - type: CMUZPhysics
   - type: Clickable
   - type: Fixtures
     fixtures:


### PR DESCRIPTION
:cl:
- fix: Improved runechat readability with a black outline/halo.
- fix: Fixed distress withdrawal ending, spawn-as-job invalid placement, and reverted the broken throw/Z-physics changes.
- add: Added deeper serverperf baseline/deep diagnostics for lag hunts.
- fix: AG80 gets falloff and its burst mode is fixed