### PR TITLE
UPP, We-Yu, HAZOPs Pyro additions and Bgel buff reverted

### DIFF
--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/cmbciu_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/cmbciu_requisitions_catalog.yml
@@ -268,6 +268,8 @@
         crate: RMCCrateMagazineBGel
     - name: Specialist Ammo
       entries:
+      - cost: 2000
+        crate: RMCCratePyroTankMixed
       # Sniper
       - cost: 2000
         crate: AU14CrateMagazineSpecSniperM96S

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/hazops_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/hazops_requisitions_catalog.yml
@@ -268,6 +268,8 @@
         crate: RMCCrateMagazineBGel
     - name: Specialist Ammo
       entries:
+      - cost: 2000
+        crate: RMCCratePyroTankMixedHAZOPS
       # Sniper
       - cost: 2000
         crate: AU14CrateMagazineSpecSniperM96S

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/lacn_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/lacn_requisitions_catalog.yml
@@ -268,6 +268,8 @@
         crate: RMCCrateMagazineBGel
     - name: Specialist Ammo
       entries:
+      - cost: 2000
+        crate: RMCCratePyroTankMixed
       # Sniper
       - cost: 2000
         crate: AU14CrateMagazineSpecSniperM96S

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/prodigy_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/prodigy_requisitions_catalog.yml
@@ -268,6 +268,8 @@
         crate: RMCCrateMagazineBGel
     - name: Specialist Ammo
       entries:
+      - cost: 2000
+        crate: RMCCratePyroTankMixed
       # Sniper
       - cost: 2000
         crate: AU14CrateMagazineSpecSniperM96S

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/rmc_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/rmc_requisitions_catalog.yml
@@ -274,6 +274,8 @@
         crate: RMCCrateMagazineBGel
     - name: Specialist Ammo
       entries:
+      - cost: 2000
+        crate: RMCCratePyroTankMixed
       # Sniper
       - cost: 2000
         crate: AU14CrateMagazineSpecSniperM96S

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/upp_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/upp_requisitions_catalog.yml
@@ -272,6 +272,8 @@
         crate: RMCCrateMagazineBGel
     - name: Specialist Ammo
       entries:
+      - cost: 2000
+        crate: RMCCratePyroTankMixedUPP
       # Sniper
       - cost: 2000
         crate: AU14CrateMagazineSpecSniperM96S

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/uscm_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/uscm_requisitions_catalog.yml
@@ -274,6 +274,8 @@
         crate: RMCCrateMagazineBGel
     - name: Specialist Ammo
       entries:
+      - cost: 2000
+        crate: RMCCratePyroTankMixed
       # Sniper
       - cost: 2000
         crate: AU14CrateMagazineSpecSniperM96S

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/vaipo_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/vaipo_requisitions_catalog.yml
@@ -268,6 +268,8 @@
         crate: RMCCrateMagazineBGel
     - name: Specialist Ammo
       entries:
+      - cost: 2000
+        crate: RMCCratePyroTankMixed
       # Sniper
       - cost: 2000
         crate: AU14CrateMagazineSpecSniperM96S

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/weyu_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/weyu_requisitions_catalog.yml
@@ -268,6 +268,8 @@
         crate: RMCCrateMagazineBGel
     - name: Specialist Ammo
       entries:
+      - cost: 2000
+        crate: RMCCratePyroTankMixedWY
       # Sniper
       - cost: 2000
         crate: AU14CrateMagazineSpecSniperM96S

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/hazopsvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/hazopsvendors.yml
@@ -323,7 +323,7 @@
         isAppendSquadRoleName: false
         givePrefix: rmc-job-prefix-weapons-specialist-shotgunner
         isAppendPrefix: true
-      - id: AU14KitHAZOPSPyroM240A2
+      - id: CMU14PyroSpecEquipmentCaseHAZOPS
         giveSquadRoleName: au14-job-name-specialist-pyro
         givePrefix: au14-job-prefix-specialist-pyro
         isAppendSquadRoleName: false

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/uppvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/uppvendors.yml
@@ -879,7 +879,7 @@
         givePrefix: au14-job-prefix-govforspecialist-marksmanUPP
         isAppendSquadRoleName: false
         isAppendPrefix: true
