### PR TITLE
Camo + Un1984 Scream

### DIFF
--- a/Content.Client/Options/UI/Tabs/CmuTab.xaml
+++ b/Content.Client/Options/UI/Tabs/CmuTab.xaml
@@ -25,6 +25,11 @@
                           Text="{Loc 'cmu-ui-options-ui-less-surgery'}"
                           ToolTip="{Loc 'cmu-ui-options-ui-less-surgery-tooltip'}" />
 
+                <Label Text="{Loc 'cmu-ui-options-vocal'}" StyleClasses="LabelKeyText" />
+                <CheckBox Name="ScreamOnHotbarCheckBox"
+                          Text="{Loc 'cmu-ui-options-scream-on-hotbar'}"
+                          ToolTip="{Loc 'cmu-ui-options-scream-on-hotbar-tooltip'}" />
+
                 <Label Text="{Loc 'ui-options-cmu-zlevels'}" StyleClasses="LabelKeyText" />
                 <ui:OptionSlider Name="ZLevelBlurSlider" Title="{Loc 'ui-options-zlevel-blur'}" />
             </BoxContainer>

--- a/Content.Client/Options/UI/Tabs/CmuTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/CmuTab.xaml.cs
@@ -35,6 +35,7 @@ public sealed partial class CmuTab : Control
         Control.AddOptionCheckBox(CCVars.ChatGhostFollowButton, ChatGhostFollowButton);
         Control.AddOptionCheckBox(CMUMedicalCCVars.TargetedHealingEnabled, TargetedHealingCheckBox);
         Control.AddOptionCheckBox(CMUMedicalCCVars.UiLessSurgeryEnabled, UiLessSurgeryCheckBox);
+        Control.AddOptionCheckBox(CCVars.CMUScreamOnHotbarEnabled, ScreamOnHotbarCheckBox);
         Control.AddOptionPercentSlider(CMUZLevelsCVars.BlurStrength, ZLevelBlurSlider, scale: OldZLevelBlurStrength);
 
         Control.Initialize();

--- a/Content.Client/_CMU14/Vocal/CMUScreamOnHotbarPreferenceSystem.cs
+++ b/Content.Client/_CMU14/Vocal/CMUScreamOnHotbarPreferenceSystem.cs
@@ -1,0 +1,31 @@
+using Content.Shared._CMU14.Vocal;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+
+namespace Content.Client._CMU14.Vocal;
+
+/// <summary>
+///     Notifies the server immediately when the local player's "pin scream to hotbar" preference changes,
+///     so the toggle takes effect mid-round instead of only on next spawn.
+/// </summary>
+public sealed partial class CMUScreamOnHotbarPreferenceSystem : EntitySystem
+{
+    [Dependency] private IConfigurationManager _cfg = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _cfg.OnValueChanged(CCVars.CMUScreamOnHotbarEnabled, OnPreferenceChanged);
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        _cfg.UnsubValueChanged(CCVars.CMUScreamOnHotbarEnabled, OnPreferenceChanged);
+    }
+
+    private void OnPreferenceChanged(bool enabled)
+    {
+        RaiseNetworkEvent(new CMUScreamOnHotbarPreferenceMessage(enabled));
+    }
+}

--- a/Content.Client/_RMC14/Item/ItemCamouflageVisualizerSystem.cs
+++ b/Content.Client/_RMC14/Item/ItemCamouflageVisualizerSystem.cs
@@ -4,7 +4,9 @@ using Content.Client._RMC14.Attachable.Systems;
 using Content.Client.Clothing;
 using Content.Client.Items.Systems;
 using Content.Shared._RMC14.Attachable.Components;
+using Content.Shared._RMC14.Clothing;
 using Content.Shared._RMC14.Item;
+using Content.Shared._RMC14.UniformAccessories;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Item;
 using Content.Shared.Hands;
@@ -171,6 +173,47 @@ public sealed partial class ItemCamouflageVisualizerSystem : VisualizerSystem<It
                 {
                     _attachableHolderVisuals.RefreshVisuals((container.Owner, holder), (uid, visuals), visuals.LastSlotId, visuals.LastSuffix);
                 }
+            }
+
+            if (TryComp(uid, out HelmetAccessoryComponent? accessory))
+            {
+#pragma warning disable RA0002
+                accessory.Rsi = new SpriteSpecifier.Rsi(rsi, accessory.Rsi.RsiState);
+
+                if (accessory.HatRsi != null)
+                    accessory.HatRsi = new SpriteSpecifier.Rsi(rsi, accessory.HatRsi.RsiState);
+
+                if (accessory.ToggledRsi != null)
+                    accessory.ToggledRsi = new SpriteSpecifier.Rsi(rsi, accessory.ToggledRsi.RsiState);
+
+                if (accessory.HatToggledRsi != null)
+                    accessory.HatToggledRsi = new SpriteSpecifier.Rsi(rsi, accessory.HatToggledRsi.RsiState);
+#pragma warning restore RA0002
+
+                if (_container.TryGetContainingContainer((uid, null), out var accessoryContainer))
+                    _item.VisualsChanged(accessoryContainer.Owner);
+            }
+
+            if (TryComp(uid, out OuterClothingAccessoryComponent? outerAccessory))
+            {
+#pragma warning disable RA0002
+                outerAccessory.Rsi = new SpriteSpecifier.Rsi(rsi, outerAccessory.Rsi.RsiState);
+
+                if (outerAccessory.ToggledRsi != null)
+                    outerAccessory.ToggledRsi = new SpriteSpecifier.Rsi(rsi, outerAccessory.ToggledRsi.RsiState);
+#pragma warning restore RA0002
+
+                if (_container.TryGetContainingContainer((uid, null), out var outerAccessoryContainer))
+                    _item.VisualsChanged(outerAccessoryContainer.Owner);
+            }
+
+            if (TryComp(uid, out UniformAccessoryComponent? uniformAccessory) &&
+                uniformAccessory.PlayerSprite != null)
+            {
+                uniformAccessory.PlayerSprite = new SpriteSpecifier.Rsi(rsi, uniformAccessory.PlayerSprite.RsiState);
+
+                if (_container.TryGetContainingContainer((uid, null), out var uniformAccessoryContainer))
+                    _item.VisualsChanged(uniformAccessoryContainer.Owner);
             }
         }
 

