### PR TITLE
Xeno "admin" chatsan removal

### DIFF
--- a/Resources/Locale/en-US/_AU14/chat/chatsan.ftl
+++ b/Resources/Locale/en-US/_AU14/chat/chatsan.ftl
@@ -86,9 +86,6 @@ cm-chatsan-replacement-sw = south-west
 
 
 # Xeno
-cm-chatsan-word-admin-xeno = admin
-cm-chatsan-replacement-admin-xeno = grandmother
-
 cm-chatsan-word-admins-xeno = admins
 cm-chatsan-replacement-admins-xeno = grandmothers
 

--- a/Resources/Prototypes/_CMU14/Languages/Accents/word_replacements.yml
+++ b/Resources/Prototypes/_CMU14/Languages/Accents/word_replacements.yml
@@ -37,7 +37,6 @@
 - type: accent
   id: CMChatSanitizeXeno
   wordReplacements:
-    cm-chatsan-word-admin-xeno: cm-chatsan-replacement-admin-xeno
     cm-chatsan-word-admins-xeno: cm-chatsan-replacement-admins-xeno
     cm-chatsan-word-eorg-xeno: cm-chatsan-replacement-eorg-xeno
     cm-chatsan-word-sniper: cm-chatsan-replacement-sniper


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This is one of the MOST COMMON MAP LOCATIONS IN THE GAME why are chatsanning this are we dumb

:cl:
- fix: Xenos can now say "admin" again.
