### PR TITLE
Large Magazine Pouch Death + Mag/Ammo Boxes

### DIFF
--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/cmbciu_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/cmbciu_requisitions_catalog.yml
@@ -104,6 +104,10 @@
         crate: RMCCrateGearParachute
       - cost: 800
         crate: RMCCrateAttachmentSmartScope
+    - name: Pouches
+      entries:
+      - cost: 150
+        crate: RMCCrateClothingMagazinePouchesLarge
     - name: Medical
       entries:
       - cost: 3000

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/hazops_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/hazops_requisitions_catalog.yml
@@ -104,6 +104,10 @@
         crate: RMCCrateGearParachute
       - cost: 800
         crate: RMCCrateAttachmentSmartScope
+    - name: Pouches
+      entries:
+      - cost: 150
+        crate: RMCCrateClothingMagazinePouchesLarge
     - name: Medical
       entries:
       - cost: 3000

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/lacn_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/lacn_requisitions_catalog.yml
@@ -104,6 +104,10 @@
         crate: RMCCrateGearParachute
       - cost: 800
         crate: RMCCrateAttachmentSmartScope
+    - name: Pouches
+      entries:
+      - cost: 150
+        crate: RMCCrateClothingMagazinePouchesLarge
     - name: Medical
       entries:
       - cost: 3000

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/prodigy_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/prodigy_requisitions_catalog.yml
@@ -104,6 +104,10 @@
         crate: RMCCrateGearParachute
       - cost: 800
         crate: RMCCrateAttachmentSmartScope
+    - name: Pouches
+      entries:
+      - cost: 150
+        crate: RMCCrateClothingMagazinePouchesLarge
     - name: Medical
       entries:
       - cost: 3000

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/rmc_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/rmc_requisitions_catalog.yml
@@ -108,6 +108,10 @@
         crate: RMCCrateGearParachute
       - cost: 800
         crate: RMCCrateAttachmentSmartScope
+    - name: Pouches
+      entries:
+      - cost: 150
+        crate: RMCCrateClothingMagazinePouchesLarge
     - name: Medical
       entries:
       - cost: 3000

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/upp_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/upp_requisitions_catalog.yml
@@ -106,6 +106,10 @@
         crate: RMCCrateGearParachute
       - cost: 800
         crate: RMCCrateAttachmentSmartScope
+    - name: Pouches
+      entries:
+      - cost: 150
+        crate: RMCCrateClothingMagazinePouchesLarge
     - name: Medical
       entries:
       - cost: 3000

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/uscm_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/uscm_requisitions_catalog.yml
@@ -108,6 +108,10 @@
         crate: RMCCrateGearParachute
       - cost: 800
         crate: RMCCrateAttachmentSmartScope
+    - name: Pouches
+      entries:
+      - cost: 150
+        crate: RMCCrateClothingMagazinePouchesLarge
     - name: Medical
       entries:
       - cost: 3000

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/vaipo_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/vaipo_requisitions_catalog.yml
@@ -104,6 +104,10 @@
         crate: RMCCrateGearParachute
       - cost: 800
         crate: RMCCrateAttachmentSmartScope
+    - name: Pouches
+      entries:
+      - cost: 150
+        crate: RMCCrateClothingMagazinePouchesLarge
     - name: Medical
       entries:
       - cost: 3000

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/weyu_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/weyu_requisitions_catalog.yml
@@ -104,6 +104,10 @@
         crate: RMCCrateGearParachute
       - cost: 800
         crate: RMCCrateAttachmentSmartScope
+    - name: Pouches
+      entries:
+      - cost: 150
+        crate: RMCCrateClothingMagazinePouchesLargePMC
     - name: Medical
       entries:
       - cost: 3000

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/cmbciuvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/cmbciuvendors.yml
@@ -106,8 +106,6 @@
         amount: 12
       - id: RMCPouchMagazine
         amount: 50
-      - id: RMCPouchMagazineLarge
-        amount: 8
       - id: RMCPouchShotgunLarge
         amount: 8
       - id: RMCPouchGeneralMedium
@@ -116,8 +114,6 @@
         amount: 6
       - id: RMCPouchMagazinePistol
         amount: 25
-      - id: RMCPouchMagazinePistolLarge
-        amount: 6
       - id: RMCPouchPistol
         amount: 20
       - id: AU14PouchIFAKFill
@@ -926,6 +922,28 @@
         amount: 5
       - id: RMCMagazinePistolMK45
         amount: 200
+    - name: Magazine Boxes
+      entries:
+      - id: RMCBoxMagazineRifleM16
+        amount: 2
+      - id: CMUBoxMagazineSMGMP5
+        amount: 2
+      - id: CMUBoxMagazineSMGPDW90
+        amount: 2
+      - id: RMCBoxMagazinePistolM1984
+        amount: 2
+      - id: CMUBoxMagazinePistolMK45
+        amount: 2
+    - name: Ammo Boxes
+      entries:
+      - id: RMCBoxBulletsRifle
+        amount: 5
+      - id: CMUBoxBulletsSMGP90
+        amount: 5
+      - id: CMUBoxBulletsPistol45
+        amount: 5
+      - id: CMUBoxBulletsPistol9MM
+        amount: 5
     - name: explosives
       entries:
       - id: CMPacketGrenadeHighExplosiveFilled
@@ -1010,6 +1028,12 @@
         amount: 4
       - id: RMCOuterClothingExternalWebbing
         amount: 4
+    - name: Pouches
+      entries:
+      - id: RMCPouchMagazineLarge
+        amount: 10
+      - id: RMCPouchMagazinePistolLarge
+        amount: 10
     - name: Devices
       entries:
       - id: RMCIntelDetector

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/hazopsvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/hazopsvendors.yml
@@ -123,8 +123,6 @@
         amount: 3
       - id: RMCPouchMagazine
         amount: 50