--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -1,11 +1,15 @@
 using Content.Server._RMC14.Emote;
 using Content.Server.Actions;
 using Content.Server.Chat.Systems;
+using Content.Shared._CMU14.Vocal;
+using Content.Shared.CCVar;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Humanoid;
 using Content.Shared.Speech;
 using Content.Shared.Speech.Components;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -19,6 +23,7 @@ public sealed partial class VocalSystem : EntitySystem
     [Dependency] private ChatSystem _chat = default!;
     [Dependency] private ActionsSystem _actions = default!;
     [Dependency] private RMCEmoteSystem _rmcEmote = default!;
+    [Dependency] private INetConfigurationManager _netConfig = default!;
 
     public override void Initialize()
     {
@@ -29,6 +34,8 @@ public sealed partial class VocalSystem : EntitySystem
         SubscribeLocalEvent<VocalComponent, SexChangedEvent>(OnSexChanged);
         SubscribeLocalEvent<VocalComponent, EmoteEvent>(OnEmote);
         SubscribeLocalEvent<VocalComponent, ScreamActionEvent>(OnScreamAction);
+        SubscribeLocalEvent<VocalComponent, PlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeNetworkEvent<CMUScreamOnHotbarPreferenceMessage>(OnScreamOnHotbarPreference);
     }
 
     private void OnShutdown(EntityUid uid, VocalComponent component, ComponentShutdown args)
@@ -40,6 +47,33 @@ public sealed partial class VocalSystem : EntitySystem
         }
     }
 
+    private void OnPlayerAttached(EntityUid uid, VocalComponent component, PlayerAttachedEvent args)
+    {
+        // scream is off the hotbar by default; players can opt back in under CMU settings
+        var enabled = _netConfig.GetClientCVar(args.Player.Channel, CCVars.CMUScreamOnHotbarEnabled);
+        SetScreamOnHotbar(uid, component, enabled);
+    }
+
+    private void OnScreamOnHotbarPreference(CMUScreamOnHotbarPreferenceMessage msg, EntitySessionEventArgs args)
+    {
+        // lets the toggle take effect immediately, instead of waiting for the player's next spawn
+        if (args.SenderSession.AttachedEntity is not { } uid || !TryComp<VocalComponent>(uid, out var component))
+            return;
+
+        SetScreamOnHotbar(uid, component, msg.Enabled);
+    }
+
+    private void SetScreamOnHotbar(EntityUid uid, VocalComponent component, bool enabled)
+    {
+        if (enabled)
+        {
+            _actions.AddAction(uid, ref component.ScreamActionEntity, component.ScreamAction);
+        }
+        else if (component.ScreamActionEntity != null)
+        {
+            _actions.RemoveAction(uid, component.ScreamActionEntity);
+        }
+    }
 
     private void OnSexChanged(EntityUid uid, VocalComponent component, SexChangedEvent args)
     {
@@ -67,9 +101,9 @@ public sealed partial class VocalSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, VocalComponent component, MapInitEvent args)
     {
-        
         LoadSounds(uid, component);
     }
+
     private void OnScreamAction(EntityUid uid, VocalComponent component, ScreamActionEvent args)
     {
         if (args.Handled)

--- a/Content.Shared/CCVar/CCVars.CMU.Vocal.cs
+++ b/Content.Shared/CCVar/CCVars.CMU.Vocal.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    /// <summary>
+    ///     Whether this client's character gets the scream emote action pinned to their hotbar automatically.
+    ///     Replicated so the server can honor the controlling player's preference.
+    /// </summary>
+    public static readonly CVarDef<bool> CMUScreamOnHotbarEnabled =
+        CVarDef.Create("cmu.vocal.scream_on_hotbar", false, CVar.REPLICATED | CVar.CLIENT | CVar.ARCHIVE);
+}

--- a/Content.Shared/_CMU14/Vocal/CMUScreamOnHotbarPreferenceMessage.cs
+++ b/Content.Shared/_CMU14/Vocal/CMUScreamOnHotbarPreferenceMessage.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._CMU14.Vocal;
+
+/// <summary>
+///     Sent by the client the moment it changes its "pin scream to hotbar" preference, so the server can
+///     apply the change to the client's currently attached entity immediately instead of waiting for
+///     their next spawn. See <see cref="Content.Shared.CCVar.CCVars.CMUScreamOnHotbarEnabled"/>.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class CMUScreamOnHotbarPreferenceMessage(bool enabled) : EntityEventArgs
+{
+    public readonly bool Enabled = enabled;
+}

