### PR TITLE
Small Colony Medical Tweak

### DIFF
--- a/Resources/Prototypes/_CMU14/Entities/Clothing/Universal/belts.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Clothing/Universal/belts.yml
@@ -27,9 +27,6 @@
     - id: AU14NaloxoneAutoInjector
     - id: CMUSplintItem
     - id: CMUCastItem
-    - id: CMSurgicalLine
-    - id: CMSynthGraft
-    - id: CMHealthAnalyzer
     - id: CMRollerBedSpawnFolded
     - id: CMPortableSurgicalBedSpawnFolded
     - id: CMBloodPackFull

--- a/Resources/Prototypes/_CMU14/Roles/Colony/Medical/Loadouts/med.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/Medical/Loadouts/med.yml
@@ -9,6 +9,7 @@
     - CMSurgicalCaseFilled
     - ClothingNeckStethoscope
     - AU14CMDefibrillator
+    - CMSyringe
   equipment:
     ears2: RMCFlashlightPen
     eyes: RMCGlassesMedicalHUDGlasses


### PR DESCRIPTION

## About the PR
Removed the dupe fill of the med analyzer, suture line and synth graft from medical colony filled life saver bag, added one syringe  to be in `MedEssentialAU14`

## Why / Balance
For the first, not intended for two sets of lines and analyzer, I had forgotten when I had made the filled bag, and for the syringe, I was asked to give one syringe to colony medical because someone reported the difficulty sourcing them on maps.

## Technical details
removed  the extra health analyzer, suture line, synth graft `AU14BeltMedicBagFilled `. added one syringe to `MedEssentialsAU14`


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: one syringe to colony medical staff
- remove: The unintended extra health analyzer, suture line, synth graft from filled colony life saver bags