-      - id: RMCPouchMagazineLarge
-        amount: 8
       - id: RMCPouchShotgunLarge
         amount: 8
       - id: RMCPouchGeneralMedium
@@ -133,8 +131,6 @@
         amount: 4
       - id: RMCPouchMagazinePistol
         amount: 25
-      - id: RMCPouchMagazinePistolLarge
-        amount: 6
       - id: RMCPouchPistol
         amount: 20
       - id: AU14PouchIFAKFill
@@ -519,6 +515,18 @@
         amount: 100
       - id: RMCSpeedLoader44Marksman
         amount: 10
+    - name: Magazine Boxes
+      entries:
+      - id: CMUBoxMagazineSMGXMP5A6
+        amount: 2
+      - id: RMCBoxMagazinePistolM1984
+        amount: 2
+    - name: Ammo Boxes
+      entries:
+      - id: RMCBoxBulletsRifle
+        amount: 5
+      - id: CMUBoxBulletsPistol9MM
+        amount: 5
     - name: explosives
       entries:
       - id: CMPacketGrenadeHighExplosiveFilled
@@ -601,6 +609,12 @@
         amount: 4
       - id: RMCOuterClothingExternalWebbing
         amount: 4
+    - name: Pouches
+      entries:
+      - id: RMCPouchMagazineLarge
+        amount: 10
+      - id: RMCPouchMagazinePistolLarge
+        amount: 10
     - name: Devices
       entries:
       - id: RMCIntelDetector

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/lacnvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/lacnvendors.yml
@@ -104,8 +104,6 @@
         amount: 3
       - id: RMCPouchMagazine
         amount: 50
-      - id: RMCPouchMagazineLarge
-        amount: 8
       - id: RMCPouchShotgunLarge
         amount: 8
       - id: RMCPouchGeneralMedium
@@ -114,8 +112,6 @@
         amount: 4
       - id: RMCPouchMagazinePistol
         amount: 25
-      - id: RMCPouchMagazinePistolLarge
-        amount: 6
       - id: RMCPouchPistol
         amount: 20
       - id: AU14PouchIFAKFill
@@ -959,6 +955,18 @@
         amount: 100
       - id: RMCSpeedLoader44Marksman
         amount: 10
+    - name: Magazine Boxes
+      entries:
+      - id: CMUBoxMagazineRifleKramer
+        amount: 2
+      - id: RMCBoxMagazinePistolM1984
+        amount: 2
+    - name: Ammo Boxes
+      entries:
+      - id: RMCBoxBulletsRifle
+        amount: 5
+      - id: CMUBoxBulletsPistol9MM
+        amount: 5
     - name: explosives
       entries:
       - id: CMPacketGrenadeHighExplosiveFilled
@@ -1027,6 +1035,12 @@
         amount: 4
       - id: RMCOuterClothingExternalWebbing
         amount: 4
+    - name: Pouches
+      entries:
+      - id: RMCPouchMagazineLarge
+        amount: 10
+      - id: RMCPouchMagazinePistolLarge
+        amount: 10
     - name: Devices
       entries:
       - id: RMCIntelDetector

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/marinevendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/marinevendors.yml
@@ -160,8 +160,6 @@
         amount: 3
       - id: RMCPouchMagazine
         amount: 50
-      - id: RMCPouchMagazineLarge
-        amount: 8
       - id: RMCPouchShotgunLarge
         amount: 8
       - id: RMCPouchGeneralMedium
@@ -170,8 +168,6 @@
         amount: 4
       - id: RMCPouchMagazinePistol
         amount: 25
-      - id: RMCPouchMagazinePistolLarge
-        amount: 6
       - id: RMCPouchPistol
         amount: 20
       - id: AU14PouchIFAKFill
@@ -1396,6 +1392,28 @@
         amount: 100
       - id: RMCSpeedLoader44Marksman
         amount: 10
+    - name: Magazine Boxes
+      entries:
+      - id: CMUBoxMagazineRifleM54CMK1
+        amount: 2
+      - id: RMCBoxMagazineSMGM63
+        amount: 2
+      - id: RMCBoxMagazinePistolM1984
+        amount: 2
+      - id: RMCBoxMagazinePistolM77AP
+        amount: 2
+    - name: Ammo Boxes
+      entries:
+      - id: RMCBoxBulletsRifle
+        amount: 5
+      - id: RMCBoxBulletsSMG
+        amount: 5
+      - id: RMCBoxBulletsSmartGun
+        amount: 5
+      - id: CMUBoxBulletsPistol9MM
+        amount: 5
+      - id: CMUBoxBulletsPistol9MMAP
+        amount: 5
     - name: explosives
       entries:
       - id: CMPacketGrenadeHighExplosiveFilled
@@ -1484,6 +1502,12 @@
         amount: 4
       - id: RMCOuterClothingExternalWebbing
         amount: 4
+    - name: Pouches
+      entries:
+      - id: RMCPouchMagazineLarge
+        amount: 10
+      - id: RMCPouchMagazinePistolLarge
+        amount: 10
     - name: Devices
       entries:
       - id: RMCIntelDetector

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/prodigyvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/prodigyvendors.yml
@@ -106,8 +106,6 @@
         amount: 3
       - id: RMCPouchMagazine
         amount: 50
-      - id: RMCPouchMagazineLarge
-        amount: 8
       - id: RMCPouchShotgunLarge
         amount: 8
       - id: RMCPouchGeneralMedium
@@ -116,8 +114,6 @@
         amount: 4
       - id: RMCPouchMagazinePistol
         amount: 25
-      - id: RMCPouchMagazinePistolLarge
-        amount: 6
       - id: RMCPouchPistol
         amount: 20
       - id: AU14PouchIFAKFill
