### PR TITLE
Fix server log noise

### DIFF
--- a/Content.Client/Doors/DoorSystem.cs
+++ b/Content.Client/Doors/DoorSystem.cs
@@ -122,7 +122,7 @@ public sealed partial class DoorSystem : SharedDoorSystem
 
                 return;
             case DoorState.Closing:
-                if (entity.Comp.ClosingAnimationTime == 0.0 || entity.Comp.CurrentlyCrushing.Count != 0)
+                if (entity.Comp.ClosingAnimationTime == 0.0 || entity.Comp.IsCrushing)
                     return;
 
                 _animationSystem.Play(entity, (Animation)entity.Comp.ClosingAnimation, DoorComponent.AnimationKey);

--- a/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
+++ b/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
@@ -279,7 +279,7 @@ namespace Content.Server.Preferences.Managers
 
         public bool HavePreferencesLoaded(ICommonSession session)
         {
-            return _cachedPlayerPrefs.ContainsKey(session.UserId);
+            return _cachedPlayerPrefs.TryGetValue(session.UserId, out var prefs) && prefs.PrefsLoaded;
         }
 
 

--- a/Content.Server/_CMU14/ZLevels/Core/CMUZLevelsSystem.View.cs
+++ b/Content.Server/_CMU14/ZLevels/Core/CMUZLevelsSystem.View.cs
@@ -43,6 +43,7 @@ public sealed partial class CMUZLevelsSystem
     private readonly Dictionary<EntityUid, Dictionary<int, EntityUid>> _viewerProbeEyes = new();
     private readonly Dictionary<EntityUid, (EntityUid Viewer, int Depth)> _probeEyeIndex = new();
     private readonly Dictionary<EntityUid, Dictionary<ICommonSession, int>> _extraViewerProbeSubscribers = new();
+    private readonly HashSet<EntityUid> _movedViewerProbeEyes = new();
     private readonly HashSet<EntityUid> _viewSubscriptionViewers = new();
     private readonly CMUZLevelOpeningCache _zOpeningCache = new();
     private readonly List<int> _wantedProbeDepths = new();
@@ -103,8 +104,12 @@ public sealed partial class CMUZLevelsSystem
             return;
 
         if (_gameTiming.CurTime < _nextZLevelViewerUpdate)
+        {
+            UpdateMovedViewerProbeEyes();
             return;
+        }
 
+        _movedViewerProbeEyes.Clear();
         _nextZLevelViewerUpdate = _gameTiming.CurTime + _zLevelViewerUpdateRate;
 
         using var profile = Prof.Group("CMU Z PVS Probes");
@@ -208,6 +213,28 @@ public sealed partial class CMUZLevelsSystem
         return count;
     }
 
+    private void UpdateMovedViewerProbeEyes()
+    {
+        if (_movedViewerProbeEyes.Count == 0)
+            return;
+
+        foreach (var uid in _movedViewerProbeEyes)
+        {
+            if (TerminatingOrDeleted(uid) ||
+                !_viewerProbeEyes.ContainsKey(uid) ||
+                !TryComp(uid, out CMUZLevelViewerComponent? viewer))
+            {
+                continue;
+            }
+
+            var globalPos = _transform.GetWorldPosition(uid);
+            var eyeOffset = GetViewerProbeOffset(uid);
+            UpdateProbeEyes(uid, viewer, globalPos, eyeOffset);
+        }
+
+        _movedViewerProbeEyes.Clear();
+    }
+
     private void OnViewerStartup(Entity<CMUZLevelViewerComponent> ent, ref ComponentStartup args)
     {
         _meta.AddFlag(ent, MetaDataFlags.ExtraTransformEvents);
@@ -219,6 +246,7 @@ public sealed partial class CMUZLevelsSystem
 
         QueueDeleteViewerProbeEyes(ent);
         _extraViewerProbeSubscribers.Remove(ent);
+        _movedViewerProbeEyes.Remove(ent);
         _viewSubscriptionViewers.Remove(ent);
     }
 