-      - id: AU14KitUPPPyroLPO80
+      - id: CMU14PyroSpecEquipmentCaseUPP
         giveSquadRoleName: au14-job-name-specialist-pyro
         givePrefix: au14-job-prefix-specialist-pyro
         isAppendSquadRoleName: false

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/wypmcvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/wypmcvendors.yml
@@ -822,7 +822,7 @@
         isAppendSquadRoleName: false
         givePrefix: rmc-job-prefix-weapons-specialist-shotgunner
         isAppendPrefix: true
-      - id: RMCPyroSpecEquipmentCase
+      - id: CMU14PyroSpecEquipmentCaseWeylandYutani
         giveSquadRoleName: rmc-job-name-weapons-specialist-pyro
         isAppendSquadRoleName: false
         givePrefix: au14-job-prefix-specialist-pyro

--- a/Resources/Prototypes/_CMU14/Entities/Weapons/Factions/HAZOPS/Flamethrowers/m240a2.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Weapons/Factions/HAZOPS/Flamethrowers/m240a2.yml
@@ -4,6 +4,7 @@
   name: M240A2 heavy incinerator unit
   description: The USCMC's answer to WY's Flammerwerfer 3. Much more effective than the standard M240, but inflicts a movement penality. Typically issued to HAZOPS.
   components:
+  - type: RMCMagneticItem
   - type: Sprite
     sprite: _AU14/Weapons/Guns/HAZOPS/M240A2.rsi
     state: base
@@ -24,7 +25,7 @@
     - Back
   - type: Gun
     cameraRecoilScalar: 0
-    fireRate: 2.5
+    fireRate: 0.8
     selectedMode: FullAuto
     availableModes:
     - FullAuto
@@ -45,6 +46,8 @@
         whitelist:
           tags:
           - AU14TankFlamerM240A2HAZOPS
+          - AU14TankFlamerM240A2HAZOPSNapalmB
+          - AU14TankFlamerM240A2HAZOPSNapalmX
   - type: Wieldable
   - type: WieldableSpeedModifiers
     base: 0.70
@@ -107,10 +110,10 @@
   - type: SolutionContainerManager
     solutions:
       rmc_flamer_tank:
-        maxVol: 150
+        maxVol: 300
         reagents:
         - ReagentId: RMCNapalmUT
-          Quantity: 150
+          Quantity: 300
   - type: SolutionContainerVisuals
     maxFillLevels: 2
     fillBaseName: flametank_strip
@@ -120,3 +123,86 @@
 
 - type: Tag
   id: AU14TankFlamerM240A2HAZOPS