--- a/Resources/Locale/en-US/_CMU14/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/_CMU14/escape-menu/ui/options-menu.ftl
@@ -5,3 +5,7 @@ cmu-ui-options-targeted-healing = Target bandages and medical kits to the select
 cmu-ui-options-targeted-healing-tooltip = Prevents wound treatments from automatically moving to another body part when the selected part cannot be treated.
 cmu-ui-options-ui-less-surgery = Perform surgery directly with tools
 cmu-ui-options-ui-less-surgery-tooltip = Interprets surgery tools from the selected body part and its current surgical access instead of opening the surgery window.
+
+cmu-ui-options-vocal = Vocal
+cmu-ui-options-scream-on-hotbar = Pin scream to hotbar
+cmu-ui-options-scream-on-hotbar-tooltip = Adds a scream action to your hotbar. Scream is always usable through the emote wheel regardless of this setting.

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/marinevendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/marinevendors.yml
@@ -19,14 +19,8 @@
     sections:
     - name: Fatigues
       entries:
-      - id: AU14DesertFatigues
-        amount: 40
-      - id: AU14JungleFatigues
-        amount: 40
-      - id: AU14SnowFatigues
-        amount: 40
-      - id: AU14MixedSnowFatigues
-        amount: 40
+      - id: AU14CamoUSCMFatigues
+        amount: 120
     - name: Footwear
       entries:
       - id: CMBootsBlack
@@ -61,22 +55,14 @@
         amount: 2
     - name: Headgear
       entries:
-      - id: AU14DesertM10Helmet
+      - id: AU14CamoM10Helmet
+        amount: 65
+      - id: AU14CamoBoonieHat
         amount: 40
-      - id: AU14JungleM10Helmet
-        amount: 25
-      - id: AU14DesertBoonieHat
-        amount: 20
-      - id: AU14JungleBoonieHat
-        amount: 20
-      - id: AU14DesertPatrolCap
-        amount: 25
-      - id: AU14JunglePatrolCap
-        amount: 25
-      - id: AU14DesertFlapCap
-        amount: 15
-      - id: AU14JungleFlapCap
-        amount: 15
+      - id: AU14CamoPatrolCap
+        amount: 50
+      - id: AU14CamoFlapCap
+        amount: 30
       - id: AU14HeadCommandoBeanie
         amount: 10
       - id: RMCM5CameraGear
@@ -89,30 +75,20 @@
         amount: 8
     - name: Armor
       entries:
-      - id: AU14ArmorM3DesertOne
-        amount: 40
-      - id: AU14ArmorM3DesertTwo
-        amount: 40
-      - id: AU14ArmorM3DesertThree
-        amount: 40
-      - id: AU14ArmorM3JungleOne
-        amount: 25
-      - id: AU14ArmorM3JungleTwo
-        amount: 25
-      - id: AU14ArmorM3JungleThree
-        amount: 25
+      - id: AU14CamoArmorM3Smooth
+        amount: 65
+      - id: AU14CamoArmorM3Ribbed
+        amount: 65
+      - id: AU14CamoArmorM3Dimpled
+        amount: 65
     - name: Armor Components
       entries:
-      - id: AU14KitDesertArmor
-        amount: 40
-      - id: AU14KitJungleArmor
-        amount: 25
+      - id: AU14CamoKitArmor
+        amount: 65
       - id: AU14ArmorGarbShotgunShellHolder
         amount: 8
-      - id: AU14ArmorGarbJunglePoncho
-        amount: 25
-      - id: AU14ArmorGarbDesertPoncho
-        amount: 40
+      - id: AU14CamoArmorGarbPoncho
+        amount: 65
     - name: Backpack
       entries:
       - id: CMBackpackMarine
@@ -232,20 +208,14 @@
         amount: 25
     - name: Helmet Garb
       entries:
-      - id: AU14HelmetGarbM10SkrimJungle
-        amount: 15
-      - id: AU14HelmetGarbM10SkrimDesert
-        amount: 15
-      - id: AU14HelmetGarbM10SkrimSnow
-        amount: 15
+      - id: AU14CamoHelmetGarbM10Skrim
+        amount: 45
       - id: AU14HelmetGarbM10RainCover
         amount: 40
       - id: AU14HelmetGarbM10Netting
         amount: 40
-      - id: RMCHelmetGarbGasmaskJungle
-        amount: 20
-      - id: RMCHelmetGarbGasmaskDesert
-        amount: 20
+      - id: AU14CamoHelmetGarbGasmask
+        amount: 40
     - name: Patches
       entries:
       - id: AU14PatchUAFlag
@@ -621,10 +591,8 @@
         amount: 5
     - name: Headgear
       entries:
-      - id: AU14DesertM11Helmet
-        amount: 5
-      - id: AU14JungleM11Helmet
-        amount: 5
+      - id: AU14CamoM11Helmet
+        amount: 10
       - id: CMHeadCapPeakedFormal
         amount: 5
       - id: CMHeadCapPeakedService
@@ -632,10 +600,8 @@
       - id: RMCHeadBeretSquad
         amount: 5
         name: Black Beret