@@ -874,6 +870,22 @@
         amount: 20
       - id: RMCSpeedLoader357Hollowpoint
         amount: 5
+    - name: Magazine Boxes
+      entries:
+      - id: CMUBoxMagazineRifleProdigyStandard
+        amount: 2
+      - id: RMCBoxMagazineSMGM63
+        amount: 2
+      - id: RMCBoxMagazinePistolM1984
+        amount: 2
+    - name: Ammo Boxes
+      entries:
+      - id: RMCBoxBulletsRifle
+        amount: 5
+      - id: RMCBoxBulletsSMG
+        amount: 5
+      - id: CMUBoxBulletsPistol9MM
+        amount: 5
     - name: explosives
       entries:
       - id: CMPacketGrenadeHighExplosiveFilled
@@ -950,6 +962,12 @@
         amount: 4
       - id: RMCOuterClothingExternalWebbing
         amount: 4
+    - name: Pouches
+      entries:
+      - id: RMCPouchMagazineLarge
+        amount: 10
+      - id: RMCPouchMagazinePistolLarge
+        amount: 10
     - name: Devices
       entries:
       - id: RMCIntelDetector

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/rmcvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/rmcvendors.yml
@@ -146,8 +146,6 @@
         amount: 3
       - id: RMCPouchMagazine
         amount: 50
-      - id: RMCPouchMagazineLarge
-        amount: 8
       - id: RMCPouchShotgunLarge
         amount: 8
       - id: RMCPouchGeneralMedium
@@ -156,8 +154,6 @@
         amount: 4
       - id: RMCPouchMagazinePistol
         amount: 25
-      - id: RMCPouchMagazinePistolLarge
-        amount: 6
       - id: AU14PouchPistolAlt
         amount: 20
       - id: AU14PouchIFAKFill
@@ -1218,6 +1214,30 @@
         amount: 200
       - id: AU14MagazinePistolL165A1
         amount: 200
+    - name: Magazine Boxes
+      entries:
+      - id: RMCBoxMagazineRifleL24
+        amount: 2
+      - id: CMUBoxMagazineSMGL90A2
+        amount: 2
+      - id: CMUBoxMagazinePistolL54
+        amount: 2
+      - id: CMUBoxMagazinePistolL165A1
+        amount: 2
+    - name: Ammo Boxes
+      entries:
+      - id: RMCBoxBulletsRifleL24
+        amount: 5
+      - id: RMCBoxBulletsRifleL90
+        amount: 5
+      - id: RMCBoxBulletsSMG
+        amount: 5
+      - id: RMCBoxBulletsSmartGun
+        amount: 5
+      - id: CMUBoxBulletsPistol9MM
+        amount: 5
+      - id: CMUBoxBulletsPistol9MMSH
+        amount: 5
     - name: explosives
       entries:
       - id: AU14PacketGrenadeHighExplosiveRMCFilled
@@ -1292,6 +1312,12 @@
         amount: 4
       - id: RMCOuterClothingExternalWebbing
         amount: 4
+    - name: Pouches
+      entries:
+      - id: RMCPouchMagazineLarge
+        amount: 10
+      - id: RMCPouchMagazinePistolLarge
+        amount: 10
     - name: Devices
       entries:
       - id: RMCIntelDetector

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/uppvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/uppvendors.yml
@@ -131,8 +131,6 @@
         amount: 3
       - id: RMCPouchMagazine
         amount: 50
-      - id: RMCPouchMagazineLarge
-        amount: 8
       - id: RMCPouchShotgunLarge
         amount: 8
       - id: RMCPouchGeneralMedium
@@ -141,8 +139,6 @@
         amount: 4
       - id: RMCPouchMagazinePistol
         amount: 25
-      - id: RMCPouchMagazinePistolLarge
-        amount: 6
       - id: AU14PouchPistolAlt
         amount: 20
       - id: AU14PouchIFAKFill
@@ -1195,6 +1191,20 @@
         amount: 100
       - id: RMCMagazineSMGType19Drum
         amount: 40
+    - name: Magazine Boxes
+      entries:
+      - id: CMUBoxMagazineRifleAG80
+        amount: 2
+      - id: RMCBoxMagazinePistolType73
+        amount: 2
+    - name: Ammo Boxes
+      entries:
+      - id: CMUBoxBulletsRifleAG80
+        amount: 5
+      - id: RMCBoxBulletsSMG
+        amount: 5
+      - id: CMUBoxBulletsPistolType73
+        amount: 5
     - name: explosives
       entries:
       - id: AU14PacketGrenadeHighExplosiveUPPFilled
@@ -1245,6 +1255,12 @@
         amount: 4
       - id: RMCOuterClothingExternalWebbing
         amount: 4
+    - name: Pouches
+      entries:
+      - id: RMCPouchMagazineLarge
+        amount: 10
+      - id: RMCPouchMagazinePistolLarge
+        amount: 10
     - name: Devices
       entries:
       - id: AU14PowerCellSmartgunUPP

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/vaipovendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/vaipovendors.yml
@@ -139,8 +139,6 @@
         amount: 3
       - id: RMCPouchMagazine
         amount: 50
-      - id: RMCPouchMagazineLarge
-        amount: 8
       - id: RMCPouchShotgunLarge
         amount: 8
       - id: RMCPouchGeneralMedium
@@ -149,8 +147,6 @@
         amount: 4
       - id: RMCPouchMagazinePistol
         amount: 25
-      - id: RMCPouchMagazinePistolLarge
-        amount: 6
       - id: RMCPouchPistol
         amount: 20
       - id: AU14PouchIFAKFill
@@ -957,6 +953,26 @@
         amount: 15
       - id: RMCMagazinePistolM1984HP
         amount: 5