+
+
+- type: entity
+  parent: RMCTankFlamer
+  id: AU14TankFlamerM240A2HAZOPSNapalmB
+  name: M240A2 heavy incinerator tank (B)
+  description: A heavy, high capacity tank utilized by the M240A2. Has a colorless HAZOPS logo imprinted on the side. This one seems to contain 'Napalm-B'
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Ammunition/fl3.rsi
+    state: flametank
+    layers:
+    - state: flametank
+    - state: flametank_strip1
+    - state: flametank_strip2
+      map: [ "enum.SolutionContainerLayers.Fill" ]
+  - type: RMCFlamerTank
+    maxIntensity: 70
+    maxRange: 7
+  - type: SolutionContainerManager
+    solutions:
+      rmc_flamer_tank:
+        maxVol: 300
+        reagents:
+        - ReagentId: RMCNapalmB
+          Quantity: 300
+  - type: SolutionContainerVisuals
+    maxFillLevels: 2
+    fillBaseName: flametank_strip
+  - type: Tag
+    tags:
+    - AU14TankFlamerM240A2HAZOPSNapalmB
+
+- type: Tag
+  id: AU14TankFlamerM240A2HAZOPSNapalmB
+
+
+- type: entity
+  parent: RMCTankFlamer
+  id: AU14TankFlamerM240A2HAZOPSNapalmX
+  name: M240A2 heavy incinerator tank (X)
+  description: A heavy, high capacity tank utilized by the M240A2. Has a colorless HAZOPS logo imprinted on the side. This one seems to contain 'Napalm-X'
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Ammunition/fl3.rsi
+    state: flametank
+    layers:
+    - state: flametank
+    - state: flametank_strip1
+    - state: flametank_strip2
+      map: [ "enum.SolutionContainerLayers.Fill" ]
+  - type: RMCFlamerTank
+    maxIntensity: 70
+    maxRange: 6
+  - type: SolutionContainerManager
+    solutions:
+      rmc_flamer_tank:
+        maxVol: 300
+        reagents:
+        - ReagentId: RMCNapalmX
+          Quantity: 300
+  - type: SolutionContainerVisuals
+    maxFillLevels: 2
+    fillBaseName: flametank_strip
+  - type: Tag
+    tags:
+    - AU14TankFlamerM240A2HAZOPSNapalmX
+
+- type: Tag
+  id: AU14TankFlamerM240A2HAZOPSNapalmX
+
+- type: entity
+  parent: RMCBackpackFlamer
+  id: AU14FuelM240A2FuelTankFilled
+  suffix: HAZOPS
+  components:
+  - type: StorageFill
+    contents:
+    - id: AU14TankFlamerM240A2HAZOPSNapalmB
+      amount: 2
+    - id: AU14TankFlamerM240A2HAZOPSNapalmX
+
+

--- a/Resources/Prototypes/_CMU14/Entities/Weapons/Factions/HAZOPS/Flamethrowers/m240a2.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Weapons/Factions/HAZOPS/Flamethrowers/m240a2.yml
@@ -204,5 +204,6 @@
     - id: AU14TankFlamerM240A2HAZOPSNapalmB
       amount: 2
     - id: AU14TankFlamerM240A2HAZOPSNapalmX
+      amount: 1
 
 

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/weapon_specialist_ammo.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/weapon_specialist_ammo.yml
@@ -110,6 +110,7 @@
     - id: RMCMagazineRifleM4SPRA19Incendiary
       amount: 2
 
+
 - type: entity
   parent: RMCCrateAmmo
   id: RMCCrateMagazineM4SPRCustomStandard
@@ -194,6 +195,39 @@
     - id: RMCTankFlamerLarge
     - id: RMCTankFlamerLargeB
     - id: RMCTankFlamerLargeX
+
+- type: entity
+  parent: RMCCrateAmmo
+  id: RMCCratePyroTankMixedUPP
+  name: LPO80-T Mixed Fuel Tank Crate (extended x1, type-B x1, type-X x1)
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCTankFlamerXLargeUPP
+    - id: RMCTankFlamerBLargeUPP
+    - id: RMCTankFlamerLargeUPP
+
+- type: entity
+  parent: RMCCrateAmmo
+  id: RMCCratePyroTankMixedWY
+  name: Flammenwerfer-3 Mixed Fuel Tank Crate (extended x1, type-B x1, type-X x1)
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCTankFlamerFL3
+    - id: RMCTankFlamerFL3B
+    - id: RMCTankFlamerFL3X
+
+- type: entity
+  parent: RMCCrateAmmo
+  id: RMCCratePyroTankMixedHAZOPS
+  name: M240A2 Mixed Fuel Tank Crate (extended x1, type-B x1, type-X x1)
+  components:
+  - type: StorageFill
+    contents:
+    - id: AU14TankFlamerM240A2HAZOPS
+    - id: AU14TankFlamerM240A2HAZOPSNapalmB
+    - id: AU14TankFlamerM240A2HAZOPSNapalmX
 
 - type: entity
   parent: RMCCrateAmmo

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/broiler.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/broiler.yml
@@ -2,7 +2,7 @@
   parent: [ Clothing, ClothingSlotBase ]
   id: RMCBackpackBroiler
   name: Broiler-T flexible refueling system