-      - id: AU14JunglePatrolCap
-        amount: 5
-      - id: AU14DesertPatrolCap
-        amount: 5
+      - id: AU14CamoPatrolCap
+        amount: 10
     - name: Backpack
       entries:
       - id: RMCBackpackRTO
@@ -699,8 +665,7 @@
     - name: Smartgun Harness
       choices: { SmartgunHarness: 1 }
       entries:
-      - id: AU14ArmorSmartGunDesertCombatHarness
-      - id: AU14ArmorSmartGunJungleCombatHarness
+      - id: AU14CamoArmorSmartGunCombatHarness
     - name: Smartgun Belts
       choices: { SmartgunBelts: 1 }
       entries:
@@ -728,12 +693,10 @@
     - name: Helmets and Hats
       choices: { CMHat: 1 }
       entries:
-      - id: AU14DesertM11Helmet
-      - id: AU14JungleM11Helmet
+      - id: AU14CamoM11Helmet
       - id: RMCHeadBeretSquad
         name: Black Beret
-      - id: AU14JunglePatrolCap
-      - id: AU14DesertPatrolCap
+      - id: AU14CamoPatrolCap
     - name: Equipment
       takeAll: CMStandard
       entries:
@@ -1255,25 +1218,27 @@
     - name: Uniform
       choices: { AU14Uniform: 1 }
       entries:
-      - id: AU14DesertFatigues
+      - id: AU14CamoUSCMFatigues
     - name: Footwear
       choices: { AU14FootWear: 1 }
       entries:
       - id: CMBootsBlack
       - id: CMBootsBrown
     - name: Hat
-      choices: { CMHat: 1 }
+      choices: { CMHat: 2 }
       entries:
       - id: CMHeadCapMP
       - id: CMHeadBeretRed
     - name: Helmet
       choices: { AU14Helmet: 1 }
       entries:
-      - id: AU14DesertM10MPHelmet
+      - id: AU14CamoM10Helmet
     - name: Vest
       choices: { AU14vest: 1 }
       entries:
-      - id: AU14ArmorM3DesertOne
+      - id: AU14CamoArmorM3Smooth
+      - id: AU14CamoArmorM3Ribbed
+      - id: AU14CamoArmorM3Dimpled
     - name: Backpack
       choices: { CMBackpack: 1 }
       entries:

--- a/Resources/Prototypes/_CMU14/Entities/Clothing/Factions/USCM-USARMY/armor.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Clothing/Factions/USCM-USARMY/armor.yml
@@ -537,6 +537,78 @@
 
 - type: entity
   parent: AU14BaseArmor
+  id: AU14CamoArmorM3Smooth
+  name: M3 pattern smooth USCM armor
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/JungleArmor/uscmarmorone.rsi
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/JungleArmor/uscmarmorone.rsi
+      Desert: _AU14/Clothing/DesertArmor/uscmarmorone.rsi
+      Snow: _AU14/Clothing/JungleArmor/uscmarmorone.rsi
+      Classic: _AU14/Clothing/JungleArmor/uscmarmorone.rsi
+      Urban: _AU14/Clothing/JungleArmor/uscmarmorone.rsi
+
+- type: entity
+  parent: AU14BaseArmor
+  id: AU14CamoArmorM3Ribbed
+  name: M3 pattern ribbed USCM armor
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/JungleArmor/uscmarmortwo.rsi
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/JungleArmor/uscmarmortwo.rsi
+      Desert: _AU14/Clothing/DesertArmor/uscmarmortwo.rsi
+      Snow: _AU14/Clothing/JungleArmor/uscmarmortwo.rsi
+      Classic: _AU14/Clothing/JungleArmor/uscmarmortwo.rsi
+      Urban: _AU14/Clothing/JungleArmor/uscmarmortwo.rsi
+
+- type: entity
+  parent: AU14BaseArmor
+  id: AU14CamoArmorM3Dimpled
+  name: M3 pattern dimpled USCM armor
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/JungleArmor/uscmarmorthree.rsi
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/JungleArmor/uscmarmorthree.rsi
+      Desert: _AU14/Clothing/DesertArmor/uscmarmorthree.rsi
+      Snow: _AU14/Clothing/JungleArmor/uscmarmorthree.rsi
+      Classic: _AU14/Clothing/JungleArmor/uscmarmorthree.rsi
+      Urban: _AU14/Clothing/JungleArmor/uscmarmorthree.rsi
+
+- type: entity
+  parent: [ RMCAllowSuitStorageClothingSmartgunner, AU14BaseArmor ]
+  id: AU14CamoArmorSmartGunCombatHarness
+  name: M56 Combat Harness
+  description: An M56 Combat Harness specially made for Smartgunners.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/JungleArmor/uscmarmorsmartgunner.rsi
+  - type: Storage
+    maxItemSize: Small
+    grid:
+    - 0,0,3,1 # 2 slots
+  - type: RMCArmorSpeedTier
+    speedTier: light
+  - type: ClothingSpeedModifier
+    walkModifier: .725
+    sprintModifier: .725
+  - type: ClothingBlockBackpack
+  - type: SmartGunArmor
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/JungleArmor/uscmarmorsmartgunner.rsi
+      Desert: _AU14/Clothing/DesertArmor/uscmarmorsmartgunner.rsi
+      Snow: _AU14/Clothing/JungleArmor/uscmarmorsmartgunner.rsi
+      Classic: _AU14/Clothing/JungleArmor/uscmarmorsmartgunner.rsi
+      Urban: _AU14/Clothing/JungleArmor/uscmarmorsmartgunner.rsi
+
+- type: entity
+  parent: AU14BaseArmor
   id: AU14ArmorCBRN
   name: CBRN M3-M armor
   description: While lacking the appearance of the M3 pattern armor worn in regular service, this armor piece is still a derivative of it. It has been heavily modified to fit over the MOPP suit with additional padding and Venlar composite layers removed, so as not to restrict the wearer’s movement. However, with the reduction of composite layers, the personal protection offered is less than desired with complaints having been lodged since 2165.