+    - name: Magazine Boxes
+      entries:
+      - id: RMCBoxMagazineRifleM54C
+        amount: 2
+      - id: CMUBoxMagazineRifleMAR40
+        amount: 2
+      - id: RMCBoxMagazinePistolM1984
+        amount: 2
+      - id: CMUBoxMagazinePistolM48A4
+        amount: 2
+    - name: Ammo Boxes
+      entries:
+      - id: RMCBoxBulletsRifle
+        amount: 5
+      - id: CMUBoxBulletsRifleMAR
+        amount: 5
+      - id: CMUBoxBulletsPistol9MM
+        amount: 5
+      - id: CMUBoxBulletsPistol45
+        amount: 5
     - name: explosives
       entries:
       - id: CMPacketGrenadeHighExplosiveFilled
@@ -1033,6 +1049,12 @@
         amount: 4
       - id: RMCOuterClothingExternalWebbing
         amount: 4
+    - name: Pouches
+      entries:
+      - id: RMCPouchMagazineLarge
+        amount: 10
+      - id: RMCPouchMagazinePistolLarge
+        amount: 10
     - name: Devices
       entries:
       - id: RMCIntelDetector

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/wypmcvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/wypmcvendors.yml
@@ -112,8 +112,6 @@
         amount: 3
       - id: RMCPouchMagazine
         amount: 50
-      - id: RMCPouchMagazineLargePMC
-        amount: 8
       - id: RMCPouchShotgunLarge
         amount: 8
       - id: RMCPouchGeneralMedium
@@ -122,8 +120,6 @@
         amount: 4
       - id: RMCPouchMagazinePistol
         amount: 25
-      - id: RMCPouchMagazinePistolLarge
-        amount: 6
       - id: RMCPouchPistol
         amount: 20
       - id: AU14PouchIFAKFill
@@ -904,6 +900,24 @@
       entries:
       - id: CMMagazinePistolM77AP
         amount: 200
+    - name: Magazine Boxes
+      entries:
+      - id: CMUBoxMagazineSMGFP9000
+        amount: 2
+      - id: RMCBoxMagazineSMGM63
+        amount: 2
+      - id: RMCBoxMagazinePistolM77AP
+        amount: 2
+    - name: Ammo Boxes
+      entries:
+      - id: RMCBoxBulletsRifle
+        amount: 5
+      - id: RMCBoxBulletsSMG
+        amount: 5
+      - id: RMCBoxBulletsSmartGun
+        amount: 5
+      - id: CMUBoxBulletsSMGP90
+        amount: 5
     - name: explosives
       entries:
       - id: CMPacketGrenadeHighExplosiveFilled
@@ -982,6 +996,12 @@
         amount: 4
       - id: RMCOuterClothingExternalWebbing
         amount: 4
+    - name: Pouches
+      entries:
+      - id: RMCPouchMagazineLargePMC
+        amount: 10
+      - id: RMCPouchMagazinePistolLarge
+        amount: 10
     - name: Devices
       entries:
       - id: RMCIntelDetector

--- a/Resources/Prototypes/_CMU14/Entities/Weapons/Ammunition/bullet_boxes.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Weapons/Ammunition/bullet_boxes.yml
@@ -366,27 +366,6 @@
   - type: BulletBox
     bulletType: CMUBoxBulletsSMGType19
     amount: 0
-#   -- REG 9mm SMG Ammunition Box --
-- type: entity
-  parent: RMCBoxBulletsSMG
-  id: CMUBoxBulletsSMG9MM
-  name: smg ammunition box (9×19mm)
-  description: A 9×19mm ammunition box. Used to refill MP5 magazines. It comes with a leather strap allowing to wear it on the back.
-  components:
-  - type: BulletBox
-    bulletType: CMUBoxBulletsSMG9MM
-
-- type: entity
-  parent: CMUBoxBulletsSMG9MM
-  id: CMUBoxBulletsSMG9MMEmpty
-  suffix: Empty
-  components:
-  - type: Construction
-    graph: RMCBoxMagazine
-    node: CMUBoxBulletsSMG9MMEmpty
-  - type: BulletBox
-    bulletType: CMUBoxBulletsSMG9MM
-    amount: 0
 
 # -- PISTOL AMMUNITION BOXES --
 #   -- REG 7.62x25mm Pistol Ammunition Box --
@@ -427,7 +406,7 @@
 - type: entity
   parent: RMCBoxBulletsPistol
   id: CMUBoxBulletsPistol9MM
-  name: pistol ammunition box (9×19mm Parabellum)
+  name: pistol ammunition box (9×19mm)
   description: A 9×19mm ammunition box. Used to refill 9×19mm pistol magazines. It comes with a leather strap allowing to wear it on the back.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Command/Advisor.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Command/Advisor.yml
@@ -45,7 +45,7 @@
   - !type:OverallPlaytimeRequirement
     time: 3600
   - !type:AgeRequirement
-    requiredAge: 21
+    requiredAge: 25
   - !type:TraitsRequirement
     inverted: true
     traits:

--- a/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Command/Officer_Intelligence.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Command/Officer_Intelligence.yml
@@ -54,7 +54,7 @@
   - !type:OverallPlaytimeRequirement
     time: 18000 # 5 hours
   - !type:AgeRequirement
-    requiredAge: 30
+    requiredAge: 25
   - !type:TraitsRequirement
     inverted: true
     traits:

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/clothing.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/clothing.yml
@@ -13,6 +13,30 @@
         amount: 2
 
 - type: entity