-  description: A specialized back harness that carries the Broiler-T flexible refueling system. Designed by and for UNMC Pyrotechnicians.
+  description: A specialized back harness that carries the Broiler-T flexible refueling system. Designed by and for USCM Pyrotechnicians.
   components:
   - type: Corrodible
     isCorrodible: false
@@ -60,9 +60,71 @@
   - type: RMCBroiler
 
 - type: entity
+  parent: [ Clothing, ClothingSlotBase ]
+  id: RMCBackpackBroilerUPP
+  name: Broiler-T flexible refueling system
+  suffix: UPP
+  description: A specialized back harness that carries the Broiler-T flexible refueling system. A reverse engineered version for UPP Pyrotechnicians.
+  components:
+  - type: Corrodible
+    isCorrodible: false
+  - type: Item
+    size: Large
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Back/Satchels/Marines/broiler/jungle.rsi
+    state: icon
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Back/Satchels/Marines/broiler/jungle.rsi
+    quickEquip: false
+    slots:
+    - back
+  - type: ItemMapper
+    mapLayers:
+      incinerator:
+        whitelist:
+          tags:
+          - RMCWeaponFlamerSpecUPP
+  - type: Appearance
+  - type: CMHolster
+    whitelist:
+      tags:
+      - RMCWeaponFlamerSpecUPP
+  - type: InteractedBlacklist
+    blacklist:
+      components:
+      - Xeno
+  - type: CMItemSlots
+    count: 3
+    startingItems:
+    - RMCTankFlamerLargeUPP
+    - RMCTankFlamerBLargeUPP
+    - RMCTankFlamerXLargeUPP
+    slot:
+      name: Tank
+      whitelist:
+        tags:
+        - RMCTankFlamerLargeUPP
+        - RMCTankFlamerLarge
+  - type: ItemSlots
+    slots:
+      item:
+        name: Incinerator
+        insertVerbText: sheath-insert-verb
+        ejectVerbText: sheath-eject-verb
+        insertSound: /Audio/_RMC14/Weapons/Guns/gun_rifle_draw.ogg
+        ejectSound: /Audio/_RMC14/Weapons/Guns/gun_rifle_draw.ogg
+        whitelist:
+          tags:
+          - RMCWeaponFlamerSpecUPP
+  - type: ItemCamouflage
+    camouflageVariations: {}
+  - type: RMCMagneticItemReceiver
+  - type: RMCBroiler
+
+- type: entity
   parent: RMCBackpackBroiler
   id: RMCBackpackBroilerEmpty
-  suffix: empty 
+  suffix: empty
   components:
   - type: CMItemSlots
     startingItems: []

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
@@ -294,6 +294,120 @@
     - type: PyroWhitelist
 
 - type: entity
