### PR TITLE
SGO Medical HUD & PMC Gloves W/ Knuckledusters

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Eyes/glasses.yml
@@ -75,7 +75,9 @@
   - type: Appearance
 
 - type: entity
-  parent: ClothingEyesBase
+  parent: 
+  - ClothingEyesBase
+  - ShowMedicalIcons
   id: RMCGlassesSmartGunSight
   name: M56B head mounted sight # TODO RMC14 meson tile vision see description below
   description: A headset and goggles system for the M56B Smart Gun. # TODO RMC14 Has a low-res short-range imager, allowing for view of terrain.

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Hands/veteran.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Hands/veteran.yml
@@ -61,9 +61,23 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Hands/Gloves/gauntlets.rsi
   - type: CMArmor
-    melee: 30
-    bullet: 40
-    explosionArmor: 30
+    melee: 10
+    bullet: 5
+    explosionArmor: 5
+  - type: MeleeWeapon
+    attackRate: 1
+    damage:
+      types:
+        Blunt: 15
+        Structural: 10
+    soundHit:
+      collection: Punch
+    animation: WeaponArcFist
+    mustBeEquippedToUse: true
+  - type: DamageImpactProfile
+    melee:
+      contact: Crush
+      penetration: None
 
 - type: entity
   parent: RMCHandsVeteranPMC


### PR DESCRIPTION
## About the PR
Made it so AR/SGO Can use their eye piece to see people who are hurt to allow for suppressive fire.
Made the WY PMC Gloves have knuckledusters built into them, they will later be given to the 3rd Party Leader and CT (And maybe CT in GOVFOR vendor if its good enough)


:cl:
- add: Knuckledusters built into WY PMC Gloves
- tweak: SGO Medical HUD Element