--- a/Resources/Prototypes/_CMU14/Entities/Clothing/Factions/USCM-USARMY/garb.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Clothing/Factions/USCM-USARMY/garb.yml
@@ -481,3 +481,238 @@
     rsi:
       sprite: _AU14/Clothing/USCMC/Garb/magazinewebbing.rsi
       state: helmet
+
+# Camo system (ItemCamouflage) conforming variants
+# HelmetAccessory, OuterClothingAccessory and UniformAccessory rendering are
+# all wired into ItemCamouflageVisualizerSystem, so these re-texture in-game.
+# No Classic/Urban sprites exist for the skrim - both fall back to Jungle.
+# No Snow sprite exists for the gasmask - it falls back to Jungle.
+# No Snow/Classic/Urban sprites exist for the M3 armor garb pieces - all fall
+# back to Jungle.
+- type: entity
+  parent: RMCHelmetGarbBase
+  id: AU14CamoHelmetGarbM10Skrim
+  name: M10 Helmet Cover
+  description: A camo cover for the M10 helmet.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/USCMHelmetGarb/junglehelmetcover.rsi
+    state: icon
+  - type: Item
+    sprite: _AU14/Clothing/USCMHelmetGarb/junglehelmetcover.rsi
+  - type: HelmetAccessory
+    rsi:
+      sprite: _AU14/Clothing/USCMHelmetGarb/junglehelmetcover.rsi
+      state: helmet
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/USCMHelmetGarb/junglehelmetcover.rsi
+      Desert: _AU14/Clothing/USCMHelmetGarb/deserthelmetcover.rsi
+      Snow: _AU14/Clothing/USCMHelmetGarb/snowhelmetcover.rsi
+      Classic: _AU14/Clothing/USCMHelmetGarb/junglehelmetcover.rsi
+      Urban: _AU14/Clothing/USCMHelmetGarb/junglehelmetcover.rsi
+
+- type: entity
+  parent: RMCHelmetGarbGasmask
+  id: AU14CamoHelmetGarbGasmask
+  name: M5 integrated gasmask
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/HelmetGarb/Gasmasks/gasmask_jungle.rsi
+    state: icon
+  - type: Item
+    sprite: _RMC14/Objects/Clothing/HelmetGarb/Gasmasks/gasmask_jungle.rsi
+  - type: HelmetAccessory
+    rsi:
+      sprite: _RMC14/Objects/Clothing/HelmetGarb/Gasmasks/gasmask_jungle.rsi
+      state: helmet
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _RMC14/Objects/Clothing/HelmetGarb/Gasmasks/gasmask_jungle.rsi
+      Desert: _RMC14/Objects/Clothing/HelmetGarb/Gasmasks/gasmask_desert.rsi
+      Snow: _RMC14/Objects/Clothing/HelmetGarb/Gasmasks/gasmask_jungle.rsi
+      Classic: _RMC14/Objects/Clothing/HelmetGarb/Gasmasks/gasmask.rsi
+      Urban: _RMC14/Objects/Clothing/HelmetGarb/Gasmasks/gasmask_urban.rsi
+
+- type: entity
+  parent: RMCPonchoBase
+  id: AU14CamoArmorGarbPoncho
+  name: M3 poncho
+  description: The standard USCM poncho has variations for every climate. Custom fitted to be attached to standard USCM armor variants and worn over uniforms, it is comfortable, warming or cooling as needed, and well-fit. A marine couldn't ask for more.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Accessory/Ponchos/jungle.rsi
+    state: icon
+  - type: UniformAccessory
+    playerSprite:
+      sprite: _RMC14/Objects/Clothing/Accessory/Ponchos/jungle.rsi
+      state: poncho
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _RMC14/Objects/Clothing/Accessory/Ponchos/jungle.rsi
+      Desert: _RMC14/Objects/Clothing/Accessory/Ponchos/desert.rsi
+      Snow: _RMC14/Objects/Clothing/Accessory/Ponchos/snow.rsi
+      Classic: _RMC14/Objects/Clothing/Accessory/Ponchos/classic.rsi
+      Urban: _RMC14/Objects/Clothing/Accessory/Ponchos/urban.rsi
+
+- type: entity
+  parent: BaseItem
+  id: AU14CamoArmorGarbBracer
+  name: M3 bracers
+  description: An armor piece made to be used in combination with M3 pattern armor.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/USCMArmorGarb/junglebracers.rsi
+    state: icon
+  - type: Item
+    sprite: _AU14/Clothing/USCMArmorGarb/junglebracers.rsi
+  - type: OuterClothingAccessory
+    rsi:
+      sprite: _AU14/Clothing/USCMArmorGarb/junglebracers.rsi
+      state: helmet
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/USCMArmorGarb/junglebracers.rsi
+      Desert: _AU14/Clothing/USCMArmorGarb/desertbracers.rsi
+      Snow: _AU14/Clothing/USCMArmorGarb/junglebracers.rsi
+      Classic: _AU14/Clothing/USCMArmorGarb/junglebracers.rsi
+      Urban: _AU14/Clothing/USCMArmorGarb/junglebracers.rsi
+
+- type: entity
+  parent: BaseItem
+  id: AU14CamoArmorGarbGroinPlate
+  name: M3 groin plate
+  description: An armor piece made to be used in combination with M3 pattern armor.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/USCMArmorGarb/junglegroinplate.rsi
+    state: icon
+  - type: Item
+    sprite: _AU14/Clothing/USCMArmorGarb/junglegroinplate.rsi
+  - type: OuterClothingAccessory
+    rsi:
+      sprite: _AU14/Clothing/USCMArmorGarb/junglegroinplate.rsi
+      state: helmet
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/USCMArmorGarb/junglegroinplate.rsi
+      Desert: _AU14/Clothing/USCMArmorGarb/desertgroinplate.rsi
+      Snow: _AU14/Clothing/USCMArmorGarb/junglegroinplate.rsi
+      Classic: _AU14/Clothing/USCMArmorGarb/junglegroinplate.rsi
+      Urban: _AU14/Clothing/USCMArmorGarb/junglegroinplate.rsi
+
+- type: entity
+  parent: BaseItem
+  id: AU14CamoArmorGarbNeckGuard
+  name: M3 neck guard
+  description: An armor piece made to be used in combination with M3 pattern armor.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/USCMArmorGarb/jungleneckguard.rsi
+    state: icon
+  - type: Item
+    sprite: _AU14/Clothing/USCMArmorGarb/jungleneckguard.rsi
+  - type: OuterClothingAccessory
+    rsi:
+      sprite: _AU14/Clothing/USCMArmorGarb/jungleneckguard.rsi
+      state: helmet
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/USCMArmorGarb/jungleneckguard.rsi
+      Desert: _AU14/Clothing/USCMArmorGarb/desertneckguard.rsi
+      Snow: _AU14/Clothing/USCMArmorGarb/jungleneckguard.rsi
+      Classic: _AU14/Clothing/USCMArmorGarb/jungleneckguard.rsi
+      Urban: _AU14/Clothing/USCMArmorGarb/jungleneckguard.rsi
+
+- type: entity
+  parent: BaseItem
+  id: AU14CamoArmorGarbShinGuards
+  name: M3 shin guards
+  description: An armor piece made to be used in combination with M3 pattern armor.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/USCMArmorGarb/jungleshinguards.rsi
+    state: icon
+  - type: Item
+    sprite: _AU14/Clothing/USCMArmorGarb/jungleshinguards.rsi
+  - type: OuterClothingAccessory
+    rsi:
+      sprite: _AU14/Clothing/USCMArmorGarb/jungleshinguards.rsi
+      state: helmet
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/USCMArmorGarb/jungleshinguards.rsi
+      Desert: _AU14/Clothing/USCMArmorGarb/desertshinguards.rsi
+      Snow: _AU14/Clothing/USCMArmorGarb/jungleshinguards.rsi
+      Classic: _AU14/Clothing/USCMArmorGarb/jungleshinguards.rsi
+      Urban: _AU14/Clothing/USCMArmorGarb/jungleshinguards.rsi
+
+- type: entity
+  parent: BaseItem
+  id: AU14CamoArmorGarbShoulderPads
+  name: M3 shoulder pads
+  description: An armor piece made to be used in combination with M3 pattern armor.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/USCMArmorGarb/jungleshoulderpads.rsi
+    state: icon
+  - type: Item
+    sprite: _AU14/Clothing/USCMArmorGarb/jungleshoulderpads.rsi
+  - type: OuterClothingAccessory
+    rsi:
+      sprite: _AU14/Clothing/USCMArmorGarb/jungleshoulderpads.rsi
+      state: helmet
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/USCMArmorGarb/jungleshoulderpads.rsi
+      Desert: _AU14/Clothing/USCMArmorGarb/desertshoulderpads.rsi
+      Snow: _AU14/Clothing/USCMArmorGarb/jungleshoulderpads.rsi
+      Classic: _AU14/Clothing/USCMArmorGarb/jungleshoulderpads.rsi
+      Urban: _AU14/Clothing/USCMArmorGarb/jungleshoulderpads.rsi
+
+- type: entity
+  parent: BaseItem
+  id: AU14CamoArmorGarbThighGuards
+  name: M3 thigh guards
+  description: An armor piece made to be used in combination with M3 pattern armor.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/USCMArmorGarb/junglethighguards.rsi
+    state: icon
+  - type: Item
+    sprite: _AU14/Clothing/USCMArmorGarb/junglethighguards.rsi
+  - type: OuterClothingAccessory
+    rsi:
+      sprite: _AU14/Clothing/USCMArmorGarb/junglethighguards.rsi
+      state: helmet
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/USCMArmorGarb/junglethighguards.rsi
+      Desert: _AU14/Clothing/USCMArmorGarb/desertthighguard.rsi
+      Snow: _AU14/Clothing/USCMArmorGarb/junglethighguards.rsi
+      Classic: _AU14/Clothing/USCMArmorGarb/junglethighguards.rsi
+      Urban: _AU14/Clothing/USCMArmorGarb/junglethighguards.rsi
+
+- type: entity
+  parent: RMCKitBase
+  id: AU14CamoKitArmor
+  name: M3 armor customization kit
+  components:
+  - type: Item
+    size: Ginormous
+  - type: Storage
+    maxItemSize: Ginormous
+    grid:
+    - 0,0,9,0
+  - type: Sprite
+    sprite: _RMC14/Objects/Storage/procase_mini.rsi
+  - type: Icon
+    sprite: _RMC14/Objects/Storage/procase_mini.rsi
+  - type: StorageFill
+    contents:
+    - id: AU14CamoArmorGarbBracer
+    - id: AU14CamoArmorGarbThighGuards
+    - id: AU14CamoArmorGarbShoulderPads
+    - id: AU14CamoArmorGarbShinGuards
+    - id: AU14CamoArmorGarbNeckGuard
+    - id: AU14CamoArmorGarbGroinPlate