+  parent: RMCBaseEquipmentCase
+  id: CMU14PyroSpecEquipmentCaseHAZOPS
+  name: pyrotechnician equipment case
+  suffix: HAZOPS
+  description: "A large case containing M240A2, M35 pyrotechnician armor and helmet, and additional pieces of equipment.\nNOTE: You cannot put items back inside this case."
+  components:
+  - type: Sprite
+    layers:
+    - state: closed
+      map: [ base ]
+    - state: pyro
+      map: [ label ]
+  - type: Storage
+    maxItemSize: Huge
+    grid:
+    - 0,0,11,3
+  - type: StorageFill
+    contents:
+    - id: CMArmorM35
+    - id: CMArmorHelmetM35
+    - id: AU14FuelM240A2FuelTankFilled
+    - id: AU14WeaponFlamerM240A2HAZOPS
+    - id: AU14TankFlamerM240A2HAZOPS
+    - id: AU14TankFlamerM240A2HAZOPSNapalmB
+    - id: AU14TankFlamerM240A2HAZOPSNapalmX
+    - id: RMCPouchFuelTank
+    - id: CMFireExtinguisher
+    - id: CMFireExtinguisherPortable
+    - id: RMCBinoculars
+    - id: RMCPamphletAdminWeaponsSpecialistPyro
+    #- id: RMCMK80
+    #- id: CMMagazinePistolMK80
+    #  amount: 2
+  - type: CMChangeUserOnVend
+    addComponents:
+    - type: PyroWhitelist
+
+- type: entity
+  parent: RMCBaseEquipmentCase
+  id: CMU14PyroSpecEquipmentCaseWeylandYutani
+  name: pyrotechnician equipment case
+  suffix: WY
+  description: "A large case containing Flammenwerfer-3, M35 pyrotechnician armor and helmet, and additional pieces of equipment.\nNOTE: You cannot put items back inside this case."
+  components:
+  - type: Sprite
+    layers:
+    - state: closed
+      map: [ base ]
+    - state: pyro
+      map: [ label ]
+  - type: Storage
+    maxItemSize: Huge
+    grid:
+    - 0,0,11,3
+  - type: StorageFill
+    contents:
+    - id: CMArmorM35
+    - id: CMArmorHelmetM35
+    - id: CMU14FuelFL3FuelTankFilled
+    - id: RMCWeaponFL3Flamer
+    - id: RMCTankFlamerFL3
+    - id: RMCTankFlamerFL3B
+    - id: RMCTankFlamerFL3X
+    - id: RMCPouchFuelTank
+    - id: CMFireExtinguisher
+    - id: CMFireExtinguisherPortable
+    - id: RMCBinoculars
+    - id: RMCPamphletAdminWeaponsSpecialistPyro
+    #- id: RMCMK80
+    #- id: CMMagazinePistolMK80
+    #  amount: 2
+  - type: CMChangeUserOnVend
+    addComponents:
+    - type: PyroWhitelist
+
+- type: entity
+  parent: RMCBaseEquipmentCase
+  id: CMU14PyroSpecEquipmentCaseUPP
+  name: pyrotechnician equipment case
+  suffix: UPP
+  description: "A large case containing LPO80-T, M35 pyrotechnician armor and helmet, and additional pieces of equipment.\nNOTE: You cannot put items back inside this case."
+  components:
+  - type: Sprite
+    layers:
+    - state: closed
+      map: [ base ]
+    - state: pyro
+      map: [ label ]
+  - type: Storage
+    maxItemSize: Huge
+    grid:
+    - 0,0,11,3
+  - type: StorageFill
+    contents:
+    - id: CMArmorM35
+    - id: CMArmorHelmetM35
+    - id: RMCBackpackBroilerUPP
+    - id: RMCWeaponFlamerSpecUPP
+    - id: RMCTankFlamerLargeUPP
+    - id: RMCTankFlamerBLargeUPP
+    - id: RMCTankFlamerXLargeUPP
+    - id: RMCPouchFuelTank
+    - id: CMFireExtinguisher
+    - id: CMFireExtinguisherPortable
+    - id: RMCBinoculars
+    - id: RMCPamphletAdminWeaponsSpecialistPyro
+    #- id: RMCMK80
+    #- id: CMMagazinePistolMK80
+    #  amount: 2
+  - type: CMChangeUserOnVend
+    addComponents:
+    - type: PyroWhitelist
+
+- type: entity
   parent: RMCKitBase
   id: RMCKitLoader
   name: loader kit

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/fl3_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/fl3_flamer.yml
@@ -4,6 +4,7 @@
   name: flammenwerfer 3 heavy incineration unit
   description: A heavy industrial incineration unit produced by the Weyland Corporation and later by Weyland-Yutani. Often found among foliage cleaning missions on frontier colonies, it usually isn't seen in combat, but is devastating when actually used.
   components:
+  - type: RMCMagneticItem
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Guns/Flamethrower/FL3/fl3_inhands.rsi
     layers:
@@ -41,6 +42,8 @@
         whitelist:
           tags:
           - RMCTankFlamerFL3