+  id: RMCCrateClothingMagazinePouchesLarge
+  parent: RMCCrateBase
+  name: large magazine pouches crate (2x Pistol, Magazine)
+  components:
+  - type: StorageFill
+    contents:
+      - id: RMCPouchMagazineLarge
+        amount: 2
+      - id: RMCPouchMagazinePistolLarge
+        amount: 2
+
+- type: entity
+  id: RMCCrateClothingMagazinePouchesLargePMC
+  parent: RMCCrateBase
+  name: large magazine pouches crate (2x Pistol, Magazine)
+  components:
+  - type: StorageFill
+    contents:
+      - id: RMCPouchMagazineLargePMC
+        amount: 2
+      - id: RMCPouchMagazinePistolLarge
+        amount: 2
+
+- type: entity
   id: RMCCrateClothingMedicalPouches
   parent: RMCCrateBase
   name: medical pouches crate (1x firstaid, medical, syringe, medkit)

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/bullet_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/bullet_boxes.yml
@@ -454,9 +454,3 @@
   - type: BulletBox
     bulletType: RMCBoxBulletsRifleL24AP
 
-# HAZOPS Ammunition Boxes
-# -- .50 JP Pistol Ammunition Box --
-# UPP Ammunition Boxes
-# CMB CIU Ammunition Boxes
-# Shared Ammunition Boxes
-# -- 9mm Ammunition Box --

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
@@ -346,7 +346,7 @@
 - type: entity
   parent: RMCBoxMagazineRifleBase
   id: RMCBoxMagazineRifleM54CEmpty
-  name: magazine box (M54C x 10)
+  name: magazine box (M41A MK2 x 10)
   components:
   - type: Construction
     graph: RMCBoxMagazine
@@ -1752,7 +1752,7 @@
 - type: entity
   parent: RMCBoxMagazineSMGBase
   id: RMCBoxMagazineSMGM63Empty
-  name: magazine box (M63 x 12)
+  name: magazine box (M39 x 12)
   components:
   - type: Construction
     graph: RMCBoxMagazine
@@ -1989,7 +1989,7 @@
 - type: entity
   parent: RMCBoxMagazinePistolBase
   id: RMCBoxMagazinePistolM1984Empty
-  name: magazine box (M1984 x 16)
+  name: magazine box (M4A3 x 16)
   components:
   - type: Construction
     graph: RMCBoxMagazine
@@ -2035,7 +2035,7 @@
 - type: entity
   parent: RMCBoxMagazinePistolBase
   id: RMCBoxMagazinePistolM1984APEmpty
-  name: magazine box (AP M1984 x 16)
+  name: magazine box (AP M4A3 x 16)
   components:
   - type: Construction
     graph: RMCBoxMagazine
@@ -3161,3 +3161,625 @@
       whitelist:
         tags:
         - RMCMagazinePistolM13DrumAP