--- a/Resources/Prototypes/_CMU14/Entities/Clothing/Factions/USCM-USARMY/hats.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Clothing/Factions/USCM-USARMY/hats.yml
@@ -123,3 +123,59 @@
     sprite: _AU14/Clothing/US_Army/Hats/cavalry.rsi
   - type: Clothing
     sprite: _AU14/Clothing/US_Army/Hats/cavalry.rsi
+
+# Camo system (ItemCamouflage) conforming variants
+# No Snow/Classic/Urban sprites exist yet - all fall back to the Jungle sprite until dedicated art is made.
+- type: entity
+  parent: ClothingHeadBase
+  id: AU14CamoPatrolCap
+  name: Patrol Cap
+  description: A simple patrol cap.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/JungleHats/cap.rsi
+  - type: Clothing
+    sprite: _AU14/Clothing/JungleHats/cap.rsi
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/JungleHats/cap.rsi
+      Desert: _AU14/Clothing/DesertHats/cap.rsi
+      Snow: _AU14/Clothing/JungleHats/cap.rsi
+      Classic: _AU14/Clothing/JungleHats/cap.rsi
+      Urban: _AU14/Clothing/JungleHats/cap.rsi
+
+- type: entity
+  parent: ClothingHeadBase
+  id: AU14CamoFlapCap
+  name: Patrol Flap-Cap
+  description: A simple patrol cap with a sun flap.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/JungleHats/flapcap.rsi
+  - type: Clothing
+    sprite: _AU14/Clothing/JungleHats/flapcap.rsi
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/JungleHats/flapcap.rsi
+      Desert: _AU14/Clothing/DesertHats/flapcap.rsi
+      Snow: _AU14/Clothing/JungleHats/flapcap.rsi
+      Classic: _AU14/Clothing/JungleHats/flapcap.rsi
+      Urban: _AU14/Clothing/JungleHats/flapcap.rsi
+
+- type: entity
+  parent: ClothingHeadBase
+  id: AU14CamoBoonieHat
+  name: Boonie Hat
+  description: A brimmed hat to protect your face from the sun.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/JungleHats/booniehat.rsi
+  - type: Clothing
+    sprite: _AU14/Clothing/JungleHats/booniehat.rsi
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/JungleHats/booniehat.rsi
+      Desert: _AU14/Clothing/DesertHats/booniehat.rsi
+      Snow: _AU14/Clothing/JungleHats/booniehat.rsi
+      Classic: _AU14/Clothing/JungleHats/booniehat.rsi
+      Urban: _AU14/Clothing/JungleHats/booniehat.rsi