+          - RMCTankFlamerFL3X
+          - RMCTankFlamerFL3B
   - type: RMCIgniter
     sound:
       path: /Audio/_RMC14/Weapons/Guns/Flamer/wy_flamer_ignite.ogg
@@ -109,6 +112,69 @@
     - RMCTankFlamerFL3
 
 - type: entity
+  parent: RMCTankFlamer
+  id: RMCTankFlamerFL3B
+  name: FW3 heavy incinerator tank (B)
+  description: A heavy, high capacity tank utilized by the Flammenwerfer 3 Heavy Incineration Unit. This one has a blue, heat-resistant Weyland-Yutani logo on it. This one seems to contain 'Napalm-B'.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Ammunition/fl3.rsi
+    state: flametank
+    layers:
+    - state: flametank
+    - state: flametank_strip1
+    - state: flametank_strip2
+      map: [ "enum.SolutionContainerLayers.Fill" ]
+  - type: RMCFlamerTank
+    maxIntensity: 70
+    maxRange: 8
+  - type: SolutionContainerManager
+    solutions:
+      rmc_flamer_tank:
+        maxVol: 300
+        reagents:
+        - ReagentId: RMCNapalmB
+          Quantity: 300
+  - type: SolutionContainerVisuals
+    maxFillLevels: 2
+    fillBaseName: flametank_strip
+  - type: Tag
+    tags:
+    - RMCTankFlamerFL3B
+
+- type: entity
+  parent: RMCTankFlamer
+  id: RMCTankFlamerFL3X
+  name: FW3 heavy incinerator tank (X)
+  description: A heavy, high capacity tank utilized by the Flammenwerfer 3 Heavy Incineration Unit. This one has a blue, heat-resistant Weyland-Yutani logo on it. This one seems to contain 'Napalm-X'.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Ammunition/fl3.rsi
+    state: flametank
+    layers:
+    - state: flametank
+    - state: flametank_strip1
+    - state: flametank_strip2
+      map: [ "enum.SolutionContainerLayers.Fill" ]
+  - type: RMCFlamerTank
+    maxIntensity: 70
+    maxRange: 8
+  - type: SolutionContainerManager
+    solutions:
+      rmc_flamer_tank:
+        maxVol: 300
+        reagents:
+        - ReagentId: RMCNapalmX
+          Quantity: 300
+  - type: SolutionContainerVisuals
+    maxFillLevels: 2
+    fillBaseName: flametank_strip
+  - type: Tag
+    tags:
+    - RMCTankFlamerFL3X
+
+
+- type: entity
   parent: RMCTankFlamerFL3
   id: RMCTankFlamerFL3Whiteout
   name: FW3 heavy incinerator tank (EX)
@@ -127,3 +193,16 @@
 
 - type: Tag
   id: RMCTankFlamerFL3
+
+- type: entity
+  parent: RMCBackpackFlamer
+  id: CMU14FuelFL3FuelTankFilled
+  suffix: WY
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCTankFlamerFL3B
+      amount: 2
+    - id: RMCTankFlamerFL3X
+
+

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/fl3_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/fl3_flamer.yml
@@ -204,5 +204,6 @@
     - id: RMCTankFlamerFL3B
       amount: 2
     - id: RMCTankFlamerFL3X
+      amount: 1
 
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/lpo80.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/lpo80.yml
@@ -41,6 +41,57 @@
       rmc-aslot-underbarrel: 0.284, -0.313
 
 - type: entity