@@ -235,15 +263,8 @@ public sealed partial class CMUZLevelsSystem
     {
         base.OnViewerMove(ent, ref args);
 
-        var globalPos = _transform.GetWorldPosition(ent);
-        if (!_viewerProbeEyes.TryGetValue(ent, out var probes))
-            return;
-
-        var eyeOffset = GetViewerProbeOffset(ent);
-        foreach (var (depth, eye) in probes)
-        {
-            _transform.SetWorldPosition(eye, GetProbeWorldPosition(ent.Comp, depth, globalPos, eyeOffset));
-        }
+        if (_viewerProbeEyes.ContainsKey(ent))
+            _movedViewerProbeEyes.Add(ent);
     }
 
     private void OnPlayerAttached(PlayerAttachedEvent ev)

--- a/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.GameTicking;
 using Content.Server.Mind;
 using Content.Server.Players.PlayTimeTracking;
+using Content.Server.Preferences.Managers;
 using Content.Server.Roles;
 using Content.Server._RMC14.PlayTimeTracking;
 using Content.Server._RMC14.Xenonids.JoinXeno;
@@ -31,6 +32,7 @@ public sealed partial class XenoRoleSystem : EntitySystem
     [Dependency] private NameModifierSystem _nameModifier = default!;
     [Dependency] private PlayTimeTrackingSystem _playTime = default!;
     [Dependency] private PlayTimeTrackingManager _playTimeManager = default!;