+
+# Kramer AR (LACN)
+- type: entity
+  parent: RMCBoxMagazineRifleBase
+  id: CMUBoxMagazineRifleKramerEmpty
+  name: magazine box (Kramer x 10)
+  components:
+  - type: Sprite
+    layers:
+    - state: rifle_box
+      color: "#5c5738"
+    - state: rifle_ammo_full_mags_base
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+    - state: rifle_ammo_full_mags_color
+      map: [ "enum.CMItemSlotsLayers2.Fill" ]
+      color: "#ffc000"
+    - state: rifle_box_generic
+      color: "#5c5738"
+    - state: rifle_box_marking
+      color: "#7c4c1b"
+    - state: rifle_lid
+      map: [ "lid" ]
+      color: "#5c5738"
+    - state: rifle_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7c4c1b"
+  - type: CMItemSlots
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - AU14WeaponRifleKramerMagazineStandard
+
+- type: entity
+  parent: CMUBoxMagazineRifleKramerEmpty
+  id: CMUBoxMagazineRifleKramer
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: AU14WeaponRifleKramerMagazineStandard
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - AU14WeaponRifleKramerMagazineStandard
+
+# FP9000 (WYPMC)
+- type: entity
+  parent: RMCBoxMagazineSMGBase
+  id: CMUBoxMagazineSMGFP9000Empty
+  name: magazine box (FP9000 x 10)
+  components:
+  - type: Sprite
+    layers:
+    - state: smg_box
+      color: "#2b2b2b"
+    - state: rifle_ammo_full_mags_base
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+    - state: rifle_ammo_full_mags_color
+      map: [ "enum.CMItemSlotsLayers2.Fill" ]
+      color: "#ffc000"
+    - state: smg_box_63
+      color: "#2b2b2b"
+    - state: smg_box_marking
+      color: "#7c4c1b"
+    - state: smg_lid
+      map: [ "lid" ]
+      color: "#2b2b2b"
+    - state: smg_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7c4c1b"
+  - type: CMItemSlots
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - RMCMagazineSMGFP9000
+
+- type: entity
+  parent: CMUBoxMagazineSMGFP9000Empty
+  id: CMUBoxMagazineSMGFP9000
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: RMCMagazineSMGFP9000
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - RMCMagazineSMGFP9000
+
+# L54 (RMC/TWE)
+- type: entity
+  parent: RMCBoxMagazinePistolBase
+  id: CMUBoxMagazinePistolL54Empty
+  name: magazine box (L54 x 10)
+  components:
+  - type: Sprite
+    layers:
+    - state: pistol_box
+      color: "#3a3a4b"
+    - state: pistol_ammo_full
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+      color: "#ffc000"
+    - state: pistol_box_80
+      color: "#3a3a4b"
+    - state: pistol_box_marking
+      color: "#7c4c1b"
+    - state: pistol_lid
+      map: [ "lid" ]
+      color: "#3a3a4b"
+    - state: pistol_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7c4c1b"
+  - type: CMItemSlots
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - RMCMagazinePistolL54
+
+- type: entity
+  parent: CMUBoxMagazinePistolL54Empty
+  id: CMUBoxMagazinePistolL54
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: RMCMagazinePistolL54
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - RMCMagazinePistolL54
+
+# MP5 (CMBCIU)
+- type: entity
+  parent: RMCBoxMagazineSMGBase
+  id: CMUBoxMagazineSMGMP5Empty
+  name: magazine box (MP5 x 10)
+  components:
+  - type: Sprite
+    layers:
+    - state: smg_box
+      color: "#37474f"
+    - state: rifle_ammo_full_mags_base
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+    - state: rifle_ammo_full_mags_color
+      map: [ "enum.CMItemSlotsLayers2.Fill" ]
+      color: "#ffc000"
+    - state: smg_box_63
+      color: "#37474f"
+    - state: smg_box_marking
+      color: "#7c4c1b"
+    - state: smg_lid
+      map: [ "lid" ]
+      color: "#37474f"
+    - state: smg_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7c4c1b"
+  - type: CMItemSlots
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - CMMagazineSMGMP5
+
+- type: entity
+  parent: CMUBoxMagazineSMGMP5Empty
+  id: CMUBoxMagazineSMGMP5
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: CMMagazineSMGMP5
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - CMMagazineSMGMP5
+
+# PDW90 (CMBCIU)
+- type: entity
+  parent: RMCBoxMagazineSMGBase
+  id: CMUBoxMagazineSMGPDW90Empty
+  name: magazine box (P90 x 10)
+  components:
+  - type: Sprite
+    layers:
+    - state: smg_box
+      color: "#465a66"
+    - state: rifle_ammo_full_mags_base
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+    - state: rifle_ammo_full_mags_color
+      map: [ "enum.CMItemSlotsLayers2.Fill" ]
+      color: "#ffc000"
+    - state: smg_box_63
+      color: "#465a66"
+    - state: smg_box_marking
+      color: "#7c4c1b"
+    - state: smg_lid
+      map: [ "lid" ]
+      color: "#465a66"
+    - state: smg_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7c4c1b"
+  - type: CMItemSlots
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - RMCMagazineSMGPDW90
+
+- type: entity
+  parent: CMUBoxMagazineSMGPDW90Empty
+  id: CMUBoxMagazineSMGPDW90
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: RMCMagazineSMGPDW90
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - RMCMagazineSMGPDW90
+
+# MK-45 (CMBCIU)
+- type: entity
+  parent: RMCBoxMagazinePistolBase
+  id: CMUBoxMagazinePistolMK45Empty
+  name: magazine box (MK-45 x 10)
+  components:
+  - type: Sprite
+    layers:
+    - state: pistol_box
+      color: "#37474f"
+    - state: pistol_ammo_full
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+      color: "#ffc000"
+    - state: pistol_box_80
+      color: "#37474f"
+    - state: pistol_box_marking
+      color: "#7c4c1b"
+    - state: pistol_lid
+      map: [ "lid" ]
+      color: "#37474f"
+    - state: pistol_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7c4c1b"
+  - type: CMItemSlots
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - RMCMagazinePistolMK45
+
+- type: entity
+  parent: CMUBoxMagazinePistolMK45Empty
+  id: CMUBoxMagazinePistolMK45
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: RMCMagazinePistolMK45
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - RMCMagazinePistolMK45
+
+# XMP5A6 (HAZOPS)
+- type: entity
+  parent: RMCBoxMagazineRifleBase
+  id: CMUBoxMagazineSMGXMP5A6Empty
+  name: magazine box (XMP5A6 x 10)
+  components:
+  - type: Sprite
+    layers:
+    - state: rifle_box
+      color: "#5c4a2e"
+    - state: rifle_ammo_full_mags_base
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+    - state: rifle_ammo_full_mags_color
+      map: [ "enum.CMItemSlotsLayers2.Fill" ]
+      color: "#ffc000"
+    - state: rifle_box_generic
+      color: "#5c4a2e"
+    - state: rifle_box_marking
+      color: "#7c4c1b"
+    - state: rifle_lid
+      map: [ "lid" ]
+      color: "#5c4a2e"
+    - state: rifle_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7c4c1b"
+  - type: CMItemSlots
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - AU14MagazineXMP5A6
+
+- type: entity
+  parent: CMUBoxMagazineSMGXMP5A6Empty
+  id: CMUBoxMagazineSMGXMP5A6
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: AU14MagazineXMP5A6
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - AU14MagazineXMP5A6
+
+# L90A2 SMG (RMC/TWE)
+- type: entity
+  parent: RMCBoxMagazineRifleBase
+  id: CMUBoxMagazineSMGL90A2Empty
+  name: magazine box (L90A2 x 10)
+  components:
+  - type: Sprite
+    layers:
+    - state: rifle_box
+      color: "#3a3a4b"
+    - state: rifle_ammo_full_mags_base
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+    - state: rifle_ammo_full_mags_color
+      map: [ "enum.CMItemSlotsLayers2.Fill" ]
+      color: "#ffc000"
+    - state: rifle_box_generic
+      color: "#3a3a4b"
+    - state: rifle_box_marking
+      color: "#7c4c1b"
+    - state: rifle_lid
+      map: [ "lid" ]
+      color: "#3a3a4b"
+    - state: rifle_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7c4c1b"
+  - type: CMItemSlots
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - AU14MagazineSMGL90A2
+
+- type: entity
+  parent: CMUBoxMagazineSMGL90A2Empty
+  id: CMUBoxMagazineSMGL90A2
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: AU14MagazineSMGL90A2
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - AU14MagazineSMGL90A2
+
+# L165A1 (RMC/TWE)
+- type: entity
+  parent: RMCBoxMagazinePistolBase
+  id: CMUBoxMagazinePistolL165A1Empty
+  name: magazine box (L165A1 x 10)
+  components:
+  - type: Sprite
+    layers:
+    - state: pistol_box
+      color: "#3a3a4b"
+    - state: pistol_ammo_full
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+      color: "#ffc000"
+    - state: pistol_box_80
+      color: "#3a3a4b"
+    - state: pistol_box_marking
+      color: "#7c4c1b"
+    - state: pistol_lid
+      map: [ "lid" ]
+      color: "#3a3a4b"
+    - state: pistol_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7c4c1b"
+  - type: CMItemSlots
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - CMMagazinePistolMK80
+
+- type: entity
+  parent: CMUBoxMagazinePistolL165A1Empty
+  id: CMUBoxMagazinePistolL165A1
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: AU14MagazinePistolL165A1
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - CMMagazinePistolMK80
+
+# M54C MK1 (USCM)
+- type: entity
+  parent: RMCBoxMagazineRifleBase
+  id: CMUBoxMagazineRifleM54CMK1Empty
+  name: magazine box (M41A MK1 x 10)
+  components:
+  - type: Sprite
+    layers:
+    - state: rifle_box
+      color: "#7b8246"
+    - state: rifle_ammo_full_mags_base
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+    - state: rifle_ammo_full_mags_color
+      map: [ "enum.CMItemSlotsLayers2.Fill" ]
+      color: "#ffc000"
+    - state: rifle_box_generic
+      color: "#7b8246"
+    - state: rifle_box_marking
+      color: "#7c4c1b"
+    - state: rifle_lid
+      map: [ "lid" ]
+      color: "#7b8246"
+    - state: rifle_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7c4c1b"
+  - type: CMItemSlots
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - CMMagazineRifleM54CMK1
+
+- type: entity
+  parent: CMUBoxMagazineRifleM54CMK1Empty
+  id: CMUBoxMagazineRifleM54CMK1
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: CMMagazineRifleM54CMK1
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - CMMagazineRifleM54CMK1
+
+# MAR40 (VAIPO)
+- type: entity
+  parent: RMCBoxMagazineRifleBase
+  id: CMUBoxMagazineRifleMAR40Empty
+  name: magazine box (MAR40 x 10)
+  components:
+  - type: Sprite
+    layers:
+    - state: rifle_box
+      color: "#a4906a"
+    - state: rifle_ammo_full_mags_base
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+    - state: rifle_ammo_full_mags_color
+      map: [ "enum.CMItemSlotsLayers2.Fill" ]
+      color: "#ffc000"
+    - state: rifle_box_generic
+      color: "#a4906a"
+    - state: rifle_box_marking
+      color: "#7c4c1b"
+    - state: rifle_lid
+      map: [ "lid" ]
+      color: "#a4906a"
+    - state: rifle_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7c4c1b"
+  - type: CMItemSlots
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - RMCMagazineRifleMAR40
+
+- type: entity
+  parent: CMUBoxMagazineRifleMAR40Empty
+  id: CMUBoxMagazineRifleMAR40
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: RMCMagazineRifleMAR40
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - RMCMagazineRifleMAR40
+
+# M48A4 (VAIPO)
+- type: entity
+  parent: RMCBoxMagazinePistolBase
+  id: CMUBoxMagazinePistolM48A4Empty
+  name: magazine box (M48A4 x 10)
+  components:
+  - type: Sprite
+    layers:
+    - state: pistol_box
+      color: "#a4906a"
+    - state: pistol_ammo_full
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+      color: "#ffc000"
+    - state: pistol_box_80
+      color: "#a4906a"
+    - state: pistol_box_marking
+      color: "#7c4c1b"
+    - state: pistol_lid
+      map: [ "lid" ]
+      color: "#a4906a"
+    - state: pistol_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7c4c1b"
+  - type: CMItemSlots
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - AU14MagazinePistolM48A4
+
+- type: entity
+  parent: CMUBoxMagazinePistolM48A4Empty
+  id: CMUBoxMagazinePistolM48A4
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: AU14MagazinePistolM48A4
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - AU14MagazinePistolM48A4
+
+# AG80 (UPP)
+- type: entity
+  parent: RMCBoxMagazineRifleBase
+  id: CMUBoxMagazineRifleAG80Empty
+  name: magazine box (AG80 x 10)
+  components:
+  - type: Sprite
+    layers:
+    - state: rifle_box
+      color: "#515237"
+    - state: rifle_ammo_full_mags_base
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+    - state: rifle_ammo_full_mags_color
+      map: [ "enum.CMItemSlotsLayers2.Fill" ]
+      color: "#ffc000"
+    - state: rifle_box_generic
+      color: "#515237"
+    - state: rifle_box_marking
+      color: "#7c4c1b"
+    - state: rifle_lid
+      map: [ "lid" ]
+      color: "#515237"
+    - state: rifle_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7c4c1b"
+  - type: CMItemSlots
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - AU14MagazineRifleAG80
+
+- type: entity
+  parent: CMUBoxMagazineRifleAG80Empty
+  id: CMUBoxMagazineRifleAG80
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: AU14MagazineRifleAG80
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - AU14MagazineRifleAG80
+
+# MCS-X Pulse Rifle (Prodigy)
+- type: entity
+  parent: RMCBoxMagazineRifleBase
+  id: CMUBoxMagazineRifleProdigyStandardEmpty
+  name: magazine box (MCS-X x 10)
+  components:
+  - type: Sprite
+    layers:
+    - state: rifle_box
+      color: "#4f6b5c"
+    - state: rifle_ammo_full_mags_base
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+    - state: rifle_ammo_full_mags_color
+      map: [ "enum.CMItemSlotsLayers2.Fill" ]
+      color: "#ffc000"
+    - state: rifle_box_generic
+      color: "#4f6b5c"
+    - state: rifle_box_marking
+      color: "#7c4c1b"
+    - state: rifle_lid
+      map: [ "lid" ]
+      color: "#4f6b5c"
+    - state: rifle_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7c4c1b"
+  - type: CMItemSlots
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - AU14WeaponRifleprodigyrifleMagazineStandard
+
+- type: entity
+  parent: CMUBoxMagazineRifleProdigyStandardEmpty
+  id: CMUBoxMagazineRifleProdigyStandard
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: AU14WeaponRifleprodigyrifleMagazineStandard
+    count: 10
+    slot:
+      whitelist:
+        tags:
+        - AU14WeaponRifleprodigyrifleMagazineStandard

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mp5_smg.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mp5_smg.yml
@@ -130,7 +130,7 @@
     zeroOnlyOnEmpty: true
   - type: Appearance
   - type: RefillableByBulletBox