+  parent: RMCWeaponFlamer
+  id: RMCWeaponFlamerSpecUPP
+  name: LPO80-T incinerator unit
+  description: An aged but effective lightweight combat incinerator officially in service as a anti-fortification tool but, in practice, utilized in close quarters combat for flushing out enemy combatants. This one seems to be refurbished to fit certain fuel tanks.
+  components:
+  - type: RMCCanUseBroiler
+  - type: RMCIgniter
+    enabled: true
+    locked: true
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Flamethrower/lpo80.rsi
+  - type: Item
+    sprite: _RMC14/Objects/Weapons/Guns/Flamethrower/lpo80.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Weapons/Guns/Flamethrower/lpo80.rsi
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Tank
+        startingItem: RMCTankFlamerLargeUPP
+        insertSound: /Audio/_RMC14/Weapons/Handling/flamer_reload.ogg
+        ejectSound: /Audio/_RMC14/Weapons/Handling/flamer_unload.ogg
+        priority: 2
+        whitelist:
+          tags:
+          - RMCTankFlamerLargeUPP
+          - RMCTankFlamerXLargeUPP
+          - RMCTankFlamerBLargeUPP
+  - type: AttachableHolder # TODO RMC14 barrel nozzle
+    slots:
+      rmc-aslot-rail:
+        whitelist:
+          tags:
+          - RMCAttachmentRailFlashlight
+          - RMCAttachmentMagneticHarness
+      rmc-aslot-stock:
+        locked: true
+      rmc-aslot-underbarrel:
+        whitelist:
+          tags:
+          - RMCAttachmentExtinguisher
+  - type: AttachableHolderVisuals
+    offsets:
+      rmc-aslot-rail: -0.032, 0.092
+      rmc-aslot-stock: -0.468, 0.064
+      rmc-aslot-underbarrel: 0.284, -0.313
+  - type: Tag
+    tags:
+    - RMCWeaponFlamerSpecUPP
+
+- type: entity
   parent: RMCTankFlamer
   id: RMCTankFlamerSPP
   name: LPO80 incinerator tank
@@ -61,5 +112,95 @@
     tags:
     - RMCTankFlamerSPP
 
+- type: entity
+  parent: RMCTankFlamer
+  id: RMCTankFlamerLargeUPP
+  name: LPO80-T incinerator tank
+  description: A fuel tank used to store fuel for use in the LPO80 incinerator unit. Handle with care. This one seems to be larger than the standard LPO80 tank, and is likely used for extended operations.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Ammunition/lpo80.rsi
+    state: flametank
+    layers:
+    - state: flametank
+    - state: flametank_strip1
+    - state: flametank_strip2
+      map: [ "enum.SolutionContainerLayers.Fill" ]
+  - type: SolutionContainerManager
+    solutions:
+      rmc_flamer_tank:
+        maxVol: 250
+        reagents:
+        - ReagentId: RMCNapalmUT
+          Quantity: 250
+  - type: SolutionContainerVisuals
+    maxFillLevels: 2
+    fillBaseName: flametank_strip
+  - type: Tag
+    tags:
+    - RMCTankFlamerLargeUPP
+
 - type: Tag
-  id: RMCTankFlamerSPP
+  id: RMCTankFlamerLargeUPP
+
+- type: entity
+  parent: RMCTankFlamer
+  id: RMCTankFlamerXLargeUPP
+  name: LPO80-T incinerator tank (X)
+  description: A fuel tank used to store fuel for use in the LPO80 incinerator unit. Handle with care. This one seems to be larger than the standard LPO80 tank, and is likely used for extended operations.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Ammunition/lpo80.rsi
+    state: flametank
+    layers:
+    - state: flametank
+    - state: flametank_strip1
+    - state: flametank_strip2
+      map: [ "enum.SolutionContainerLayers.Fill" ]
+  - type: SolutionContainerManager
+    solutions:
+      rmc_flamer_tank:
+        maxVol: 250
+        reagents:
+        - ReagentId: RMCNapalmX
+          Quantity: 250
+  - type: SolutionContainerVisuals
+    maxFillLevels: 2
+    fillBaseName: flametank_strip
+  - type: Tag
+    tags:
+    - RMCTankFlamerXLargeUPP
+
+- type: Tag
+  id: RMCTankFlamerXLargeUPP
+
+- type: entity
+  parent: RMCTankFlamer
+  id: RMCTankFlamerBLargeUPP
+  name: LPO80-T incinerator tank (B)
+  description: A fuel tank used to store fuel for use in the LPO80 incinerator unit. Handle with care. This one seems to be larger than the standard LPO80 tank, and is likely used for extended operations.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Ammunition/lpo80.rsi
+    state: flametank
+    layers:
+    - state: flametank
+    - state: flametank_strip1
+    - state: flametank_strip2
+      map: [ "enum.SolutionContainerLayers.Fill" ]
+  - type: SolutionContainerManager
+    solutions:
+      rmc_flamer_tank:
+        maxVol: 250
+        reagents:
+        - ReagentId: RMCNapalmB
+          Quantity: 250
+  - type: SolutionContainerVisuals
+    maxFillLevels: 2
+    fillBaseName: flametank_strip
+  - type: Tag
+    tags:
+    - RMCTankFlamerBLargeUPP
+
+- type: Tag
+  id: RMCTankFlamerBLargeUPP

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34t_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34t_flamer.yml
@@ -87,10 +87,10 @@
   - type: SolutionContainerManager
     solutions:
       rmc_flamer_tank:
-        maxVol: 500
+        maxVol: 250
         reagents:
         - ReagentId: RMCNapalmB
-          Quantity: 500
+          Quantity: 250
 
 - type: entity
   parent: RMCTankFlamerLarge
@@ -103,10 +103,10 @@
   - type: SolutionContainerManager
     solutions:
       rmc_flamer_tank:
-        maxVol: 450
+        maxVol: 250
         reagents:
         - ReagentId: RMCNapalmX
-          Quantity: 450
+          Quantity: 250
 
 - type: entity
   parent: RMCTankFlamerLarge
@@ -119,10 +119,10 @@
   - type: SolutionContainerManager
     solutions:
       rmc_flamer_tank:
-        maxVol: 450
+        maxVol: 250
         reagents:
         - ReagentId: RMCNapalmEX
-          Quantity: 450
+          Quantity: 250
 
 - type: entity
   parent: RMCTankFlamerLarge

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
@@ -89,7 +89,7 @@
     tileDamage:
       types:
         Heat: 1
-    armorMultiplier: 0.75
+    armorMultiplier: 0.5
     armorWhitelist:
       components:
       - Xeno
@@ -100,8 +100,8 @@
     patExtinguishMultiplier: 2
     sprayExtinguishMultiplier: 3
   - type: SpeedModifierContacts
-    walkSpeedModifier: 0.4
-    sprintSpeedModifier: 0.4
+    walkSpeedModifier: 0.666
+    sprintSpeedModifier: 0.666
   - type: GenericVisualizer
     visuals:
       enum.TileFireLayers.Base:

--- a/Resources/Prototypes/_RMC14/rmc_tags.yml
+++ b/Resources/Prototypes/_RMC14/rmc_tags.yml
@@ -74,6 +74,18 @@
   id: RMCSmartPistol
 
 - type: Tag
+  id: RMCTankFlamerSPP
+
+- type: Tag
+  id: RMCTankFlamerFL3B
+
+- type: Tag
+  id: RMCTankFlamerFL3X
+
+- type: Tag
+  id: RMCWeaponFlamerSpecUPP
+
+- type: Tag
   id: RMCMK80
 
 - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
M240A2 now has X-Gel, BGel. UPP pyro is no longer a bad choice. We-Yu PMC gets the Flammenwerfer 3 now. Also reverted https://github.com/AU-14/ColonialMarinesUniverse/pull/1427  as it made xenos unable to move at all in BGel

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: a viable Pyrospec for UPP has been added, HAZOPS pyrospec now gets X-Gel and B-Gel, with a reduced fire rate. We-Yu pyrospec now gets the flammenwerfer-3
- remove: Reverted PR #1427
- add: you can now buy pyrospec ammunition at ASRS
- tweak: M240A2 fuel tank size increased from 150 to 300 (since it says its a copy of the Flammenwerfer-3)
- tweak: M240A2 and Flammenwerfer-3 has intergrated mag harness now.