--- a/Resources/Prototypes/_CMU14/Entities/Clothing/Factions/USCM-USARMY/helmets.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Clothing/Factions/USCM-USARMY/helmets.yml
@@ -163,3 +163,95 @@
     sprite: _AU14/Clothing/US_Army/Helmets/helmet.rsi
   - type: Clothing
     sprite: _AU14/Clothing/US_Army/Helmets/helmet.rsi
+
+# Camo system (ItemCamouflage) conforming variants
+# No Snow/Classic/Urban sprites exist yet - all fall back to the Jungle sprite until dedicated art is made.
+- type: entity
+  parent: RMCMarineHelmetBase
+  id: AU14CamoM10CorpsmanHelmet
+  name: M10 Corpsman Helmet
+  description: Standard Issue Helmet used by USCM. Provides modest protection from bullet and melee attacks at the head. It also has an inbuilt camera allowing for command staff to observe the squad's actions. This one is painted with the red cross.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/JungleHats/m10corpsmanhelmet.rsi
+  - type: Clothing
+    sprite: _AU14/Clothing/JungleHats/m10corpsmanhelmet.rsi
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/JungleHats/m10corpsmanhelmet.rsi
+      Desert: _AU14/Clothing/DesertHats/m10corpsmanhelmet.rsi
+      Snow: _AU14/Clothing/JungleHats/m10corpsmanhelmet.rsi
+      Classic: _AU14/Clothing/JungleHats/m10corpsmanhelmet.rsi
+      Urban: _AU14/Clothing/JungleHats/m10corpsmanhelmet.rsi
+
+- type: entity
+  parent: RMCMarineHelmetBase
+  id: AU14CamoM10Helmet
+  name: M10 Helmet
+  description: Standard Issue Helmet used by USCM. Provides modest protection from bullet and melee attacks at the head. It also has an inbuilt camera allowing for command staff to observe the squad's actions.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/JungleHats/m10helmet.rsi
+  - type: Clothing
+    sprite: _AU14/Clothing/JungleHats/m10helmet.rsi
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/JungleHats/m10helmet.rsi
+      Desert: _AU14/Clothing/DesertHats/m10helmet.rsi
+      Snow: _AU14/Clothing/JungleHats/m10helmet.rsi
+      Classic: _AU14/Clothing/JungleHats/m10helmet.rsi
+      Urban: _AU14/Clothing/JungleHats/m10helmet.rsi
+
+- type: entity
+  parent: RMCMarineHelmetBase
+  id: AU14CamoM11Helmet
+  name: M11 Helmet
+  description: A slightly fancier helmet for USCM leadership. This one contains a small built-in camera and has cushioning to project your fragile brain.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/JungleHats/m11helmet.rsi
+  - type: Clothing
+    sprite: _AU14/Clothing/JungleHats/m11helmet.rsi
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/JungleHats/m11helmet.rsi
+      Desert: _AU14/Clothing/DesertHats/m11helmet.rsi
+      Snow: _AU14/Clothing/JungleHats/m11helmet.rsi
+      Classic: _AU14/Clothing/JungleHats/m11helmet.rsi
+      Urban: _AU14/Clothing/JungleHats/m11helmet.rsi
+
+- type: entity
+  parent: RMCMarineHelmetBase
+  id: AU14CamoM30Helmet
+  name: M30 Helmet
+  description: The M30 tactical helmet has an left eyepiece filter used to filter flight data. It is issued to Pilots and DCCs.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/JungleHats/m30pilothelmet.rsi
+  - type: Clothing
+    sprite: _AU14/Clothing/JungleHats/m30pilothelmet.rsi
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/JungleHats/m30pilothelmet.rsi
+      Desert: _AU14/Clothing/DesertHats/m30pilothelmet.rsi
+      Snow: _AU14/Clothing/JungleHats/m30pilothelmet.rsi
+      Classic: _AU14/Clothing/JungleHats/m30pilothelmet.rsi
+      Urban: _AU14/Clothing/JungleHats/m30pilothelmet.rsi
+
+- type: entity
+  parent: RMCMarineHelmetBase
+  id: AU14CamoM50Helmet #meant to have a built-in welding visor
+  name: M50 Helmet
+  description: A lightweight M50 tanker helmet designed for use by vehicle crewmen in the USCM. It offers low weight protection, and allows agile movement inside the confines of an armored vehicle.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/JungleHats/m50tankerhelmet.rsi
+  - type: Clothing
+    sprite: _AU14/Clothing/JungleHats/m50tankerhelmet.rsi
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/JungleHats/m50tankerhelmet.rsi
+      Desert: _AU14/Clothing/DesertHats/m50tankerhelmet.rsi
+      Snow: _AU14/Clothing/JungleHats/m50tankerhelmet.rsi
+      Classic: _AU14/Clothing/JungleHats/m50tankerhelmet.rsi
+      Urban: _AU14/Clothing/JungleHats/m50tankerhelmet.rsi