-    bulletType: CMUBoxBulletsSMG9MM
+    bulletType: CMUBoxBulletsPistol9MM
     
 - type: entity
   parent: CMCartridge10x20mm

--- a/Resources/Prototypes/_RMC14/Entities/Structures/req_sign.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/req_sign.yml
@@ -1,9 +1,9 @@
 ﻿- type: entity
   id: RMCSignRequisitions
-  name: UNMC requisitions office guidelines
+  name: requisitions office guidelines
   description: 1. You are not entitled to service or equipment. Attachments are a privilege, not a right.
 
-    2. You must be fully dressed to obtain service. Cryosleep underwear is non-permissible.
+    2. You must be fully dressed in uniform to obtain service. Underwear is non-permissible.
 
     3. The Logistics Officer has the final say and the right to decline service. Only the Acting Commander may override their decisions.
 
@@ -23,7 +23,7 @@
   parent: RMCSignRequisitions
   id: RMCSignRequisitionsCreed
   name: LOC creed plaque
-  description: The short version of the Logistics Officer Creed made by the UN Logistics Officer Corps, this on is purely decorative and ceremonial version which is much shorter and doesn't include more modern edits.
+  description: The short version of the Logistics Officer Creed, this on is purely decorative and ceremonial version which is much shorter and doesn't include more modern edits.
   components:
   - type: Sprite
     state: rocreed

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/magazine_box_crafting.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/magazine_box_crafting.yml
@@ -266,18 +266,6 @@
   description: A 5.7x28mm armor-piercing ammunition box. Used to refill P90 AP magazines. It comes with a leather strap allowing to wear it on the back.
   iconColor: "#727e90"
   objectType: Item
