### PR TITLE
Hotfix: Update ZombieSummonerComponent.cs 

### DIFF
--- a/Content.Shared/_CMU14/Threats/Mobs/ZombieSummoner/ZombieSummonerComponent.cs
+++ b/Content.Shared/_CMU14/Threats/Mobs/ZombieSummoner/ZombieSummonerComponent.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared._CMU14.Threats.Mobs.ZombieSummoner;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, ComponentProtoName("ZombieSummoner")]
 public sealed partial class ZombieSummonerComponent : Component
 {
     [DataField]
@@ -158,7 +158,7 @@ public sealed partial class ZombieSummonerComponent : Component
     public float PointAccumulator;
 }
 
-[RegisterComponent]
+[RegisterComponent, ComponentProtoName("ZombieSummonerZombieLabel")]
 public sealed partial class ZombieSummonerZombieLabelComponent : Component
 {
     [DataField]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed the zombie summoner prototype load crash by explicitly binding the zombie summoner component names used in YAML.

## Technical details
Added explicit `ComponentProtoName `attributes for `ZombieSummonerComponent` and `ZombieSummonerZombieLabelComponent `so `type: ZombieSummoner` and `type: ZombieSummonerZombieLabel` resolve correctly.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed the zombie summoner prototype registration crash that prevented the server from starting