+    [Dependency] private IServerPreferencesManager _preferences = default!;
     [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private PvsOverrideSystem _pvsOverride = default!;
     [Dependency] private RMCPlayTimeManager _rmcPlaytime = default!;
@@ -202,6 +204,7 @@ public sealed partial class XenoRoleSystem : EntitySystem
             for (var i = _toUpdate.Count - 1; i >= 0; i--)
             {
                 var removed = false;
+                var retry = false;
                 try
                 {
                     var xeno = _toUpdate[i];
@@ -217,6 +220,12 @@ public sealed partial class XenoRoleSystem : EntitySystem
                     var player = actor.PlayerSession;
                     if (!_mind.TryGetMind(player.UserId, out var mind))
                         continue;
+
+                    if (!_preferences.HavePreferencesLoaded(player))
+                    {
+                        retry = true;
+                        continue;
+                    }
 
                     if (_hive.GetHive(xeno.Owner) is { } hive)
                         _pvsOverride.AddForceSend(hive, player);
@@ -236,7 +245,7 @@ public sealed partial class XenoRoleSystem : EntitySystem
                 }
                 finally
                 {
-                    if (!removed)
+                    if (!removed && !retry)
                         _toUpdate.RemoveAt(i);
                 }
             }

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -131,8 +131,11 @@ public sealed partial class DoorComponent : Component
     /// <summary>
     /// List of EntityUids of entities we're currently crushing. Cleared in OnPartialOpen().
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public HashSet<EntityUid> CurrentlyCrushing = new();
+
+    [AutoNetworkedField]
+    public bool IsCrushing;
     #endregion
 
     #region Graphics

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -251,7 +251,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
     private void OnWeldAttempt(EntityUid uid, DoorComponent component, WeldableAttemptEvent args)
     {
-        if (component.CurrentlyCrushing.Count > 0)
+        if (HasCurrentlyCrushing((uid, component)))
         {
             args.Cancel();
             return;
@@ -518,7 +518,10 @@ public abstract partial class SharedDoorSystem : EntitySystem
             PhysicsSystem.SetCanCollide(uid, collidable, body: physics);
 
         if (!collidable)
+        {
             door.CurrentlyCrushing.Clear();
+            door.IsCrushing = false;
+        }
 
         if (door.Occludes)
             _occluder.SetEnabled(uid, collidable, occluder);
@@ -535,10 +538,15 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (!door.CanCrush)
             return;
 
+        PruneCurrentlyCrushing((uid, door));
+
         // Find entities and apply curshing effects
         var stunTime = door.DoorStunTime + door.OpenTimeOne;
         foreach (var entity in GetColliding(uid, physics))
         {
+            if (TerminatingOrDeleted(entity))
+                continue;
+
             door.CurrentlyCrushing.Add(entity);
             if (door.CrushDamage != null)
                 _damageableSystem.TryChangeDamage(entity, door.CrushDamage, origin: uid);
@@ -546,6 +554,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
             _stunSystem.TryParalyze(entity, stunTime, true);
         }
 
+        door.IsCrushing = door.CurrentlyCrushing.Count != 0;
         if (door.CurrentlyCrushing.Count == 0)
             return;
 
@@ -608,6 +617,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
     private void PreventCollision(EntityUid uid, DoorComponent component, ref PreventCollideEvent args)
     {
+        PruneCurrentlyCrushing((uid, component));
         if (component.CurrentlyCrushing.Contains(args.OtherEntity))
         {
             args.Cancelled = true;
@@ -755,6 +765,8 @@ public abstract partial class SharedDoorSystem : EntitySystem
                 continue;
             }
 
+            PruneCurrentlyCrushing(ent);
+
             if (Paused(ent))
                 continue;
 
@@ -779,7 +791,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         var door = ent.Comp;
         door.NextStateChange = null;
 
-        if (door.CurrentlyCrushing.Count > 0 && door.State != DoorState.Opening)
+        if (HasCurrentlyCrushing(ent) && door.State != DoorState.Opening)
         {
             // This is a closed door that is crushing people and needs to auto-open. Note that we don't check "can open"
             // here. The door never actually finished closing and we don't want people to get stuck inside of doors.
@@ -830,6 +842,22 @@ public abstract partial class SharedDoorSystem : EntitySystem
                 Log.Error($"Welded door was in the list of active doors. Door: {ToPrettyString(ent)}");
                 break;
         }
+    }
+
+    private bool HasCurrentlyCrushing(Entity<DoorComponent> door)
+    {
+        PruneCurrentlyCrushing(door);
+        return door.Comp.CurrentlyCrushing.Count > 0;
+    }
+
+    private void PruneCurrentlyCrushing(Entity<DoorComponent> door)
+    {
+        var wasCrushing = door.Comp.IsCrushing;
+        door.Comp.CurrentlyCrushing.RemoveWhere(uid => TerminatingOrDeleted(uid));
+        door.Comp.IsCrushing = door.Comp.CurrentlyCrushing.Count != 0;
+
+        if (wasCrushing != door.Comp.IsCrushing)
+            Dirty(door);
     }
     #endregion
 }

--- a/Content.Shared/Gibbing/Systems/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/Systems/GibbingSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Gibbing.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -320,6 +321,9 @@ public sealed partial class GibbingSystem : EntitySystem
     private void FlingDroppedEntity(EntityUid target, Vector2? direction, float impulse, float impulseVariance,
         Angle scatterConeAngle)
     {
+        if (!TryComp<PhysicsComponent>(target, out _))
+            return;
+
         var scatterAngle = direction?.ToAngle() ?? _random.NextAngle();
         var scatterVector = _random.NextAngle(scatterAngle - scatterConeAngle / 2, scatterAngle + scatterConeAngle / 2)
             .ToVec() * (impulse + _random.NextFloat(impulseVariance));

--- a/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
+++ b/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
@@ -50,7 +50,7 @@ public abstract partial class SharedMouseRotatorSystem : EntitySystem
         if (args.SenderSession.AttachedEntity is not { } ent
             || !TryComp<MouseRotatorComponent>(ent, out var rotator))
         {
-            Log.Error($"User {args.SenderSession.Name} ({args.SenderSession.UserId}) tried setting local rotation directly without a valid mouse rotator component attached!");
+            Log.Debug($"Ignoring mouse rotation request from {args.SenderSession.Name} ({args.SenderSession.UserId}) without a valid mouse rotator component attached.");
             return;
         }
 

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -14,6 +14,7 @@ namespace Content.Shared.SSDIndicator;
 public sealed partial class SSDIndicatorSystem : EntitySystem
 {
     public static readonly EntProtoId StatusEffectSSDSleeping = "StatusEffectSSDSleeping";
+    private static readonly TimeSpan SsdSleepRetrySuppression = TimeSpan.FromDays(365);
 
     [Dependency] private IConfigurationManager _cfg = default!;
     [Dependency] private IGameTiming _timing = default!;
@@ -95,7 +96,7 @@ public sealed partial class SSDIndicatorSystem : EntitySystem
 
                 // Don't keep retrying every tick once the effect is applied — TrySetStatusEffectDuration
                 // walks ActiveStatusEffects on the target every call. Reset on PlayerDetached.
-                ssd.FallAsleepTime = TimeSpan.MaxValue;
+                ssd.FallAsleepTime = _timing.CurTime + SsdSleepRetrySuppression;
                 Dirty(uid, ssd);
             }
         }

--- a/Content.Shared/StatusEffectNew/SharedStatusEffectsSystem.cs
+++ b/Content.Shared/StatusEffectNew/SharedStatusEffectsSystem.cs
@@ -26,6 +26,8 @@ public abstract partial class SharedStatusEffectsSystem : EntitySystem
     private EntityQuery<StatusEffectContainerComponent> _containerQuery;
     private EntityQuery<StatusEffectComponent> _effectQuery;
 
+    private readonly List<(EntityUid Target, EntProtoId Effect)> _expiredStatusEffects = new();
+
     public override void Initialize()
     {
         base.Initialize();
@@ -50,23 +52,35 @@ public abstract partial class SharedStatusEffectsSystem : EntitySystem
     {
         base.Update(frameTime);
 
-        var query = EntityQueryEnumerator<StatusEffectComponent>();
-        while (query.MoveNext(out var ent, out var effect))
+        try
         {
-            if (effect.EndEffectTime is null)
-                continue;
+            var query = EntityQueryEnumerator<StatusEffectComponent>();
+            while (query.MoveNext(out var ent, out var effect))
+            {
+                if (effect.EndEffectTime is null)
+                    continue;
 
-            if (!(_timing.CurTime >= effect.EndEffectTime))
-                continue;
+                if (!(_timing.CurTime >= effect.EndEffectTime))
+                    continue;
 
-            if (effect.AppliedTo is null)
-                continue;
+                if (effect.AppliedTo is null)
+                    continue;
 
-            var meta = MetaData(ent);
-            if (meta.EntityPrototype is null)
-                continue;
+                var meta = MetaData(ent);
+                if (meta.EntityPrototype is not { } prototype)
+                    continue;
 
-            TryRemoveStatusEffect(effect.AppliedTo.Value, meta.EntityPrototype);
+                _expiredStatusEffects.Add((effect.AppliedTo.Value, prototype));
+            }
+
+            foreach (var (target, effect) in _expiredStatusEffects)
+            {
+                TryRemoveStatusEffect(target, effect);
+            }
+        }
+        finally
+        {
+            _expiredStatusEffects.Clear();
         }
     }
 

--- a/Content.Shared/_RMC14/Cassette/SharedCassetteSystem.cs
+++ b/Content.Shared/_RMC14/Cassette/SharedCassetteSystem.cs
@@ -267,7 +267,7 @@ public abstract partial class SharedCassetteSystem : EntitySystem
 
     private void OnPlayerRemovedFromContainer(Entity<CassettePlayerComponent> ent, ref EntRemovedFromContainerMessage args)
     {
-        _audio.Stop(_net.IsServer ? ent.Comp.AudioStream : ent.Comp.CustomAudioStream);
+        StopAllAudio(ent);
         ent.Comp.State = AudioState.Stopped;
         ent.Comp.Tape = 0;
         Dirty(ent);
@@ -371,8 +371,8 @@ public abstract partial class SharedCassetteSystem : EntitySystem
 
     private void StopAllAudio(Entity<CassettePlayerComponent> ent)
     {
-        _audio.Stop(ent.Comp.AudioStream);
-        _audio.Stop(ent.Comp.CustomAudioStream);
+        ent.Comp.AudioStream = _audio.Stop(ent.Comp.AudioStream);
+        ent.Comp.CustomAudioStream = _audio.Stop(ent.Comp.CustomAudioStream);
 
         ent.Comp.State = AudioState.Stopped;
         Dirty(ent);

--- a/Content.Shared/_RMC14/Dropship/DropshipComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/DropshipComponent.cs
@@ -15,10 +15,10 @@ public sealed partial class DropshipComponent : Component
     [DataField, AutoNetworkedField]
     public FTLState State;
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public EntityUid? Destination;
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public EntityUid? DepartureLocation;
 
     [DataField, AutoNetworkedField]
@@ -87,7 +87,7 @@ public sealed partial class DropshipComponent : Component
     [DataField, AutoNetworkedField]
     public TimeSpan CancelFlightTime = TimeSpan.FromSeconds(10);
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public EntityUid? LaunchAlarmEntity;
 
     [DataField]

--- a/Content.Shared/_RMC14/Inventory/RMCPickupDroppedItemsComponent.cs
+++ b/Content.Shared/_RMC14/Inventory/RMCPickupDroppedItemsComponent.cs
@@ -2,10 +2,10 @@
 
 namespace Content.Shared._RMC14.Inventory;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent]
 [Access(typeof(SharedCMInventorySystem))]
 public sealed partial class RMCPickupDroppedItemsComponent : Component
 {
-    [DataField, AutoNetworkedField]
+    [DataField]
     public List<EntityUid> DroppedItems = new();
 }

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -363,6 +363,10 @@ public abstract partial class SharedCMInventorySystem : EntitySystem
         if (!_pickupDroppedItemsQuery.TryComp(user, out var pickupDroppedItems) || HasComp<DevouredComponent>(user))
             return;
 
+        var removed = pickupDroppedItems.DroppedItems.RemoveAll(uid => TerminatingOrDeleted(uid));
+        if (removed > 0)
+            Dirty(user, pickupDroppedItems);
+
         // Sort items by importance
         var sortedItems = pickupDroppedItems.DroppedItems
             .OrderByDescending(item => HasComp<GunComponent>(item))
@@ -371,6 +375,9 @@ public abstract partial class SharedCMInventorySystem : EntitySystem
 
         foreach (var item in sortedItems.Distinct())
         {
+            if (TerminatingOrDeleted(item))
+                continue;
+
             if (!_container.IsEntityInContainer(item) && _interaction.InRangeUnobstructed(user, item))
             {
                 if (_hands.TryPickupAnyHand(user, item))

--- a/Content.Shared/_RMC14/OnCollide/DamageOnCollideComponent.cs
+++ b/Content.Shared/_RMC14/OnCollide/DamageOnCollideComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class DamageOnCollideComponent : Component
     [DataField, AutoNetworkedField]
     public bool InitDamaged;
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public EntityUid? Chain;
 
     [DataField(required: true)]
@@ -25,7 +25,7 @@ public sealed partial class DamageOnCollideComponent : Component
     [DataField]
     public DamageSpecifier ChainDamage = new();
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public HashSet<EntityUid> Damaged = new();
 
     [DataField]

--- a/Content.Shared/_RMC14/OnCollide/SharedOnCollideSystem.cs
+++ b/Content.Shared/_RMC14/OnCollide/SharedOnCollideSystem.cs
@@ -60,8 +60,14 @@ public abstract partial class SharedOnCollideSystem : EntitySystem
 
     private void OnCollide(Entity<DamageOnCollideComponent> ent, EntityUid other)
     {
+        if (TerminatingOrDeleted(other))
+            return;
+
         if (ent.Comp.Disabled)
             return;
+
+        if (ent.Comp.Chain is { } chain && TerminatingOrDeleted(chain))
+            ent.Comp.Chain = null;
 
         if (ent.Comp.Damaged.Contains(other))
             return;
@@ -169,9 +175,13 @@ public abstract partial class SharedOnCollideSystem : EntitySystem
             while (query.MoveNext(out var uid, out var comp))
             {
                 if (comp.InitDamaged)
+                {
+                    PruneDamaged(comp);
                     continue;
+                }
 
                 comp.InitDamaged = true;
+                PruneDamaged(comp);
                 _damageOnCollide.Add((uid, comp));
             }
 
@@ -187,5 +197,13 @@ public abstract partial class SharedOnCollideSystem : EntitySystem
         {
             _damageOnCollide.Clear();
         }
+    }
+
+    private void PruneDamaged(DamageOnCollideComponent comp)
+    {
+        comp.Damaged.RemoveWhere(uid => TerminatingOrDeleted(uid));
+
+        if (comp.Chain is { } chain && TerminatingOrDeleted(chain))
+            comp.Chain = null;
     }
 }

--- a/Content.Shared/_RMC14/Sound/SoundOnDeathComponent.cs
+++ b/Content.Shared/_RMC14/Sound/SoundOnDeathComponent.cs
@@ -10,6 +10,6 @@ public sealed partial class SoundOnDeathComponent : Component
     [DataField(required: true), AutoNetworkedField]
     public SoundSpecifier? Sound;
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public EntityUid? Entity;
 }

--- a/Content.Shared/_RMC14/Sound/SoundOnDeathSoundComponent.cs
+++ b/Content.Shared/_RMC14/Sound/SoundOnDeathSoundComponent.cs
@@ -2,10 +2,10 @@
 
 namespace Content.Shared._RMC14.Sound;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent]
 [Access(typeof(CMSoundSystem))]
 public sealed partial class SoundOnDeathSoundComponent : Component
 {
-    [DataField, AutoNetworkedField]
+    [DataField]
     public EntityUid? Parent;
 }

--- a/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
+++ b/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
@@ -124,7 +124,7 @@ public sealed partial class RMCStorageSystem : EntitySystem
 
             // TODO RMC14 make this error if this is a cm-specific storage
             if (CMPrototypeExtensions.FilterCM)
-                Log.Warning($"Storage {ToPrettyString(storage)} can't fit {ToPrettyString(args.Item)}");
+                Log.Debug($"Expanding storage {ToPrettyString(storage)} to fit {ToPrettyString(args.Item)}");
 
             foreach (var shape in _item.GetItemShape((storage, args.Storage), (args.Item, args.Item)))
             {
@@ -144,6 +144,13 @@ public sealed partial class RMCStorageSystem : EntitySystem
 
                 grid[^1] = expanded;
             }
+        }
+
+        if (CMPrototypeExtensions.FilterCM &&
+            !_storage.CanInsert(storage, args.Item, null, out var finalReason, ignoreStacks: true) &&
+            finalReason == "comp-storage-insufficient-capacity")
+        {
+            Log.Warning($"Storage {ToPrettyString(storage)} still can't fit {ToPrettyString(args.Item)} after expanding");
         }
     }
 

--- a/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
+++ b/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
@@ -613,7 +613,6 @@ public abstract partial class SharedCMAutomatedVendorSystem : EntitySystem
         {
             if (vendor.Comp.UseObjectivePoints)
             {
-                Log.Info($"[VENDOR DEBUG] Objective purchase: actor={ToPrettyString(actor)}, entry={entry.Id}, cost={entry.Points}");
                 // Read the cached faction win points directly from the vendor component
                 var available = vendor.Comp.CachedFactionWinPoints;
 
@@ -636,8 +635,6 @@ public abstract partial class SharedCMAutomatedVendorSystem : EntitySystem
                 // Update the vendor cache immediately so the UI reflects the new balance
                 var newBalance = available - entry.Points.Value;
                 UpdateVendorFactionPointsCache(faction, newBalance);
-
-                Log.Info($"[VENDOR DEBUG] Points deducted successfully, new balance: {newBalance}");
             }
             else
             {
@@ -729,7 +726,6 @@ public abstract partial class SharedCMAutomatedVendorSystem : EntitySystem
 
         var min = comp.MinOffset;
         var max = comp.MaxOffset;
-        Log.Info($"[VENDOR DEBUG] Spawning {entry.Spawn} copies of {entry.Id}");
         for (var i = 0; i < entry.Spawn; i++)
         {
             var offset = _random.NextVector2Box(min.X, min.Y, max.X, max.Y);

--- a/Content.Shared/_RMC14/Xenonids/Weeds/XenoWallWeedsComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/XenoWallWeedsComponent.cs
@@ -2,10 +2,10 @@
 
 namespace Content.Shared._RMC14.Xenonids.Weeds;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent]
 [Access(typeof(SharedXenoWeedsSystem))]
 public sealed partial class XenoWallWeedsComponent : Component
 {
-    [DataField, AutoNetworkedField]
+    [DataField]
     public EntityUid? Weeds;
 }

--- a/Resources/Prototypes/_CMU14/ZLevels/Entities/z_levels.yml
+++ b/Resources/Prototypes/_CMU14/ZLevels/Entities/z_levels.yml
@@ -2,6 +2,9 @@
   id: CMUZLevelEye
   save: false
   categories: [ HideSpawnMenu ]
+  components:
+  - type: Transform
+    gridTraversal: false
 
 - type: entity
   id: CMUMultiZStairs


### PR DESCRIPTION
:cl:
- fix: Reduced server log spam from stale networked entity references.
- fix: Fixed Z-level probe eyes causing grid traversal errors.
- fix: Fixed SSD sleep timer overflow during cleanup.
- fix: Fixed status effects mutating during update.
- fix: Fixed xeno rank updates failing while preferences load.
- tweak: Removed vendor debug spam.