-# MP5  
-- type: construction
-  parent: RMC
-  name: SMG ammunition box (9×19mm)
-  id: CMUBoxBulletsSMG9MMEmpty
-  graph: RMCBoxMagazine
-  startNode: start
-  targetNode: CMUBoxBulletsSMG9MMEmpty
-  category: construction-category-cm-box-magazine
-  description: A 9×19mm ammunition box. Used to refill MP5 magazines. It comes with a leather strap allowing to wear it on the back.
-  iconColor: "#727e90"
-  objectType: Item
 # Type 19
 - type: construction
   parent: RMC
@@ -921,12 +909,6 @@
       - material: RMCSheetCardboard
         amount: 1
         doAfter: 0.25
-   # MP5
-    - to: CMUBoxBulletsSMG9MMEmpty
-      steps:
-      - material: RMCSheetCardboard
-        amount: 1
-        doAfter: 0.25
    # Type 19
     - to: CMUBoxBulletsSMGType19Empty
       steps:
@@ -1267,9 +1249,6 @@
   - node: CMUBoxBulletsSMGP90APEmpty
     entity: CMUBoxBulletsSMGP90APEmpty
     
- # MP5
-  - node: CMUBoxBulletsSMG9MMEmpty
-    entity: CMUBoxBulletsSMG9MMEmpty
  # Type 19
   - node: CMUBoxBulletsSMGType19Empty
     entity: CMUBoxBulletsSMGType19Empty

--- a/Resources/Prototypes/_RMC14/Recipes/Materials/cardboard.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Materials/cardboard.yml
@@ -103,7 +103,6 @@
   - CMUBoxBulletsSMGP90EmptyBuild
   - CMUBoxBulletsSMGP90APEmptyBuild
   - CMUBoxBulletsSMGType19EmptyBuild
-  - CMUBoxBulletsSMG9MMEmptyBuild
   - RMCBoxBulletsPistolEmptyBuild
   - RMCBoxBulletsPistolAPEmptyBuild
   - CMUBoxBulletsPistol9MMEmptyBuild
@@ -214,12 +213,6 @@
   id: CMUBoxBulletsSMGType19EmptyBuild
   name: SMG ammunition box (7.62×25mm)
   prototype: CMUBoxBulletsSMGType19Empty
-  
-- type: rmcConstruction
-  parent: RMCCardboardBuildBase
-  id: CMUBoxBulletsSMG9MMEmptyBuild
-  name: SMG ammunition box (9×19mm)
-  prototype: CMUBoxBulletsSMG9MMEmpty
   
 - type: rmcConstruction
   parent: RMCCardboardBuildBase


### PR DESCRIPTION
- All factions now have magazine/ammo boxes and get a few in their faction vendors.
- Removed duplicate 9x19 boxes.
- Advisor requires your character to be 25 now.
- IO requires your character to be 25 instead of 30 now.
- Large magazine pouches have been moved to req and have a cheap purchased crate with some now.
- Requisitions board has been loreified. 

Most changes are QOL. Magazine pouch changes are to reinforce reliance on req and the ammo economy. 

**Changelog**
:cl:
- add: All faction weapons now have their own magazine/ammo boxes.
- remove: Removed a duplicate 9x19mm ammo box.
- tweak: Large magazine pouches have been moved to requisitions. 
- fix: Advisor characters now must be 25 instead of 21.
- fix: IO characters now only have to be 25 in-line with all other junior officers, not 30.