--- a/Resources/Prototypes/_CMU14/Entities/Clothing/Factions/USCM-USARMY/jumpsuits.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Clothing/Factions/USCM-USARMY/jumpsuits.yml
@@ -253,3 +253,25 @@
   components:
   - type: Sprite
     sprite: _AU14/Clothing/USCMC/Uniform/DressBlues/d_senior.rsi
+
+# Camo system (ItemCamouflage) conforming variants
+# No Classic/Urban sprites exist yet - both fall back to the Jungle sprite until dedicated art is made.
+- type: entity
+  parent: [RMCMarineUniformBase, RMCAlternateFoldableUniformBase]
+  id: AU14CamoUSCMFatigues
+  name: USCM fatigues
+  description: Standard-issue USCM fatigues. They have shards of light Kevlar to help protect against stabbing weapons and bullets.
+  components:
+  - type: Sprite
+    sprite: _AU14/Clothing/junglefatigues.rsi
+  - type: UniformAccessoryHolder
+    startingAccessories:
+    - AU14PatchUAFlag
+    - AU14PatchUSCM
+  - type: ItemCamouflage
+    camouflageVariations:
+      Jungle: _AU14/Clothing/junglefatigues.rsi
+      Desert: _AU14/Clothing/desertfatigues.rsi
+      Snow: _AU14/Clothing/snowfatigues.rsi
+      Classic: _AU14/Clothing/junglefatigues.rsi
+      Urban: _AU14/Clothing/junglefatigues.rsi


### PR DESCRIPTION
USCM gear is now camo, pin scream to hotbar is now an option, HelmetAccessory/OuterClothingAccessory/UniformAccessory now filter into ItemCamouflageVisualizerSystem so they can update with camouflage variants. 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: USCM gear is now camo conforming! 
- add: Added a "Pin scream to hotbar" option under Settings > CMU to let players opt back into having the scream emote pinned to their hotbar. 1984 has been removed (for now).
- code: Wired HelmetAccessory, OuterClothingAccessory and UniformAccessory rendering into ItemCamouflageVisualizerSystem so helmet garb, armor components and ponchos properly re-texture on camo change.
